### PR TITLE
Temporarily removing conda-build update to stop bleeding on nightlies

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -9,8 +9,6 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }} # [win]
-
-  host:
     - python
     - numpy 1.11.*
     - setuptools


### PR DESCRIPTION
According to the documentation this should work. Maybe it works on a more recent conda-build version. Until it's tested this will be removed so the current nightlies can succeed.