### PR TITLE
manywheel: Be explicit about libtorch cp

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -128,15 +128,15 @@ fi
     mkdir -p libtorch/{lib,bin,include,share}
 
     # Copy over all lib files
-    cp -rv build/lib                libtorch/
-    cp -rv build/lib*/torch/lib/*   libtorch/
+    cp -rv build/lib/*                libtorch/lib/
+    cp -rv build/lib*/torch/lib/*     libtorch/lib/
 
     # Copy over all include files
-    cp -rv build/include            libtorch/
-    cp -rv build/lib*/torch/include libtorch/
+    cp -rv build/include/*            libtorch/include/
+    cp -rv build/lib*/torch/include/* libtorch/include/
 
     # Copy over all of the cmake files
-    cp -rv build/lib*/torch/share   libtorch/
+    cp -rv build/lib*/torch/share/*   libtorch/share/
 
     echo "${PYTORCH_BUILD_VERSION}" > libtorch/build-version
     echo "$(pushd $pytorch_rootdir && git rev-parse HEAD)" > libtorch/build-hash


### PR DESCRIPTION
Had an issue where files were duplicated in the lib directory as well as
the root directory.

I believe this is related to the cp commands not being explicit enough
over what is actually being copied.

This resolves that by adding globs and explicitly stating destination
directories

Relates to https://github.com/pytorch/pytorch/issues/34417

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>