### PR TITLE
Bump devtoolset to 7

### DIFF
--- a/conda/README.md
+++ b/conda/README.md
@@ -18,11 +18,7 @@ docker push soumith/conda-cuda
 
 ```
 docker run -it --ipc=host --rm -v $(pwd):/remote pytorch/conda-cuda bash
-yum install -y yum-utils centos-release-scl
-yum-config-manager --enable rhel-server-rhscl-7-rpms
-yum install -y devtoolset-3-gcc devtoolset-3-gcc-c++ devtoolset-3-gcc-gfortran devtoolset-3-binutils
-export PATH=/opt/rh/devtoolset-3/root/usr/bin:$PATH
-export LD_LIBRARY_PATH=/opt/rh/devtoolset-3/root/usr/lib64:/opt/rh/devtoolset-3/root/usr/lib:$LD_LIBRARY_PATH
+
 cd remote/conda
 
 # versioned

--- a/magma/Dockerfile
+++ b/magma/Dockerfile
@@ -1,6 +1,0 @@
-FROM pytorch/conda-cuda:latest
-RUN yum install -y yum-utils centos-release-scl
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-RUN yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils
-ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:$LD_LIBRARY_PATH

--- a/magma/Dockerfile
+++ b/magma/Dockerfile
@@ -1,8 +1,6 @@
 FROM pytorch/conda-cuda:latest
 RUN yum install -y yum-utils centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-# We need to use devtoolset-3 for keeping down binary size
-# See: https://github.com/pytorch/builder/pull/400#issuecomment-580957989
-RUN yum install -y devtoolset-3-gcc devtoolset-3-gcc-c++ devtoolset-3-gcc-gfortran devtoolset-3-binutils
-ENV PATH=/opt/rh/devtoolset-3/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-3/root/usr/lib64:/opt/rh/devtoolset-3/root/usr/lib:$LD_LIBRARY_PATH
+RUN yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-binutils
+ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:$LD_LIBRARY_PATH

--- a/magma/build.sh
+++ b/magma/build.sh
@@ -3,16 +3,11 @@
 set -eou pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-BUILDER_IMAGE="pytorch/magma-builder"
 DESIRED_CUDA=${DESIRED_CUDA:-10.2}
-
-# Do this so we don't have to send a docker context
-cat "${DIR}/Dockerfile" | docker build -t "${BUILDER_IMAGE}" -
 
 docker run --rm -i \
     -v $(git rev-parse --show-toplevel):/builder \
     -w /builder \
     -e "DESIRED_CUDA=${DESIRED_CUDA}" \
-    "${BUILDER_IMAGE}" \
+    "pytorch/conda-cuda:latest" \
     magma/build_magma.sh


### PR DESCRIPTION
devtoolset-3 is no longer a thing, and the docker build will not succeed anymore. I locally tested that magma could be built successfully with CUDA 10.2 and 9.2 on devtoolset-7.

But I am not sure about the reason why it was pinned to 3, do I miss something?

cc: @seemethere @soumith 