### PR TITLE
Update randomtemp

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -67,7 +67,7 @@ if "%CUDA_VERSION%" == "80" (
 )
 
 :: randomtemp is used to resolve the intermittent build error related to CUDA.
-:: code: https://github.com/peterjc123/randomtemp
+:: code: https://github.com/peterjc123/randomtemp-rust
 :: issue: https://github.com/pytorch/pytorch/issues/25393
 ::
 :: Previously, CMake uses CUDA_NVCC_EXECUTABLE for finding nvcc and then
@@ -75,7 +75,7 @@ if "%CUDA_VERSION%" == "80" (
 :: in PATH, and then pass the arguments to it.
 :: Currently, randomtemp is placed before sccache (%TMP_DIR_WIN%\bin\nvcc)
 :: so we are actually pretending sccache instead of nvcc itself.
-curl -kL https://github.com/peterjc123/randomtemp/releases/download/v0.3/randomtemp.exe --output %SRC_DIR%\tmp_bin\randomtemp.exe
+curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.1/randomtemp.exe --output %SRC_DIR%\tmp_bin\randomtemp.exe
 set RANDOMTEMP_EXECUTABLE=%SRC_DIR%\tmp_bin\nvcc.exe
 set CUDA_NVCC_EXECUTABLE=%SRC_DIR%\tmp_bin\randomtemp.exe
 set RANDOMTEMP_BASEDIR=%SRC_DIR%\tmp_bin

--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -107,7 +107,7 @@ if "%USE_SCCACHE%" == "1" (
         set SCCACHE_IDLE_TIMEOUT=1500
 
         :: randomtemp is used to resolve the intermittent build error related to CUDA.
-        :: code: https://github.com/peterjc123/randomtemp
+        :: code: https://github.com/peterjc123/randomtemp-rust
         :: issue: https://github.com/pytorch/pytorch/issues/25393
         ::
         :: Previously, CMake uses CUDA_NVCC_EXECUTABLE for finding nvcc and then
@@ -115,7 +115,7 @@ if "%USE_SCCACHE%" == "1" (
         :: in PATH, and then pass the arguments to it.
         :: Currently, randomtemp is placed before sccache (%TMP_DIR_WIN%\bin\nvcc)
         :: so we are actually pretending sccache instead of nvcc itself.
-        curl -kL https://github.com/peterjc123/randomtemp/releases/download/v0.3/randomtemp.exe --output %CD%\tmp_bin\randomtemp.exe
+        curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.1/randomtemp.exe --output %CD%\tmp_bin\randomtemp.exe
         set RANDOMTEMP_EXECUTABLE=%CD%\tmp_bin\nvcc.exe
         set CUDA_NVCC_EXECUTABLE=%CD%\tmp_bin\randomtemp.exe
         set RANDOMTEMP_BASEDIR=%CD%\tmp_bin


### PR DESCRIPTION
updates `randomtemp` in which the previous version has a limitation that the length of the argument cannot exceed 260.