### PR TITLE
update makefile.inc to fit latest faiss master

### DIFF
--- a/conda/faiss-cpu/makefile.inc
+++ b/conda/faiss-cpu/makefile.inc
@@ -1,6 +1,7 @@
 CC=g++
 
 CFLAGS=-fPIC -m64 -Wall -g -O3 -mavx -msse4 -mpopcnt -fopenmp -Wno-sign-compare -std=c++11 -fopenmp
+CXXFLAGS=$(CFLAGS) -std=c++11
 LDFLAGS=-g -fPIC  -fopenmp
 
 # common linux flags

--- a/conda/faiss-gpu/makefile.inc
+++ b/conda/faiss-gpu/makefile.inc
@@ -1,6 +1,7 @@
 CC=g++
 
 CFLAGS=-fPIC -m64 -Wall -g -O3 -mavx -msse4 -mpopcnt -fopenmp -Wno-sign-compare -std=c++11 -fopenmp
+CXXFLAGS=$(CFLAGS) -std=c++11
 LDFLAGS=-g -fPIC  -fopenmp
 
 # common linux flags


### PR DESCRIPTION
In a recent makefile change, CXXFLAGS is used in compilation instead of CFLAGS. https://github.com/facebookresearch/faiss/commit/4d440b6698fcc7b08607534bc622902b52bf9c49#diff-b67911656ef5d18c4ae36cb6741b7965R66
Update makefile.inc to be compatible with this change. 
