### PR TITLE
Remove CUDA 8.0 builds from nightlies

### DIFF
--- a/windows/templates/build_task.yml
+++ b/windows/templates/build_task.yml
@@ -77,15 +77,6 @@ jobs:
         PY3.7_90:
           DESIRED_PYTHON: 3.7
           CUDA_VERSION: 90
-        PY3.5_80:
-          DESIRED_PYTHON: 3.5
-          CUDA_VERSION: 80
-        PY3.6_80:
-          DESIRED_PYTHON: 3.6
-          CUDA_VERSION: 80
-        PY3.7_80:
-          DESIRED_PYTHON: 3.7
-          CUDA_VERSION: 80
         PY3.5_100:
           DESIRED_PYTHON: 3.5
           CUDA_VERSION: 100
@@ -96,15 +87,6 @@ jobs:
           DESIRED_PYTHON: 3.7
           CUDA_VERSION: 100
       ${{ if and(ne(parameters.spec, 'CPU'), eq(parameters.package, 'Wheels')) }}:
-        LIBTORCH_80:
-          DESIRED_PYTHON: 3
-          BUILD_PYTHONLESS: 1
-          CUDA_VERSION: 80
-        LIBTORCH_80_DEBUG:
-          DESIRED_PYTHON: 3
-          BUILD_PYTHONLESS: 1
-          CUDA_VERSION: 80
-          DEBUG: 1
         LIBTORCH_90:
           DESIRED_PYTHON: 3
           BUILD_PYTHONLESS: 1


### PR DESCRIPTION
They are not working anymore.
@soumith @pjh5 