### PR TITLE
Adding binary size backfill script and clearer comments

### DIFF
--- a/cron/backfill_binary_sizes.sh
+++ b/cron/backfill_binary_sizes.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+
+# This script is used to backfill binary sizes (backfill the .json files stored
+# at s3://pytorch/nightly_logs/binary_sizes/). All it does it call
+# upload_binary_sizes.sh for a range of dates. This script should not be called
+# often, so the ranges of the dates are hardcoded in.
+
+# The upload_binary_sizes.sh script expects dates with underscores in
+# 2019_01_01 format.
+# You should make sure that end date is actually after start date, and that
+# both are in underscore format
+START_DATE="2019_01_01"
+END_DATE="$(date +%Y_%m_%d)"
+
+# The upload_binary_sizes script needs to construct the entire Pytorch binary
+# versions in order to query conda for the sizes. There is a built-in
+# assumption in many places that the version is like 1.1.0.dev20190101.
+# N.B. this means you cannot use this script across a version boundary, as the
+# script will only work for part of the range
+CURRENT_PYTORCH_VERSION_PREAMBLE="1.1.0.dev"
+
+# TODO actually compare times instead of string comparisons. It's easy to get
+# an infinite loop this way.
+current_date="$START_DATE"
+while [ "$current_date" != "$END_DATE" ]; do
+  ./upload_binary_sizes.sh "$current_date" "$CURRENT_PYTORCH_VERSION_PREAMBLE"
+
+  # The date command understands 20190101 and 2019-01-01 but not 2019_01_01
+  # without work, so we just remove the '_' in the calculation
+  current_date="$(date +%Y_%m_%d -d "$(echo $current_date | tr -d '_') + 1 day")"
+done

--- a/cron/upload_binary_sizes.sh
+++ b/cron/upload_binary_sizes.sh
@@ -1,26 +1,59 @@
 #!/bin/bash
 
+# The hud at pytorch.org/builder populates its binary sizes from reading json
+# files at s3://pytorch/nightly_logs/binary_sizes/cpu/2019_01_01.json (for all
+# cpu versions and dates). This script populates those files by parsing conda
+# info output or from s3
+# Usage:
+#   collect_binary_sizes.sh [date pytorch_version_preamble
+#
+# This script needs a date to search for, and it also needs the full version
+# string for that date so it can query `conda search`. You need to either
+# 1. source builder_root/cron/nightly_defaults.sh first or
+# 2. Pass in the date and the version preamble. This script assumes that the
+#    version string follows 1.1.0.dev20190101 format; the version preamble is
+#    the '1.1.0.dev' part. The date should be given is 2019_01_01 format.
+#
+# N.B. this assumes that there is one version for each date. If you upload
+#      1.1.0 *and* 1.2.0 binaries on the same date, then this will probably
+#      silently intermix the binary sizes.
+# N.B. cuda versions are hardcoded into this file in the s3 section.
+#
+# If you look closely you'll notice that uploaded json files have underscores
+# in their names like 2019_01_01 but the versions use 20190101. This is because
+# we want the jsons to be more human readable, but need the version dates to
+# match what `conda search` knows about
+
 set -ex
 echo "collect_binary_sizes.sh at $(pwd) starting at $(date) on $(uname -a) with pid $$"
 SOURCE_DIR=$(cd $(dirname $0) && pwd)
 # N.B. we do not source nightly_defaults.sh to avoid cloning repos every date
 # of a backfill
 
-# Usage:
-#   collect_binary_sizes.sh [date]
-# Queries s3 and conda to get the binary sizes (as they're stored in the cloud)
-# for a day
-
 # Optionally accept a date to upload for
 if [[ "$#" > 0 ]]; then
-    target_date=$1
-    target_version="1.0.0.dev$(echo $target_date | tr -d _)"
+    if [[ "$#" == 1 ]]; then
+      echo "You must specify the version preamble too"
+      exit 1
+    fi
+    target_date="$1"
+    version_preamble="$2"
+
+    # The docs say that this takes an underscore date but people don't read
+    # docs, so if it's wrong then we fix it.
+    if [[ "${#target_date}" == 8 ]]; then
+      target_date="${target_date:0:4}_${target_date:4:2}_${target_date:6:2}"
+    fi
+    target_date="$(echo $target_date | tr '-' '_')"
+    target_version="${version_preamble}$(echo $target_date | tr -d _)"
 else
     source "${SOURCE_DIR}/nightly_defaults.sh"
     target_date="$NIGHTLIES_DATE"
     target_version="$PYTORCH_BUILD_VERSION"
 fi
 
+# First write lines of "$platform $pkg_type $py_ver $cu_ver $size" to a log,
+# then parse that into json at the end
 binary_sizes_log="$SOURCE_DIR/binary_sizes.log"
 binary_sizes_json="$SOURCE_DIR/$target_date.json"
 rm -f "$binary_sizes_log"
@@ -57,8 +90,8 @@ rm -f "$tmp_json"
 
 
 ##############################################################################
-# Collect wheel binary sizes
-cuda_versions=("cpu" "cu80" "cu90" "cu100")
+# Collect wheel binary sizes. These are read from s3
+cuda_versions=("cpu" "cu90" "cu100")
 for cu_ver in "${cuda_versions[@]}"; do
 
     # Read the info from s3
@@ -104,4 +137,6 @@ done
 python "$SOURCE_DIR/write_json.py" "$binary_sizes_log" "$binary_sizes_json"
 
 # Upload the log to s3
+# N.B. if you want to change the name of this json file then you have to
+# coordinate the change with the gh-pages-src branch
 aws s3 cp "$binary_sizes_json" "s3://pytorch/nightly_logs/binary_sizes/" --acl public-read --quiet


### PR DESCRIPTION
This is a script that used be running in jenkins which was forgotten in the migration to circleci. It is used for the binary sizes in the builder hud