### PR TITLE
Build macOS packages with torch.distributed support

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -114,6 +114,14 @@ else
         exit 1
     fi
 fi
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Produce macOS builds with torch.distributed support.
+    # This is enabled by default on Linux, but disabled by default on macOS,
+    # because it requires an non-bundled compile-time dependency (libuv
+    # through gloo). This dependency is made available through meta.yaml, so
+    # we can override the default and set USE_DISTRIBUTED=1.
+    export USE_DISTRIBUTED=1
+fi
 
 echo "Will build for all Pythons: ${DESIRED_PYTHON[@]}"
 echo "Will build for CUDA version: ${desired_cuda}"
@@ -337,4 +345,3 @@ done
 
 unset PYTORCH_BUILD_VERSION
 unset PYTORCH_BUILD_NUMBER
-

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - mkl-include
     - typing
     - ninja
+    - libuv # [unix]
+    - pkg-config # [unix]
 {{ environ.get('MAGMA_PACKAGE') }}
 
   run:
@@ -47,6 +49,7 @@ build:
     - DEBUG
     - USE_FBGEMM
     - USE_SCCACHE # [win]
+    - USE_DISTRIBUTED # [unix]
   features:
 {{ environ.get('CONDA_CPU_ONLY_FEATURE') }}
 

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -140,6 +140,10 @@ export MACOSX_DEPLOYMENT_TARGET=10.10
 retry conda install -yq cmake numpy==1.11.3 nomkl setuptools pyyaml cffi typing ninja requests
 retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 
+# For USE_DISTRIBUTED=1 on macOS, need libuv and pkg-config to find libuv.
+export USE_DISTRIBUTED=1
+retry conda install -yq libuv pkg-config
+
 pushd "$pytorch_rootdir"
 echo "Calling setup.py bdist_wheel at $(date)"
 python setup.py bdist_wheel -d "$whl_tmp_dir"


### PR DESCRIPTION
I figured these environment variables need to be set here, and the dependencies installed/managed here, so that if these scripts are used for the stable release builds, they carry over. If some other way is preferred, let me know. I tested this out at https://github.com/pytorch/pytorch/pull/26164 and the macOS conda and wheel builds are looking good (the CMake summary includes USE_DISTRIBUTED=1 and the builds succeed).