### PR TITLE
Add typing_extensions as a new dependency

### DIFF
--- a/conda/debugging_pytorch.sh
+++ b/conda/debugging_pytorch.sh
@@ -14,7 +14,7 @@ export USE_CUDA_STATIC_LINK=1
 . ./switch_cuda_version.sh 9.0
 
 
-conda install -y cmake numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing ninja magma-cuda80 -c pytorch
+conda install -y cmake numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing_extension ninja magma-cuda80 -c pytorch
 
 export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 git clone https://github.com/pytorch/pytorch -b nightly2 --recursive

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -15,10 +15,9 @@ requirements:
     - numpy 1.11.*
     - setuptools
     - pyyaml
-    - cffi # [py2k]
     - mkl >=2019
     - mkl-include
-    - typing # [py2k]
+    - typing_extensions
     - ninja
     - libuv # [unix]
     - pkg-config # [unix]
@@ -28,10 +27,8 @@ requirements:
     - python
     - numpy >=1.11
     - mkl >=2018
-    - cffi # [py2k]
     - ninja
-    - future # [py2k]
-    - typing # [py2k]
+    - typing_extensions
     - blas * mkl
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -76,9 +76,10 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
         fi
     fi
     if [[ "$(python --version 2>&1)" == *3.8.* ]]; then
-	retry conda install -yq future hypothesis mkl>=2018 ninja numpy>=1.15 protobuf pytest setuptools six pyyaml
+	retry conda install -yq future hypothesis mkl>=2018 ninja numpy>=1.15
+        protobuf pytest setuptools six typing_extensions pyyaml
     else
-	retry conda install -yq cffi future hypothesis mkl>=2018 ninja numpy>=1.11 protobuf pytest setuptools six typing pyyaml requests
+	retry conda install -yq cffi future hypothesis mkl>=2018 ninja numpy>=1.11 protobuf pytest setuptools six typing_extensions pyyaml requests
     fi
 
 else

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -153,7 +153,7 @@ esac
 if [[ "$desired_python" == 3.8 ]]; then
     retry conda install -yq cmake numpy=1.17 nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" ninja
 else
-    retry conda install -yq cmake numpy==1.11.3 nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing ninja requests
+    retry conda install -yq cmake numpy==1.11.3 nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
 fi
 retry conda install -yq mkl-include==2020.1 mkl-static==2020.1 -c intel
 retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true

--- a/windows/build_all.bat
+++ b/windows/build_all.bat
@@ -27,13 +27,11 @@ call ..\conda\install_conda.bat
 set "PATH=%CONDA_HOME%;%CONDA_HOME%\scripts;%CONDA_HOME%\Library\bin;%PATH%"
 set "ORIG_PATH=%PATH%"
 
-conda remove -n py35 --all -y || rmdir %CONDA_HOME%\envs\py35 /s
 conda remove -n py36 --all -y || rmdir %CONDA_HOME%\envs\py36 /s
 conda remove -n py37 --all -y || rmdir %CONDA_HOME%\envs\py37 /s
 
-conda create -n py35 -y -q numpy=1.11 mkl=2018 cffi pyyaml boto3 cmake ninja typing python=3.5
-conda create -n py36 -y -q numpy=1.11 mkl=2018 cffi pyyaml boto3 cmake ninja typing python=3.6
-conda create -n py37 -y -q numpy=1.11 mkl=2018 cffi pyyaml boto3 cmake ninja typing python=3.7
+conda create -n py36 -y -q numpy=1.11 mkl=2018 cffi pyyaml boto3 cmake ninja typing_extensions python=3.6
+conda create -n py37 -y -q numpy=1.11 mkl=2018 cffi pyyaml boto3 cmake ninja typing_extensions python=3.7
 
 REM Install MKL
 rmdir /s /q mkl

--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -56,11 +56,10 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
-    if "%%v" == "3.5" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing python=%%v
-    if "%%v" == "3.6" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing python=%%v
-    if "%%v" == "3.7" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing python=%%v
-    if "%%v" == "3.8" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja python=%%v
-    if "%%v" == "3" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja python=%%v
+    if "%%v" == "3.6" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.7" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.8" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
 )
 endlocal
 


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/issues/38221

I removed some py2k and py35 lines, those are no longer supported and it looked to me like cleaning up was better than modifying.