### PR TITLE
Enable switching to devtoolset7 for all nightlies

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -123,7 +123,7 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 if [[ -z "$MAC_PACKAGE_WORK_DIR" ]]; then
     MAC_PACKAGE_WORK_DIR="$(pwd)/tmp_conda_${DESIRED_PYTHON}_$(date +%H%M%S)"
 fi
-if [[ -z "$WIN_PACKAGE_WORK_DIR" ]]; then
+if [[ "$OSTYPE" == "msys" && -z "$WIN_PACKAGE_WORK_DIR" ]]; then
     WIN_PACKAGE_WORK_DIR="$(echo $(pwd -W) | tr '/' '\\')\\tmp_conda_${DESIRED_PYTHON}_$(date +%H%M%S)"
 fi
 
@@ -156,6 +156,8 @@ if [[ ! -d "$pytorch_rootdir" ]]; then
 fi
 pushd "$pytorch_rootdir"
 git submodule update --init --recursive
+echo "Using Pytorch from "
+git --no-pager log --max-count 1
 popd
 
 # Windows builds need to install conda
@@ -237,6 +239,9 @@ else
     if [[ "$desired_cuda" == "10.0" ]]; then
         export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=10.0,<10.1 # [not osx]"
         export MAGMA_PACKAGE="    - magma-cuda100 # [not osx and not win]"
+    elif [[ "$desired_cuda" == "9.2" ]]; then
+        export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=9.2,<9.3 # [not osx]"
+        export MAGMA_PACKAGE="    - magma-cuda92 # [not osx and not win]"
     elif [[ "$desired_cuda" == "9.0" ]]; then
         export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=9.0,<9.1 # [not osx]"
         export MAGMA_PACKAGE="    - magma-cuda90 # [not osx and not win]"

--- a/conda/switch_cuda_version.sh
+++ b/conda/switch_cuda_version.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -ex -o pipefail
+
 if [[ "$OSTYPE" == "msys" ]]; then
     CUDA_DIR="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v$1"
 else

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -71,6 +71,22 @@ DEPS_SONAME=(
     "libnvrtc-builtins.so"
     "libgomp.so.1"
 )
+elif [[ $CUDA_VERSION == "9.2" ]]; then
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.9.2"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.9.2"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "/usr/lib64/libgomp.so.1"
+)
+
+DEPS_SONAME=(
+    "libcudart.so.9.2"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.9.2"
+    "libnvrtc-builtins.so"
+    "libgomp.so.1"
+)
 elif [[ $CUDA_VERSION == "10.0" ]]; then
 DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.10.0"

--- a/update_compiler.sh
+++ b/update_compiler.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -ex
+
+# Expected to be run on a Docker image built from
+# https://github.com/pytorch/builder/blob/master/conda/Dockerfile (or the
+# manywheel equivalent)
+# Updates the compiler toolchain from devtoolset 3 to 7
+
+# ~~~
+# Why does this file exist? Why not just update the compiler on the base docker
+# images?
+#
+# So, all the nightlies used to be built on devtoolset3 with the old gcc ABI.
+# These packages worked well for most people, but could not be linked against
+# by client c++ libraries that were compiled using the new gcc ABI. Since both
+# gcc ABIs are still common in the wild, we should be able to support both
+# ABIs. Hence, we need a script to alter the compiler on the root docker images
+# to configure which ABI we want to build with.
+#
+# So then this script was written to change from devtoolset3 to devtoolset7. It
+# turns out that this doesn't actually fix the problem, since devtoolset7 is
+# incapable of building with the new gcc ABI. BUT, devtoolset7 /is/ able to
+# build with avx512 instructions, which are needed for fbgemm to get good
+# performance. So now this script is called by default on all nightlies.
+#
+# But we still don't have the new gcc ABI. So what should happen next is
+# - Upgrade the compiler on all the base docker images to be devtoolset7.
+#   There's no reason to keep around devtoolset3. It will never be used.
+# - Alter this script to install another compiler toolchain, not a devtoolset#,
+#   which can build with the new gcc ABI. Then use this script as intended, in
+#   a parallel suite of new-gcc-ABI nightlies.
+#
+# When this script is finally changed to build with the new gcc ABI, then we'll
+# need to set this variable manually because
+# https://github.com/pytorch/pytorch/blob/master/torch/abi-check.cpp sets the
+# ABI to 0 by default. 
+# ``` export _GLIBCXX_USE_CXX11_ABI=1 ```
+# Note that this probably needs to get set in the .circleci infra that's
+# running this, since env variables set in this file are probably discarded.
+# ~~~
+
+# The gcc version should be 4.9.2 right now
+echo "Initial gcc version is $(gcc --version)"
+
+# Uninstall devtoolset-3
+yum remove -y -q devtoolset-3-gcc devtoolset-3-gcc-c++ devtoolset-3-gcc-gfortran devtoolset-3-binutils
+
+# Install devtoolset-7
+yum install -y -q devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils
+
+# Replace PATH and LD_LIBRARY_PATH to updated devtoolset
+export PATH=$(echo $PATH | sed 's/devtoolset-3/devtoolset-7/g')
+export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | sed 's/devtoolset-3/devtoolset-7/g')
+
+# The gcc version should now be 7.3.1
+echo "Final gcc version is $(gcc --version)"

--- a/upgrade_gcc_abi.sh
+++ b/upgrade_gcc_abi.sh
@@ -1,23 +1,7 @@
 #!/bin/bash
-set -ex
 
-# Expected to be run on a Docker image built from
-# https://github.com/pytorch/builder/blob/master/conda/Dockerfile (or the
-# manywheel equivalent)
-# Upgrades the devtoolset from 3 to 7
-
-# The gcc version should be 4.9.2 right now
-echo "Initial gcc version is $(gcc --version)"
-
-# Uninstall devtoolset-3
-yum remove -y -q devtoolset-3-gcc devtoolset-3-gcc-c++ devtoolset-3-gcc-gfortran devtoolset-3-binutils
-
-# Install devtoolset-7
-yum install -y -q devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils
-
-# Replace PATH and LD_LIBRARY_PATH to updated devtoolset
-export PATH=$(echo $PATH | sed 's/devtoolset-3/devtoolset-7/g')
-export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | sed 's/devtoolset-3/devtoolset-7/g')
-
-# The gcc version should now be 7.3.1
-echo "Final gcc version is $(gcc --version)"
+# This script has been renamed. This redirection only needs to be here for a
+# few hours for current outstanding PRs. If you are reading this after July
+# 24th then you can remove this safely.
+SOURCE_DIR=$(cd $(dirname $0) && pwd)
+source "${SOURCE_DIR}/update_compiler.sh"


### PR DESCRIPTION
- Remove assumption that devtoolset7==new-gcc-abi
  - Renamed upgrade_gcc.sh to update_compiler.sh, to better match use
  - Fixed some logic in check_binary.sh to match devtoolset7 semantics
- Turn off checking libtorch symbols for cxx11, because the logic is wrong for devtoolset7
- Add back CUDA 9.2 support