### PR TITLE
manywheel: Simplify cuda arch, remove PTX and 6.1

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -46,19 +46,19 @@ else
     echo "CUDA $CUDA_VERSION Detected"
 fi
 
-export TORCH_CUDA_ARCH_LIST="5.0"
+export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0"
 case ${CUDA_VERSION} in
     10.2)
         # No 3.7+PTX, or 6.1 for CUDA 10.2
-        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;7.0;7.5"
+        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     10.*)
-        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST};6.0;6.1;7.0"
+        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST}"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     9.*)
-        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST};6.0;6.1;7.0"
+        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST}"
         ;;
     *)
         echo "unknown cuda version $CUDA_VERSION"

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -46,7 +46,7 @@ else
     echo "CUDA $CUDA_VERSION Detected"
 fi
 
-export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;6.1;7.0"
+export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;7.0"
 case ${CUDA_VERSION} in
     10.2)
         # No 5.0 for CUDA 10.2

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -46,21 +46,19 @@ else
     echo "CUDA $CUDA_VERSION Detected"
 fi
 
-export TORCH_CUDA_ARCH_LIST="3.7+PTX;6.0;6.1;7.0"
+export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;6.1;7.0"
 case ${CUDA_VERSION} in
     10.2)
         # No 5.0 for CUDA 10.2
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
-        # Compile CUDA 10.2 without caffe2 ops
-        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DBUILD_CAFFE2_OPS=OFF")
         ;;
     10.*)
-        export TORCH_CUDA_ARCH_LIST="5.0;${TORCH_CUDA_ARCH_LIST}"
+        export TORCH_CUDA_ARCH_LIST=";${TORCH_CUDA_ARCH_LIST}"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     9.*)
-        export TORCH_CUDA_ARCH_LIST="5.0;${TORCH_CUDA_ARCH_LIST}"
+        export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
         ;;
     *)
         echo "unknown cuda version $CUDA_VERSION"

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -46,29 +46,25 @@ else
     echo "CUDA $CUDA_VERSION Detected"
 fi
 
-export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0"
-if [[ $CUDA_VERSION == "9.0" ]]; then
-    export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;7.0"
-elif [[ $CUDA_VERSION == "9.2" ]]; then
-    export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0"
-    # ATen tests can't build with CUDA 9.2 and the old compiler used here
-    EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
-elif [[ $CUDA_VERSION == "10.0" ]]; then
-    export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5"
-    # ATen tests can't build with CUDA 10.0 maybe???? (todo) and the old compiler used here
-    EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
-elif [[ $CUDA_VERSION == "10.1" ]]; then
-    export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5"
-    # ATen tests can't build with CUDA 10.1 maybe???? (todo) and the old compiler used here
-    EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
-elif [[ $CUDA_VERSION == "10.2" ]]; then
-    export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5"
-    # ATen tests can't build with CUDA 10.1 maybe???? (todo) and the old compiler used here
-    EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
-else
-    echo "unknown cuda version $CUDA_VERSION"
-    exit 1
-fi
+export TORCH_CUDA_ARCH_LIST="5.0"
+case ${CUDA_VERSION} in
+    10.2)
+        # No 3.7+PTX, or 6.1 for CUDA 10.2
+        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;7.0;7.5"
+        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
+        ;;
+    10.*)
+        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST};6.0;6.1;7.0"
+        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
+        ;;
+    9.*)
+        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST};6.0;6.1;7.0"
+        ;;
+    *)
+        echo "unknown cuda version $CUDA_VERSION"
+        exit 1
+        ;;
+esac
 echo $TORCH_CUDA_ARCH_LIST
 
 cuda_version_nodot=$(echo $CUDA_VERSION | tr -d '.')

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -46,19 +46,21 @@ else
     echo "CUDA $CUDA_VERSION Detected"
 fi
 
-export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0"
+export TORCH_CUDA_ARCH_LIST="3.7+PTX;6.0;6.1;7.0"
 case ${CUDA_VERSION} in
     10.2)
-        # No 3.7+PTX, or 6.1 for CUDA 10.2
+        # No 5.0 for CUDA 10.2
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
+        # Compile CUDA 10.2 without caffe2 ops
+        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DBUILD_CAFFE2_OPS=OFF")
         ;;
     10.*)
-        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST}"
+        export TORCH_CUDA_ARCH_LIST="5.0;${TORCH_CUDA_ARCH_LIST}"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     9.*)
-        export TORCH_CUDA_ARCH_LIST="3.7+PTX;${TORCH_CUDA_ARCH_LIST}"
+        export TORCH_CUDA_ARCH_LIST="5.0;${TORCH_CUDA_ARCH_LIST}"
         ;;
     *)
         echo "unknown cuda version $CUDA_VERSION"


### PR DESCRIPTION
Simplifies the logic for cuda arch selection when building manywheels
and removes old / redundant architectures from our cuda 10.2 builds so
taht we can get below the binary size limit for PyPI

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>