### PR TITLE
Remove `pytorch` as a run-time dependency

### DIFF
--- a/conda/torchvision-0.2.0/meta.yaml
+++ b/conda/torchvision-0.2.0/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python
     - pillow >=4.1.1
     - numpy >=1.11
-    - pytorch >=0.3
     - six
 
 build:


### PR DESCRIPTION
This gives the user the flexibility to install either `pytorch` or `pytorch-cpu` depending on the hardware available. 

Without this, installing `torchvision` will forcefully install `pytorch` and all the associated `cuda` packages, thereby negating the advantages that `pytorch-cpu` has.

See also:  https://discuss.pytorch.org/t/possible-error-when-installing-pytorch-cpu-via-conda/15149