### PR TITLE
point to stable link for openssl

### DIFF
--- a/manywheel/build_scripts/build_utils.sh
+++ b/manywheel/build_scripts/build_utils.sh
@@ -5,7 +5,7 @@ PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
 # XXX: the official https server at www.openssl.org cannot be reached
 # with the old versions of openssl and curl in Centos 5.11 hence the fallback
 # to the ftp mirror:
-OPENSSL_DOWNLOAD_URL=ftp://ftp.openssl.org/source
+OPENSSL_DOWNLOAD_URL=ftp://ftp.openssl.org/source/old/1.0.2/
 # Ditto the curl sources
 CURL_DOWNLOAD_URL=http://curl.askapache.com/download
 


### PR DESCRIPTION
openssl have ticked up their version from `1.0.2k` to `1.0.2l` - I've made the build script point to `1.0.2k` which has moved to `source/old/1.0.2/...`