### PR TITLE
manywheel: Add missing dependencies

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -73,7 +73,22 @@ ARG BASE_CUDA_VERSION=10.1
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-RUN yum install -y wget curl perl util-linux xz bzip2 git patch which perl
+RUN yum install -y \
+        automake \
+        bison \
+        bzip2 \
+        curl \
+        diffutils \
+        file \
+        git \
+        patch \
+        perl \
+        unzip \
+        util-linux \
+        wget \
+        which \
+        xz \
+        yasm \
 RUN yum install -y yum-utils centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils


### PR DESCRIPTION
These dependencies weren't installed as part of the dockerfile but were
rather installed when we built python.

Install these explictly instead of as a side effect.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>