### PR TITLE
Don't run distributed tests for GPU builds

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -278,5 +278,5 @@ pushd $PYTORCH_DIR/test
 for PYDIR in "${DESIRED_PYTHON[@]}"; do
     "${PYDIR}/bin/pip" uninstall -y torch
     "${PYDIR}/bin/pip" install torch --no-index -f /$WHEELHOUSE_DIR
-    LD_LIBRARY_PATH="/usr/local/nvidia/lib64" PYCMD=$PYDIR/bin/python $PYDIR/bin/python run_test.py
+    LD_LIBRARY_PATH="/usr/local/nvidia/lib64" PYCMD=$PYDIR/bin/python $PYDIR/bin/python run_test.py --exclude distributed
 done

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -281,4 +281,5 @@ for PYDIR in "${DESIRED_PYTHON[@]}"; do
     LD_LIBRARY_PATH="/usr/local/nvidia/lib64" PYCMD=$PYDIR/bin/python $PYDIR/bin/python run_test.py --exclude distributed
     set +e
     LD_LIBRARY_PATH="/usr/local/nvidia/lib64" PYCMD=$PYDIR/bin/python $PYDIR/bin/python run_test.py -i distributed
+    set -e
 done

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -279,4 +279,6 @@ for PYDIR in "${DESIRED_PYTHON[@]}"; do
     "${PYDIR}/bin/pip" uninstall -y torch
     "${PYDIR}/bin/pip" install torch --no-index -f /$WHEELHOUSE_DIR
     LD_LIBRARY_PATH="/usr/local/nvidia/lib64" PYCMD=$PYDIR/bin/python $PYDIR/bin/python run_test.py --exclude distributed
+    set +e
+    LD_LIBRARY_PATH="/usr/local/nvidia/lib64" PYCMD=$PYDIR/bin/python $PYDIR/bin/python run_test.py -i distributed
 done


### PR DESCRIPTION
Or I can make this a flag or run only distributed with 'set +e'