### PR TITLE
Upgrade from miniconda2 to miniconda3

### DIFF
--- a/common/install_conda.sh
+++ b/common/install_conda.sh
@@ -3,10 +3,10 @@
 set -ex
 
 # Anaconda
-wget -q https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
-chmod +x  Miniconda2-latest-Linux-x86_64.sh
-./Miniconda2-latest-Linux-x86_64.sh -b -p /opt/conda
-rm Miniconda2-latest-Linux-x86_64.sh
+wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+chmod +x  Miniconda3-latest-Linux-x86_64.sh
+./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
+rm Miniconda3-latest-Linux-x86_64.sh
 export PATH=/opt/conda/bin:$PATH
 conda install -y conda-build anaconda-client git ninja
 conda remove -y --force patchelf


### PR DESCRIPTION
Looks like the libtorch CXX11 ABI build (I was able to run locally) uses the Miniconda2 installed python so the `/opt/python/XXX` is not used and actually doesn't even exist. This upgrades to Miniconda3. Not sure how to verify this works on https://github.com/pytorch/pytorch/pull/35677 but will work with @yf225 on that.

cc @malfet @seemethere @ezyang 