### PR TITLE
Add `ninja` build tool to docker images

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -18,7 +18,7 @@ RUN yum install -y cmake3 && \
 ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:$LD_LIBRARY_PATH
 
-RUN yum install -y autoconf aclocal automake make
+RUN yum install -y autoconf aclocal automake make ninja-build
 
 FROM base as patchelf
 # Install patchelf

--- a/libtorch/ubuntu16.04/Dockerfile
+++ b/libtorch/ubuntu16.04/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:9.2-devel-ubuntu16.04 as base
 
 RUN apt-get clean && apt-get update
-RUN apt-get install -y curl locales git-all autoconf automake make wget unzip
+RUN apt-get install -y curl locales git-all autoconf automake make wget unzip ninja-build
 
 RUN locale-gen en_US.UTF-8
 


### PR DESCRIPTION
`pytorch/setup.py` would switch to `ninja` instead of traditional cmake, which supposed to be much faster than make
For example:
```
$ time ninja torch_python
real  23m47.899s
user  266m41.163s
sys   6m22.785s
```
vs
```
$ time make -j32 torch_python
[100%] Built target torch_python

real	25m56.396s
user	269m59.115s
sys	6m35.354s
```