### PR TITLE
Fix libiomp5.dylib not found issue for libtorch macOS binary

### DIFF
--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -200,6 +200,7 @@ else
         cp -r "$(pwd)/any_wheel/torch/lib/include" "$(pwd)/libtorch/"
     fi
     cp -r "$(pwd)/any_wheel/torch/share/cmake" "$(pwd)/libtorch/share/"
+    cp -r "$(pwd)/any_wheel/torch/.dylibs/libiomp5.dylib" "$(pwd)/libtorch/lib/"
     rm -rf "$(pwd)/any_wheel"
 
     echo $PYTORCH_BUILD_VERSION > libtorch/build-version


### PR DESCRIPTION
This fixes https://github.com/pytorch/pytorch/issues/14727. The accompanying PR is https://github.com/pytorch/pytorch/pull/25208 which also adds tests to make sure we don't regress on this in the future.