### PR TITLE
nvprune fix: Bump CUDA to 11.0.3_450.51.06, cudnn to 8.0.3.33

### DIFF
--- a/common/install_cuda.sh
+++ b/common/install_cuda.sh
@@ -106,16 +106,16 @@ function install_110 {
     echo "Installing CUDA 11.0 and CuDNN"
     rm -rf /usr/local/cuda-11.0 /usr/local/cuda
     # # install CUDA 11.0 in the same container
-    wget -q http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run
-    chmod +x cuda_11.0.2_450.51.05_linux.run
-    ./cuda_11.0.2_450.51.05_linux.run --toolkit --silent
-    rm -f cuda_11.0.2_450.51.05_linux.run
+    wget -q http://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run
+    chmod +x cuda_11.0.3_450.51.06_linux.run
+    ./cuda_11.0.3_450.51.06_linux.run --toolkit --silent
+    rm -f cuda_11.0.3_450.51.06_linux.run
     rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.0 /usr/local/cuda
 
     # install CUDA 11.0 CuDNN
     # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
     mkdir tmp_cudnn && cd tmp_cudnn
-    wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.2/cudnn-11.0-linux-x64-v8.0.2.39.tgz -O cudnn-8.0.tgz
+    wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.3/cudnn-11.0-linux-x64-v8.0.3.33.tgz -O cudnn-8.0.tgz
     tar xf cudnn-8.0.tgz
     cp -a cuda/include/* /usr/local/cuda/include/
     cp -a cuda/lib64/* /usr/local/cuda/lib64/


### PR DESCRIPTION
CC @seemethere @malfet 

Should fix the `cudaMalloc` failure after using `nvprune` [here](https://github.com/pytorch/builder/blob/361c0f5861b7f6257f23c4935d5ad9c3ecef4fa7/common/install_cuda.sh#L213-L240). 