### PR TITLE
Revert "Temporarily pinning MKL version to 2019.1"

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -16,8 +16,8 @@ requirements:
     - setuptools
     - pyyaml
     - cffi
-    - mkl 2019.1
-    - mkl-include 2019.1
+    - mkl >=2018
+    - mkl-include
     - typing
     - ninja
 {{ environ.get('MAGMA_PACKAGE') }}


### PR DESCRIPTION
This reverts commit 89143911ca780313ff84763acbff627d702f5743.

Do not merge this. This is required to test a real fix (switching to non-deprecated MKL calls) by pointing Pytorch CI to this PR.