### PR TITLE
Fix macos smoketest

### DIFF
--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -66,7 +66,7 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   else
       LIBTORCH_ABI=
   fi
-  if [[ "$DESIRED_CUDA" == 'cu100' ]]; then
+  if [[ "$DESIRED_CUDA" == 'cu100' || "libtorch_variant" == 'macos' ]]; then
     package_name="libtorch-$LIBTORCH_ABI$libtorch_variant-${NIGHTLIES_DATE_PREAMBLE}${DATE}.zip"
   else
     package_name="libtorch-$LIBTORCH_ABI$libtorch_variant-${NIGHTLIES_DATE_PREAMBLE}${DATE}%2B${DESIRED_CUDA}.zip"

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -66,7 +66,7 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   else
       LIBTORCH_ABI=
   fi
-  if [[ "$DESIRED_CUDA" == 'cu100' || "libtorch_variant" == 'macos' ]]; then
+  if [[ "$DESIRED_CUDA" == 'cu100' || "$libtorch_variant" == 'macos' ]]; then
     package_name="libtorch-$LIBTORCH_ABI$libtorch_variant-${NIGHTLIES_DATE_PREAMBLE}${DATE}.zip"
   else
     package_name="libtorch-$LIBTORCH_ABI$libtorch_variant-${NIGHTLIES_DATE_PREAMBLE}${DATE}%2B${DESIRED_CUDA}.zip"


### PR DESCRIPTION
well, only partially, untill MPL fix is in, we will still see error like:

```
+ ./example-app
libc++abi.dylib: terminating with uncaught exception of type c10::Error: MKL is not available (main at example-app.cpp:4)
frame #0: c10::Error::Error(c10::SourceLocation, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 135 (0x10b4d4977 in libc10.dylib)
frame #1: main + 358 (0x10b4b4f86 in example-app)
frame #2: start + 1 (0x7fffb65fc235 in libdyld.dylib)
frame #3: 0x0 + 1 (0x1 in ???)

/Users/distiller/project/builder/check_binary.sh: line 224:  4332 Abort trap: 6           ./example-app

```