### PR TITLE
[conda][nightly] name the cpu build pytorch-nightly-cpu

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -222,7 +222,10 @@ if [[ -n "$cpu_only" ]]; then
     if [[ "$OSTYPE" != "darwin"* ]]; then
         build_string_suffix="cpu_${build_string_suffix}"
     fi
+    # remove the line magma-cuda*, because cpu build doesn't need magma
     $portable_sed "/magma-cuda.*/d" "$meta_yaml"
+    # rename the package pytorch-nightly-cpu, because it's cpu build
+    $portable_sed "s/name: pytorch-nightly/name: pytorch-nightly-cpu/" "$meta_yaml"
 else
     # Switch the CUDA version that /usr/local/cuda points to. This script also
     # sets CUDA_VERSION and CUDNN_VERSION


### PR DESCRIPTION
this is needed, because the `pytorch-nightly` build by default will include the default cuda, which is `cuda 9.0`