### PR TITLE
non-root building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+conda/out*/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -18,7 +18,7 @@ RUN yum install -y cmake3 && \
 ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:$LD_LIBRARY_PATH
 
-RUN yum install -y autoconf aclocal automake make
+RUN yum install -y autoconf aclocal automake make sudo
 
 FROM base as patchelf
 # Install patchelf
@@ -46,7 +46,7 @@ RUN bash ./install_cuda.sh 10.2
 FROM cuda as cuda110
 RUN bash ./install_cuda.sh 11.0
 
-# Instal MNIST test data
+# Install MNIST test data
 FROM base as mnist
 ADD ./common/install_mnist.sh install_mnist.sh
 RUN bash ./install_mnist.sh
@@ -62,3 +62,9 @@ COPY --from=cuda110  /usr/local/cuda-11.0 /usr/local/cuda-11.0
 ADD ./java/jni.h     /usr/local/include/jni.h
 ENV PATH /opt/conda/bin:$PATH
 COPY --from=mnist  /usr/local/mnist /usr/local/mnist
+RUN rm -rf /usr/local/cuda
+RUN chmod o+rw /usr/local
+RUN touch /.condarc && \
+    chmod o+rw /.condarc && \
+    chmod -R o+rw /opt/conda
+

--- a/conda/README.md
+++ b/conda/README.md
@@ -8,33 +8,30 @@
 
 ## build base docker image
 
-```
+```sh
 cd ..
-nvidia-docker build -t soumith/conda-cuda -f conda/Dockerfile .
+docker build -t soumith/conda-cuda -f conda/Dockerfile .
 docker push soumith/conda-cuda
 ```
 
 ## building pytorch / torchvision etc.
 
-```
-docker run -it --ipc=host --rm -v $(pwd):/remote pytorch/conda-cuda bash
-
-cd remote/conda
-
-# versioned
-export PYTORCH_FINAL_PACKAGE_DIR="/remote"
-export TORCH_CONDA_BUILD_FOLDER=pytorch-1.1.0
-export PYTORCH_REPO=pytorch
-export PYTORCH_BRANCH=v1.1.0
-./build_pytorch.sh 100 1.1.0 1 # cuda 10.0 pytorch 1.0.1 build_number 1
-
-# nightly
-export PYTORCH_FINAL_PACKAGE_DIR="/remote"
-export TORCH_CONDA_BUILD_FOLDER=pytorch-nightly
-export PYTORCH_REPO=pytorch
-export PYTORCH_BRANCH=master
-./build_pytorch.sh 100 nightly 1 # cuda 10.0 pytorch 1.0.1 build_number 1
-
+```sh
+# building pytorch
+docker run --rm -it \
+    -e PACKAGE_TYPE=conda \
+    -e DESIRED_CUDA=cu92 \
+    -e DESIRED_PYTHON=3.8 \
+    -e PYTORCH_BUILD_VERSION=1.5.0 \
+    -e PYTORCH_BUILD_NUMBER=1 \
+    -e OVERRIDE_PACKAGE_VERSION=1.5.0
+    -e TORCH_CONDA_BUILD_FOLDER=pytorch-nightly \
+    -v /path/to/pytorch:/pytorch \
+    -v /path/to/builder:/builder \
+    -v "$(pwd):/final_pkgs" \
+    -u "$(id -u):$(id -g)"  \
+    pytorch/conda-cuda \
+    /builder/conda/build_pytorch.sh
 ```
 
 


### PR DESCRIPTION
This adds the ability to run the docker container for conda builds locally without leaking root permissioned files & directories onto the host system. It does require a new docker image, which I have built and tested locally.