### PR TITLE
fix missing hashes from wheel's RECORD

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -288,12 +288,8 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
     if [[ -e $record_file ]]; then
         echo "Generating new record file $record_file"
         rm -f $record_file
-        # generate records for torch folder
-        find torch -type f | while read fname; do
-            echo $(make_wheel_record $fname) >>$record_file
-        done
-        # generate records for torch-[version]-dist-info folder
-        find torch*dist-info -type f | while read fname; do
+        # generate records for folders in wheel
+        find * -type f | while read fname; do
             echo $(make_wheel_record $fname) >>$record_file
         done
     fi


### PR DESCRIPTION
a fix for the broken RECORD file in the wheel, the problem is similar to pytorch/pytorch#2596
which was already fixed in pytorch/builder/pull/6

basically since torch 1.0* the wheel also contains the cafee2/ folder but hashes are not generated for it
