### PR TITLE
Update faiss build

### DIFF
--- a/conda/build_faiss.sh
+++ b/conda/build_faiss.sh
@@ -27,11 +27,23 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.5 faiss-cpu
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.6 faiss-cpu
 else
-    . ./switch_cuda_version.sh 8.0
+    export CUDA_VERSION="0.0"
+    export CUDNN_VERSION="0.0"
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 2.7 faiss-cpu
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.5 faiss-cpu
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.6 faiss-cpu
 
+    . ./switch_cuda_version.sh 8.0
+    time conda build -c $ANACONDA_USER --no-anaconda-upload --python 2.7 faiss-gpu
+    time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.5 faiss-gpu
+    time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.6 faiss-gpu
+
+    . ./switch_cuda_version.sh 9.0
+    time conda build -c $ANACONDA_USER --no-anaconda-upload --python 2.7 faiss-gpu
+    time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.5 faiss-gpu
+    time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.6 faiss-gpu
+
+    . ./switch_cuda_version.sh 9.1
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 2.7 faiss-gpu
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.5 faiss-gpu
     time conda build -c $ANACONDA_USER --no-anaconda-upload --python 3.6 faiss-gpu

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python
     - numpy >=1.11
     - mkl
-    - cudatoolkit
 
 build:
   number: {{ environ.get('FAISS_BUILD_NUMBER') }}


### PR DESCRIPTION
- faiss build with cuda80 and cuda91
- faiss-cpu not depend on cuda version
- remove cudatoolkit in faiss-gpu runtime.
nit: the missing newline was automatically removed by my editor... let me know if it's necessary. :P