### PR TITLE
Include Declarations.yaml into libtorch-binary

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -135,8 +135,9 @@ if [[ -n "$BUILD_PYTHONLESS" ]]; then
         echo "Finished tools/build_libtorch.py at $(date)"
         popd
 
-        mkdir -p libtorch/{lib,bin,include,share}
+        mkdir -p libtorch/{lib,bin,include,share/spec}
         cp -r build/lib libtorch/
+        cp build/aten/src/ATen/Declarations.yaml libtorch/share/spec/
 
         # for now, the headers for the libtorch package will just be copied in
         # from one of the wheels

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -166,8 +166,9 @@ else
     python ../tools/build_libtorch.py
     popd
 
-    mkdir -p libtorch/{lib,bin,include,share}
+    mkdir -p libtorch/{lib,bin,include,share/spec}
     cp -r "$(pwd)/build/lib" "$(pwd)/libtorch/"
+    cp "$(pwd)/build/aten/src/ATen/Declarations.yaml" "$(pwd)/libtorch/share/spec/"
 
     # for now, the headers for the libtorch package will just be
     # copied in from the wheel

--- a/windows/internal/setup.bat
+++ b/windows/internal/setup.bat
@@ -40,6 +40,7 @@ mkdir libtorch\cmake
 mkdir libtorch\include
 mkdir libtorch\lib
 mkdir libtorch\share
+mkdir libtorch\share\spec
 mkdir libtorch\test
 
 mkdir build
@@ -50,6 +51,7 @@ popd
 IF ERRORLEVEL 1 exit /b 1
 IF NOT ERRORLEVEL 0 exit /b 1
 
+move /Y build\aten\src\ATen\Declarations.yaml libtorch\share\spec\
 move /Y torch\bin\*.* libtorch\bin\
 move /Y torch\cmake\*.* libtorch\cmake\
 robocopy /move /e torch\include\ libtorch\include\


### PR DESCRIPTION
Declarations.yaml  is a artifact of building pytorch. (Now the libtorch-binary does not include it.)
The spec includes  the type-definitions of API.
It is useful to make FFI-bindings of other languages.
The definition may be changed by the building environment(CPU-only or CUDA).
Could you include the spec into libtorch-binary?