### PR TITLE
Update Windows CI for nightly builds

### DIFF
--- a/windows/templates/auth_task.yml
+++ b/windows/templates/auth_task.yml
@@ -6,7 +6,7 @@ jobs:
   - group: 'peterjc-vsts-token'
 
   pool:
-    vmImage: 'win1803'
+    vmImage: 'vs2017-win2016'
 
   steps:
   - checkout: self

--- a/windows/templates/build_task.yml
+++ b/windows/templates/build_task.yml
@@ -140,7 +140,7 @@ jobs:
 
   pool:
     ${{ if eq(parameters.msagent, 'true') }}:
-      vmImage: 'win1803'
+      vmImage: 'vs2017-win2016'
     ${{ if eq(parameters.msagent, 'false') }}:
       name: 'pytorch'
 


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent, `win1803` will be removed soon.