### PR TITLE
explicitly install and run auditwheel with python > 3.3

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -35,11 +35,11 @@ for PYDIR in /opt/python/*; do
     # time pip wheel . -w $WHEELHOUSE_DIR
 done
 
-pip install auditwheel
+/opt/python/cp36-cp36m/bin/pip install auditwheel
 yum install -y zip
 
 for whl in $WHEELHOUSE_DIR/torch*.whl; do
-    auditwheel repair $whl -w /$WHEELHOUSE_DIR/ -L lib
+    /opt/python/cp36-cp36m/bin/auditwheel repair $whl -w /$WHEELHOUSE_DIR/ -L lib
 done
 
 for whl in /$WHEELHOUSE_DIR/torch*manylinux*.whl; do


### PR DESCRIPTION
Auditwheel requires [python 3.3+ to run](https://pypi.python.org/pypi/auditwheel). Right now the build script works because of the order `for PYDIR in /opt/python/*; do` loops though the versions, but is a bit flaky.

I realized this issue when trying to build a wheel just for `cp27-cpmu`