### PR TITLE
Fix Windows LibTorch builds

### DIFF
--- a/windows/internal/setup.bat
+++ b/windows/internal/setup.bat
@@ -67,11 +67,11 @@ IF "%DEBUG%" == "" (
     set LIBTORCH_PREFIX=libtorch-win-%VARIANT%-debug
 )
 
-7z a -tzip %LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip libtorch\*
+7z a -tzip "%LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip" libtorch\*
 
 mkdir ..\output\%CUDA_PREFIX%
-copy /Y %LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip ..\output\%CUDA_PREFIX%\
-copy /Y %LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip ..\output\%CUDA_PREFIX%\%LIBTORCH_PREFIX%-latest.zip
+copy /Y "%LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip" ..\output\%CUDA_PREFIX%\
+copy /Y "%LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip" ..\output\%CUDA_PREFIX%\%LIBTORCH_PREFIX%-latest.zip
 
 goto build_end
 


### PR DESCRIPTION
\+ means to concat files when using copy. Use quotes to see them as filenames.