### PR TITLE
Remove special case for CUDA-10.2

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -48,13 +48,8 @@ fi
 
 export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;7.0"
 case ${CUDA_VERSION} in
-    10.2)
-        # No 5.0 for CUDA 10.2
-        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5"
-        EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
-        ;;
     10.*)
-        export TORCH_CUDA_ARCH_LIST=";${TORCH_CUDA_ARCH_LIST}"
+        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     9.*)


### PR DESCRIPTION
This keeps CUDA arch list consistent between CUDA-10.1 and CUDA-10.2