### PR TITLE
Update download_count_wheels.py

### DIFF
--- a/analytics/download_count_wheels.py
+++ b/analytics/download_count_wheels.py
@@ -77,11 +77,11 @@ class CacheEntry:
 
 def parse_logs(log_directory: str) -> dict:
     bytes_cache = dict()
-    entries = []
     for (dirpath, _, filenames) in os.walk(log_directory):
         for filename in tqdm(filenames):
             with gzip.open(os.path.join(dirpath, filename), 'r') as gf:
                 string = gf.read().decode("utf-8")
+                entries = []
                 entries += string.splitlines()[2:]
             for entry in entries:
                 columns = entry.split('\t')


### PR DESCRIPTION
Due to the `entries` variable being scoped outside of the for loop that processes a single file, the counts are dramatically inflated (in my case processing data for 1 month, the incorrect calculation was 230x larger than the actual number). Entries in the first logfile gets counted N times where N is the number of files to process.