### PR TITLE
Copy hidden files for PyTorch wheel builds

### DIFF
--- a/windows/internal/clone.bat
+++ b/windows/internal/clone.bat
@@ -2,7 +2,7 @@
 
 :: The conda and wheels jobs are seperated on Windows, so we don't need to clone again.
 if exist "%NIGHTLIES_PYTORCH_ROOT%" (
-    xcopy /E /Y /Q "%NIGHTLIES_PYTORCH_ROOT%" pytorch\
+    xcopy /E /Y /Q /H "%NIGHTLIES_PYTORCH_ROOT%" pytorch\
     cd pytorch
 )
 if exist "%NIGHTLIES_PYTORCH_ROOT%" goto submodule


### PR DESCRIPTION
(e.g. `.git`) otherwise subsequent git calls won't work.
cc @seemethere @soumith 