### PR TITLE
run_tests: Switch disutils -> site, for Py3.8

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -80,7 +80,7 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
     else
 	retry conda install -yq cffi future hypothesis mkl>=2018 ninja numpy>=1.11 protobuf pytest setuptools six typing pyyaml requests
     fi
-	
+
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true
@@ -145,7 +145,7 @@ fi
 # Check that OpenBlas is not linked to on Macs
 if [[ "$(uname)" == 'Darwin' ]]; then
     echo "Checking the OpenBLAS is not linked to"
-    all_dylibs=($(find "$(python -c 'from setuptools import distutils; print(distutils.sysconfig.get_python_lib())')"/torch -name '*.dylib'))
+    all_dylibs=($(find "$(python -c "import site; print(site.getsitepackages()[0])")"/torch -name '*.dylib'))
     for dylib in "${all_dylibs[@]}"; do
         if [[ -n "$(otool -L $dylib | grep -i openblas)" ]]; then
             echo "Found openblas as a dependency of $dylib"
@@ -339,10 +339,10 @@ if [[ "$cuda_ver" != 'cpu' ]]; then
     tests_to_skip+=('TestEndToEndHybridFrontendModels and test_vae_cuda')
 
     # ________________________ TestNN.test_embedding_bag_cuda ________________________
-    # 
+    #
     # self = <test_nn.TestNN testMethod=test_embedding_bag_cuda>
     # dtype = torch.float32
-    # 
+    #
     #     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     #     @repeat_test_for_types(ALL_TENSORTYPES)
     #     @skipIfRocm
@@ -354,7 +354,7 @@ if [[ "$cuda_ver" != 'cpu' ]]; then
     #             # torch.cuda.sparse.HalfTensor is not enabled.
     #             self._test_EmbeddingBag(True, 'sum', True, dtype)
     # >           self._test_EmbeddingBag(True, 'mean', True, dtype)
-    # 
+    #
     # test_nn.py:2144:
     # _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
     # test_nn.py:2062: in _test_EmbeddingBag
@@ -695,7 +695,7 @@ for exclusion in "${tests_to_skip[@]}"; do
     fi
 done
 
- 
+
 ##############################################################################
 # Run the tests
 ##############################################################################


### PR DESCRIPTION
distuils was absorbed into the stdlib as part of Python 3.8 which makes
the `from setuptools import distutils` invalid.

Instead of writing some try / except logic or logic based around Python
versions lets just make it so that you don't have to care at all and use
something that's built into the stdlib for everything.

NOTE: Doesn't work on anything python <= 2.6

[`CircleCI logs for reference`](https://circleci.com/gh/pytorch/pytorch/4352937?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

```
Jan 28 00:56:59 + echo 'Checking the OpenBLAS is not linked to'
Jan 28 00:56:59 Checking the OpenBLAS is not linked to
Jan 28 00:56:59 + all_dylibs=($(find "$(python -c 'from setuptools import distutils; print(distutils.sysconfig.get_python_lib())')"/torch -name '*.dylib'))
Jan 28 00:56:59 +++ python -c 'from setuptools import distutils; print(distutils.sysconfig.get_python_lib())'
Jan 28 00:56:59 Traceback (most recent call last):
Jan 28 00:56:59   File "<string>", line 1, in <module>
Jan 28 00:56:59 AttributeError: module 'distutils' has no attribute 'sysconfig'
Jan 28 00:56:59 ++ find /torch -name '*.dylib'
Jan 28 00:56:59 find: /torch: No such file or directory
```

Only really affects `macOS`

Will hopefully unblock https://github.com/pytorch/pytorch/pull/31948

also includes some whitespace changes since my editor automatically removes trailing whitespace. (sorry, not sorry)

If you're worried about the whitespace changes, here's a diff where it doesn't show them: https://github.com/pytorch/builder/pull/398/files?utf8=%E2%9C%93&diff=split&w=1

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>