### PR TITLE
Setting minimum conda mkl version to 2019 in nightlies

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - setuptools
     - pyyaml
     - cffi
-    - mkl >=2018
+    - mkl >=2019
     - mkl-include
     - typing
     - ninja


### PR DESCRIPTION
This is needed to fix the conda 3.5 build specifically.