### PR TITLE
make nnpack conda build with cmake

### DIFF
--- a/conda/nnpack/build.sh
+++ b/conda/nnpack/build.sh
@@ -1,24 +1,17 @@
 #!bin/bash
 
-# Instead of Conda packaging these dependencies, we expect them to be installed
-# pip install --upgrade git+https://github.com/Maratyszcza/PeachPy
-# pip install --upgrade git+https://github.com/Maratyszcza/confu
-# conda install -c conda-forge ninja
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true
+make -j$(getconf _NPROCESSORS_CONF)
+make install
+cd ..
 
-confu setup
-$PYTHON ./configure.py
+# These are the files we actually care about. If we wanted to
+# isolate them, we could make install into a different location
+# and then copy them into $PREFIX
 
-# patch ninja file to compile with -fPIC support
-sed -ibuild.ninja.bak "s/cflags = /cflags = -fPIC /" build.ninja
-sed -ibuild.ninja.bak "s/cxxflags = /cxxflags = -fPIC /" build.ninja
-
-ninja
-
-# move files to expected location
-mkdir -p $PREFIX/include
-mkdir -p $PREFIX/lib
-
-cp -p include/nnpack.h $PREFIX/include
-cp -p lib/libnnpack.a $PREFIX/lib
-cp -p lib/libpthreadpool.a $PREFIX/lib
-cp -p deps/pthreadpool/include/pthreadpool.h $PREFIX/include
+# cp -p include/nnpack.h $PREFIX/include
+# cp -p lib/libnnpack.a $PREFIX/lib
+# cp -p lib/libpthreadpool.a $PREFIX/lib
+# cp -p deps/pthreadpool/include/pthreadpool.h $PREFIX/include


### PR DESCRIPTION
@maratyszcza added CMAKE build for NNPACK which is a better approach for building than the old way for Conda, so we switch to using it here.