### PR TITLE
llvm: Add llvm docker build

### DIFF
--- a/llvm/Dockerfile
+++ b/llvm/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:xenial as dev
+ARG LLVM_VERSION=9.0.1
+ENV LLVM_URL https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+        build-essential \
+        curl \
+        cmake \
+        make \
+        python3 \
+        python3-dev \
+        xz-utils
+
+RUN mkdir -p /opt/llvm /tmp/llvm/build
+WORKDIR /tmp/llvm
+RUN curl -fL -o llvm.tar.xz "${LLVM_URL}" && \
+        tar -xf llvm.tar.xz --strip-components=1
+WORKDIR /tmp/llvm/build
+RUN cmake -G "Unix Makefiles" \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DLLVM_ENABLE_ASSERTIONS=ON \
+        -DCMAKE_INSTALL_PREFIX=/opt/llvm \
+        -DLLVM_TARGETS_TO_BUILD="host" \
+        -DLLVM_BUILD_TOOLS=OFF \
+        -DLLVM_BUILD_UTILS=OFF \
+        -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+        ../
+RUN make -j"$(nproc --ignore=2)" && make install
+
+FROM scratch as final
+COPY --from=dev /opt/llvm /opt/llvm

--- a/llvm/README.md
+++ b/llvm/README.md
@@ -1,0 +1,21 @@
+# llvm
+
+This contains the dockerfile used to build LLVM from source with assertions enabled.
+
+This is ultimately used by the main `pytorch/pytorch`'s base Docker images
+
+## How to build:
+
+```bash
+./build.sh
+```
+
+## How to deploy:
+
+```
+./deploy.sh
+```
+
+## Updating LLVM
+
+Edit the LLVM_VERSION in `env_vars.sh`

--- a/llvm/build.sh
+++ b/llvm/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${DIR}/env_vars.sh"
+
+(
+  set -x
+  cat Dockerfile | DOCKER_BUILDKIT=1 docker build --build-arg "LLVM_VERSION=${LLVM_VERSION}" -t "pytorch/llvm:${LLVM_VERSION}" -
+)

--- a/llvm/deploy.sh
+++ b/llvm/deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${DIR}/env_vars.sh"
+
+FORCE_PUSH=${FORCE_PUSH:-no}
+IMAGE="pytorch/llvm:${LLVM_VERSION}"
+
+if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "${IMAGE}" >/dev/null 2>/dev/null; then
+  if [[ ${FORCE_PUSH} = "no" ]]; then
+    echo "ERROR: ${IMAGE} already exists, run script with FORCE_PUSH=yes to forcefully push over the tag"
+    exit 1
+  else
+    echo "WARNING: Overwriting existing ${IMAGE}"
+  fi
+fi
+(
+  set -x
+  docker push "pytorch/llvm:${LLVM_VERSION}"
+)

--- a/llvm/env_vars.sh
+++ b/llvm/env_vars.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+LLVM_VERSION="9.0.1"


### PR DESCRIPTION
To be used by upstream docker images, builds took too long in upstream

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>