### PR TITLE
common: Add a tmp dir for magma installs

### DIFF
--- a/common/install_magma.sh
+++ b/common/install_magma.sh
@@ -11,11 +11,14 @@ function do_install() {
     cuda_dir="/usr/local/cuda-${cuda_version}"
     (
         set -x
+        tmp_dir=$(mktemp -d)
+        pushd ${tmp_dir}
         wget -q https://anaconda.org/pytorch/magma-cuda${cuda_version_nodot}/${MAGMA_VERSION}/download/linux-64/${magma_archive}
         tar -xvf "${magma_archive}"
         mkdir -p "${cuda_dir}/magma"
         mv include "${cuda_dir}/magma/include"
         mv lib "${cuda_dir}/magma/lib"
+        popd
     )
 }
 


### PR DESCRIPTION
Sometimes we would get into a scenario where the unpack for the magma
installation would happen in the root directory where lib and include
already exist so let's just make it so that scenario can't happen
anymore

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>