### PR TITLE
@jeremiahschung Fix date handling in download_count_wheels.py

### DIFF
--- a/analytics/download_count_wheels.py
+++ b/analytics/download_count_wheels.py
@@ -150,7 +150,6 @@ def download_logs(log_directory: str, since: float):
             continue
         # TODO: Do this in parallel
         if not os.path.exists(local_fname):
-            print("downloading: %s", remote_fname)
             dirname = os.path.dirname(local_fname)
             if not os.path.exists(dirname):
                 os.makedirs(dirname)


### PR DESCRIPTION
The existing script called key.last_modified.utcnow() which always returned the current time regardless of the value in the datetime object last_modified. This resulted in the script downloading all logs every time (the continue statement never executed due to miscalculation in the if statement). Fixed it to pull logs from the previous day only.

Test result:
Run successfully finished while downloading only files from yesterday.
[download_count_wheels_test_run.log](https://github.com/pytorch/builder/files/5285581/download_count_wheels_test_run.log)
