### PR TITLE
subprocess.run only support on python3

### DIFF
--- a/test_community_repos/run_all.sh
+++ b/test_community_repos/run_all.sh
@@ -3,6 +3,6 @@
 BASEDIR=$(dirname $0)
 pushd $BASEDIR
 
-python run_all.py
+python3 run_all.py
 
 popd


### PR DESCRIPTION
tests are failing to due default python interpreter version is 2. 