### PR TITLE
Changed min CUDA capability to 3.5 for Kepler

### DIFF
--- a/magma/magma-cuda100/cmakelists.patch
+++ b/magma/magma-cuda100/cmakelists.patch
@@ -57,8 +57,8 @@
      endif()
  
 +    if ( ${GPU_TARGET} MATCHES "All")
-+      set( MIN_ARCH 370)
-+      SET( NV_SM -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
++      set( MIN_ARCH 350)
++      SET( NV_SM -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
 +      SET( NV_COMP "")
 +    endif()
 +    

--- a/magma/magma-cuda101/cmakelists.patch
+++ b/magma/magma-cuda101/cmakelists.patch
@@ -57,8 +57,8 @@
      endif()
  
 +    if ( ${GPU_TARGET} MATCHES "All")
-+      set( MIN_ARCH 370)
-+      SET( NV_SM -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
++      set( MIN_ARCH 350)
++      SET( NV_SM -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
 +      SET( NV_COMP "")
 +    endif()
 +    

--- a/magma/magma-cuda102/cmakelists.patch
+++ b/magma/magma-cuda102/cmakelists.patch
@@ -57,8 +57,8 @@
      endif()
  
 +    if ( ${GPU_TARGET} MATCHES "All")
-+      set( MIN_ARCH 370)
-+      SET( NV_SM -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
++      set( MIN_ARCH 350)
++      SET( NV_SM -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
 +      SET( NV_COMP "")
 +    endif()
 +    

--- a/magma/magma-cuda92/cmakelists.patch
+++ b/magma/magma-cuda92/cmakelists.patch
@@ -57,8 +57,8 @@
      endif()
  
 +    if ( ${GPU_TARGET} MATCHES "All")
-+      set( MIN_ARCH 370)
-+      SET( NV_SM -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
++      set( MIN_ARCH 350)
++      SET( NV_SM -gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 )
 +      SET( NV_COMP "")
 +    endif()
 +    


### PR DESCRIPTION
Currently Kepler MIN_ARCH 370 allows only TESLA K80.
To use other Kepler GPUs MIN_ARCH must be 350.
Tested with TESLA K20x, CUDA compute capability 3.5.