### PR TITLE
Add CUDA 3.0 to arch list

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -15,7 +15,7 @@ if "%build_with_cuda%" == "" goto cuda_flags_end
 
 set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%desired_cuda%
 set CUDA_BIN_PATH=%CUDA_PATH%\bin
-set TORCH_CUDA_ARCH_LIST=3.5;5.0+PTX
+set TORCH_CUDA_ARCH_LIST=3.0;3.5;5.0+PTX
 if "%desired_cuda%" == "8.0" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1
 if "%desired_cuda%" == "9.0" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;7.0
 if "%desired_cuda%" == "9.2" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1;7.0

--- a/windows/cuda100.bat
+++ b/windows/cuda100.bat
@@ -33,10 +33,10 @@ IF "%CUDA_PATH_V10_0%"=="" (
     exit /b 1
 ) ELSE (
     IF "%BUILD_VISION%" == "" (
-        set TORCH_CUDA_ARCH_LIST=3.5;5.0+PTX;6.0;6.1;7.0;7.5
+        set TORCH_CUDA_ARCH_LIST=3.0;3.5;5.0+PTX;6.0;6.1;7.0;7.5
         set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
     ) ELSE (
-        set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_50,code=compute_50
+        set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_50,code=compute_50
     )
 
     set "CUDA_PATH=%CUDA_PATH_V10_0%"

--- a/windows/cuda90.bat
+++ b/windows/cuda90.bat
@@ -33,10 +33,10 @@ IF "%CUDA_PATH_V9_0%"=="" (
     exit /b 1
 ) ELSE (
     IF "%BUILD_VISION%" == "" (
-        set TORCH_CUDA_ARCH_LIST=3.5;5.0+PTX;6.0;7.0
+        set TORCH_CUDA_ARCH_LIST=3.0;3.5;5.0+PTX;6.0;7.0
         set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
     ) ELSE (
-        set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_50,code=compute_50
+        set NVCC_FLAGS=-D__CUDA_NO_HALF_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_50,code=compute_50
     )
 
     set "CUDA_PATH=%CUDA_PATH_V9_0%"


### PR DESCRIPTION
Now that 3.0 is working due to https://github.com/pytorch/pytorch/commit/d1496183f59b59928ac7003503591560716f21c5 is it possible to have the nightlies include this?

Thanks.