### PR TITLE
Make conda packages compatible with conda-forge

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - ninja
     - future # [py2k]
     - typing # [py2k]
+    - blas * mkl
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 
 build:


### PR DESCRIPTION
This also works with defaults and forces numpy to use MKL in both conda-forge and defaults.