### PR TITLE
Barebones NNPACK Conda Build

### DIFF
--- a/conda/nnpack/build.sh
+++ b/conda/nnpack/build.sh
@@ -7,6 +7,11 @@
 
 confu setup
 $PYTHON ./configure.py
+
+# patch ninja file to compile with -fPIC support
+sed -ibuild.ninja.bak "s/cflags = /cflags = -fPIC /" build.ninja
+sed -ibuild.ninja.bak "s/cxxflags = /cxxflags = -fPIC /" build.ninja
+
 ninja
 
 # move files to expected location

--- a/conda/nnpack/build.sh
+++ b/conda/nnpack/build.sh
@@ -1,0 +1,19 @@
+#!bin/bash
+
+# Instead of Conda packaging these dependencies, we expect them to be installed
+# pip install --upgrade git+https://github.com/Maratyszcza/PeachPy
+# pip install --upgrade git+https://github.com/Maratyszcza/confu
+# conda install -c conda-forge ninja
+
+confu setup
+$PYTHON ./configure.py
+ninja
+
+# move files to expected location
+mkdir -p $PREFIX/include
+mkdir -p $PREFIX/lib
+
+cp -p include/nnpack.h $PREFIX/include
+cp -p lib/libnnpack.a $PREFIX/lib
+cp -p lib/libpthreadpool.a $PREFIX/lib
+cp -p deps/pthreadpool/include/pthreadpool.h $PREFIX/include

--- a/conda/nnpack/meta.yaml
+++ b/conda/nnpack/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: nnpack
+  version: "0.0.1"
+
+source:
+  git_url: https://github.com/Maratyszcza/NNPACK.git
+  git_rev: master
+
+build:
+  number: 1
+
+about:
+  home: https://github.com/Maratyszcza/NNPACK
+  license: BSD-2-Clause
+  license_file: LICENSE


### PR DESCRIPTION
As title. Doesn't really do anything particularly well, but builds the library and puts the headers/libs in the right location before packaging.