### PR TITLE
Fix CUDA-10.2 installation logic on Windows

### DIFF
--- a/windows/internal/cuda_install.bat
+++ b/windows/internal/cuda_install.bat
@@ -88,6 +88,8 @@ if not exist "%SRC_DIR%\temp_build\cudnn-10.2-windows10-x64-v7.6.5.32.zip" (
     set "CUDNN_SETUP_FILE=%SRC_DIR%\temp_build\cudnn-10.2-windows10-x64-v7.6.5.32.zip"
 )
 
+goto cuda_common
+
 :cuda110
 
 if not exist "%SRC_DIR%\temp_build\cuda_11.0.2_451.48_win10.exe" (


### PR DESCRIPTION
Add missing `goto cuda_common` otherwise installing 10.2 will actually install CUDA-11