### PR TITLE
Add typing runtime dependency to conda build

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - cffi
     - ninja
     - future # [py2k]
+    - typing # [py2k]
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 
 build:


### PR DESCRIPTION
Summary:
Add typing to runtime dependency to conda build for py2