### PR TITLE
[test community repos] run_all.sh runs all repo tests and reports on the errors

### DIFF
--- a/test_community_repos/OpenNMT/run.sh
+++ b/test_community_repos/OpenNMT/run.sh
@@ -1,8 +1,12 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
+
 git clone https://github.com/OpenNMT/OpenNMT-py.git
 pushd OpenNMT-py
 ../install-deps.sh
 ../run-script.sh
 popd
 rm -rf OpenNMT-py
+
+popd
 

--- a/test_community_repos/cyclegan/run.sh
+++ b/test_community_repos/cyclegan/run.sh
@@ -1,4 +1,5 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
 git clone https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix.git
 pushd pytorch-CycleGAN-and-pix2pix
 ../download_data.sh
@@ -6,4 +7,4 @@ pushd pytorch-CycleGAN-and-pix2pix
 ../run-script.sh
 popd
 rm -rf pytorch-CycleGAN-and-pix2pix
-
+popd

--- a/test_community_repos/densenet/run.sh
+++ b/test_community_repos/densenet/run.sh
@@ -1,8 +1,11 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
 git clone https://github.com/bamos/densenet.pytorch.git
 pushd densenet.pytorch
 ../install-deps.sh
 ../run-script.sh
 popd
 rm -rf densenet.pytorch
+pop
+pop
 

--- a/test_community_repos/diracnets/run.sh
+++ b/test_community_repos/diracnets/run.sh
@@ -1,6 +1,8 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
 git clone https://github.com/szagoruyko/diracnets
 pushd diracnets
 # ../download_data.sh
 ../install-deps.sh
 ../run-script.sh
+popd

--- a/test_community_repos/examples/run.sh
+++ b/test_community_repos/examples/run.sh
@@ -1,5 +1,8 @@
 set -e
 
+BASEDIR=$(dirname $0)
+pushd $BASEDIR
+
 for file in */ ; do
     echo "Testing $file";
     for script in $file/run.sh ; do
@@ -8,3 +11,4 @@ for file in */ ; do
     echo "Test passed $file";
 done
 
+popd

--- a/test_community_repos/fairseq/run.sh
+++ b/test_community_repos/fairseq/run.sh
@@ -1,4 +1,5 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
 git clone https://github.com/facebookresearch/fairseq-py.git
 pushd fairseq-py
 ../download_data.sh
@@ -6,4 +7,5 @@ pushd fairseq-py
 ../run-script.sh
 popd
 rm -rf fairseq-py
+popd
 

--- a/test_community_repos/generative_collections/run.sh
+++ b/test_community_repos/generative_collections/run.sh
@@ -1,7 +1,10 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
+
 git clone https://github.com/znxlwm/pytorch-generative-model-collections.git
 pushd pytorch-generative-model-collections
 ../run-script.sh
 popd
 rm -rf pytorch-generative-model-collections
 
+popd

--- a/test_community_repos/optnet/run.sh
+++ b/test_community_repos/optnet/run.sh
@@ -1,4 +1,6 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
+
 git clone https://github.com/locuslab/optnet.git
 pushd optnet
 ../install-deps.sh
@@ -6,3 +8,4 @@ pushd optnet
 popd
 rm -rf optnet
 
+popd

--- a/test_community_repos/run_all.py
+++ b/test_community_repos/run_all.py
@@ -1,0 +1,55 @@
+import unittest
+import subprocess
+import sys
+
+PY3 = sys.version_info >= (3, 0)
+TIMEOUT = 2 * 60 * 60  # 2 hours
+
+
+def run(command, timeout=None):
+    """
+    Returns (return-code, stdout, stderr)
+    """
+    if PY3:
+        completed = subprocess.run(command, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, shell=True,
+                                   encoding="utf8", timeout=timeout)
+        return completed.returncode, completed.stdout, completed.stderr
+
+    # Python 2...
+    if timeout is not None:
+        print("WARNING: timeout not supported for python 2")
+    p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, shell=True)
+    output, err = p.communicate()
+    rc = p.returncode
+    return rc, output, err
+
+
+class TestRepos(unittest.TestCase):
+    pass
+
+
+def _test(cls, directory):
+    command = "bash {}/run.sh".format(directory)
+    (rc, out, err) = run(command, TIMEOUT)
+    cls.assertEqual(rc, 0, "Ran {}\nstdout:\n{}\nstderr:\n{}".format(
+        command, out, err))
+
+
+# Generate the tests, one for each repo
+(rc, stdout, stderr) = run("find . -maxdepth 1 -type d -exec echo {} \;")
+if rc is not 0:
+    print("Couldn't execute find command")
+    exit(1)
+
+# Filter out '.', remove trailing ./
+repos = stdout.split('\n')
+repos = sorted([f[2:] for f in repos if len(f) > 2])
+for f in repos:
+    print("found {}".format(f))
+    setattr(TestRepos, "test_" + f, lambda cls, f=f: _test(cls, f))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_community_repos/run_all.sh
+++ b/test_community_repos/run_all.sh
@@ -1,11 +1,8 @@
 set -e
 
-for file in */ ; do
-    echo "Testing $file";
-    for script in $file/run.sh ; do
-        $script
-    done
-    echo "Test passed $file";
-done
+BASEDIR=$(dirname $0)
+pushd $BASEDIR
 
-echo "ALL TESTS PASSED"
+python run_all.py
+
+popd

--- a/test_community_repos/torchMoji/run.sh
+++ b/test_community_repos/torchMoji/run.sh
@@ -1,4 +1,6 @@
 BASEDIR=$(dirname $0)
+pushd $BASEDIR
+
 git clone https://github.com/huggingface/torchMoji.git
 pushd torchMoji
 ../download_data.sh
@@ -7,3 +9,4 @@ pushd torchMoji
 popd
 rm -rf torchMoji
 
+popd


### PR DESCRIPTION
two main changes:
- this makes run_all.sh runs all repo tests and reports on the errors. run_all.sh calls `run_all.py` which runs each repo test as a unit test case
- modified each repo's `run.sh` to always run in the directory it is in (the base directory) when called from somewhere else, if necessary. For example, calling `OpenNMT/run.sh` will run `run.sh` in `OpenNMT/`