### PR TITLE
Downgrade MKL to 2020.0

### DIFF
--- a/common/install_mkl.sh
+++ b/common/install_mkl.sh
@@ -3,8 +3,8 @@
 set -ex
 
 # MKL
-MKL_VERSION=2020.1
-MKL_BUILD=217
+MKL_VERSION=2020.0
+MKL_BUILD=166
 mkdir -p /opt/intel/lib
 pushd /tmp
 curl -fsSL https://anaconda.org/intel/mkl-static/${MKL_VERSION}/download/linux-64/mkl-static-${MKL_VERSION}-intel_${MKL_BUILD}.tar.bz2 | tar xjv


### PR DESCRIPTION
According to community reports it is the last version of MKL that runs AVX2-optimized kernels on AMD Zen CPUs.

Fixes https://github.com/pytorch/builder/issues/504