### PR TITLE
Add code to regenerate RECORD file for the wheel after we use patchelf

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -130,6 +130,24 @@ for whl in /$WHEELHOUSE_DIR/torch*manylinux*.whl; do
     # libshm
     patchelf --set-rpath '$ORIGIN' torch/lib/libshm.so
 
+    # regenerate the RECORD file with new hashes 
+    record_file=`echo $(basename whl) | sed -e 's/-cp.*$/.dist-info\/RECORD/g'`
+    new_record_file="$record_file"_new
+    while read -r line
+    do
+      record_item="$line"
+      IFS=, read -r filename digestmethod digest size <<< "$record_item"
+      if [ $filename == $record_file ]
+      then
+        echo "$line" >> $new_record_file
+      else
+        new_digest=`openssl dgst -sha256 -binary $filename | openssl base64 | sed -e 's/+/-/g' | sed -e 's/\//_/g' | sed -e 's/=//g'`
+        new_size=`ls -nl $filename | awk '{print $5}'`
+        echo $filename,$digestmethod,$new_digest,$new_size >> $new_record_file 
+      fi
+    done < "$record_file"
+    mv $new_record_file $record_file
+
     # zip up the wheel back
     zip -r $(basename $whl) torch*
 


### PR DESCRIPTION
A fix for the broken `RECORD` files in the wheel (https://github.com/pytorch/pytorch/issues/2596)

This code should re-generate the web-safe SHA256 hashes and overwrite the current `RECORD` file

cc @soumith 