### PR TITLE
Fix urls for +cuver versions

### DIFF
--- a/cron/upload_binary_sizes.sh
+++ b/cron/upload_binary_sizes.sh
@@ -72,10 +72,10 @@ failed_binary_queries=()
 # Collect conda binary sizes
 # This is read from `conda search`. 
 
-# `conda search` takes a version string. We use *20190101 to catch
-# 1.0.0.dev20190101 or 1.1.0.dev20190101 etc. All the nightly binaries have
-# this general format of version string
-conda_search_version="*$(echo $target_date | tr -d _)"
+# `conda search` takes a version string. We use *20190101* to catch
+# 1.0.0.dev20190101 or 1.1.0.dev20190101+cu90 etc. All the nightly binaries
+# have this general format of version string
+conda_search_version="*$(echo $target_date | tr -d _)*"
 
 conda_platforms=('linux-64' 'osx-64')
 conda_pkg_names=('pytorch-nightly' 'pytorch-nightly-cpu')

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -103,6 +103,10 @@ elif [[ "$PACKAGE_TYPE" == 'conda' ]]; then
     retry conda install -yq -c pytorch "cudatoolkit=$CUDA_VERSION_SHORT" "$package_name_and_version"
   fi
 else
+  # We need to upgrade pip now that we have '+cuver' in the package name, as
+  # old pips do not correctly change the '+' to '%2B' in the url and fail to
+  # find the package.
+  pip install --upgrade pip -q
   pip_url="https://download.pytorch.org/whl/nightly/$DESIRED_CUDA/torch_nightly.html"
   retry pip install "$package_name_and_version" \
       -f "$pip_url" \


### PR DESCRIPTION
We recently added +cpu, +cu92 etc to versions so that we can combine everything into a single folder.