### PR TITLE
Some fixes for the windows build scripts

### DIFF
--- a/conda/vs2017/install_activate.bat
+++ b/conda/vs2017/install_activate.bat
@@ -12,12 +12,10 @@ IF "%cross_compiler_target_platform%" == "win-64" (
     echo CALL "VC\Auxiliary\Build\vcvarsall.bat" x64 >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
     echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
     echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-    echo CALL "VC\Auxiliary\Build\vcvarsall.bat" x86_amd64 >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   ) ELSE (
     echo CALL "VC\Auxiliary\Build\vcvarsall.bat" x64 %VSDEVCMD_ARGS% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
     echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
     echo pushd "%%VSINSTALLDIR%%" >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
-    echo CALL "VC\Auxiliary\Build\vcvarsall.bat" x86_amd64 %VSDEVCMD_ARGS% >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   )
   echo popd >> "%PREFIX%\etc\conda\activate.d\vs%YEAR%_compiler_vars.bat"
   ) else (

--- a/windows/templates/build_task.yml
+++ b/windows/templates/build_task.yml
@@ -122,6 +122,7 @@ jobs:
       taskkill /im ninja.exe /f || ver > NUL
       taskkill /im link.exe /f || ver > NUL
       taskkill /im cmake.exe /f || ver > NUL
+      taskkill /im conda-build.exe /f || ver > NUL
     displayName: 'Cleaning unclosed processes'
 
   - checkout: self

--- a/windows/templates/build_task.yml
+++ b/windows/templates/build_task.yml
@@ -12,7 +12,7 @@ parameters:
 
 jobs:
 - job: 'Windows_${{ parameters.spec }}_${{ parameters.package }}_Build'
-  timeoutInMinutes: 240
+  timeoutInMinutes: 300
   cancelTimeoutInMinutes: 5
   condition: > 
     or(and(eq('${{ parameters.package }}', 'Conda'), eq('${{ parameters.spec }}', 'CPU'),
@@ -118,6 +118,10 @@ jobs:
   - script: |
       taskkill /im nvcc.exe /f || ver > NUL
       taskkill /im sccache.exe /f || ver > NUL
+      taskkill /im cl.exe /f || ver > NUL
+      taskkill /im ninja.exe /f || ver > NUL
+      taskkill /im link.exe /f || ver > NUL
+      taskkill /im cmake.exe /f || ver > NUL
     displayName: 'Cleaning unclosed processes'
 
   - checkout: self

--- a/windows/templates/build_task.yml
+++ b/windows/templates/build_task.yml
@@ -12,7 +12,7 @@ parameters:
 
 jobs:
 - job: 'Windows_${{ parameters.spec }}_${{ parameters.package }}_Build'
-  timeoutInMinutes: 300
+  timeoutInMinutes: 240
   cancelTimeoutInMinutes: 5
   condition: > 
     or(and(eq('${{ parameters.package }}', 'Conda'), eq('${{ parameters.spec }}', 'CPU'),


### PR DESCRIPTION
1. More process kills before cloning
2. Remove x86_amd64 env activation

Fixes https://github.com/pytorch/pytorch/issues/30074