### PR TITLE
run_tests: Switch numpy_ver to be more lenient for newer versions

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -84,11 +84,13 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true
-    if [[ "$(python --version 2>&1)" == *3.7.* ]]; then
-        retry pip install -q numpy==1.15 || true
-    else
-        retry pip install -q numpy==1.11 || true
-    fi
+    numpy_ver=1.15
+    case "$(python --version 2>&1)" in
+      *2* | *3.5* | *3.6*)
+        numpy_ver=1.11
+        ;;
+    esac
+    retry pip install -q "numpy==${numpy_ver}" || true
 fi
 
 echo "Testing with:"


### PR DESCRIPTION
Ran into an issue where we should've been installing a newer version of
numpy on Python 3.8

Basically just inversed the conditional.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>