### PR TITLE
Update randomtemp to v0.3

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -75,7 +75,7 @@ if "%CUDA_VERSION%" == "80" (
 :: in PATH, and then pass the arguments to it.
 :: Currently, randomtemp is placed before sccache (%TMP_DIR_WIN%\bin\nvcc)
 :: so we are actually pretending sccache instead of nvcc itself.
-curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.2/randomtemp.exe --output %SRC_DIR%\tmp_bin\randomtemp.exe
+curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.3/randomtemp.exe --output %SRC_DIR%\tmp_bin\randomtemp.exe
 set RANDOMTEMP_EXECUTABLE=%SRC_DIR%\tmp_bin\nvcc.exe
 set CUDA_NVCC_EXECUTABLE=%SRC_DIR%\tmp_bin\randomtemp.exe
 set RANDOMTEMP_BASEDIR=%SRC_DIR%\tmp_bin

--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -115,7 +115,7 @@ if "%USE_SCCACHE%" == "1" (
         :: in PATH, and then pass the arguments to it.
         :: Currently, randomtemp is placed before sccache (%TMP_DIR_WIN%\bin\nvcc)
         :: so we are actually pretending sccache instead of nvcc itself.
-        curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.2/randomtemp.exe --output %CD%\tmp_bin\randomtemp.exe
+        curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.3/randomtemp.exe --output %CD%\tmp_bin\randomtemp.exe
         set RANDOMTEMP_EXECUTABLE=%CD%\tmp_bin\nvcc.exe
         set CUDA_NVCC_EXECUTABLE=%CD%\tmp_bin\randomtemp.exe
         set RANDOMTEMP_BASEDIR=%CD%\tmp_bin


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/45982.
Testing with https://github.com/pytorch/pytorch/pull/46026.

Without fix:
```
Compile requests                   2527
Compile requests executed          2520
Cache hits                         2469
Cache hits (C/C++)                 2469
Cache misses                         40
Cache misses (C/C++)                 40
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Compilation failures                  1
Cache errors                         10
Cache errors (C/C++)                 10
Non-cacheable compilations            0
Non-cacheable calls                   0
Non-compilation calls                 7
Unsupported compiler calls            0
Average cache write               0.117 s
Average cache read miss           0.710 s
Average cache read hit            0.092 s
Failed distributed compilations       0
Cache location                  S3, bucket: Bucket(name=ossci-compiler-cache-windows, base_url=http://ossci-compiler-cache-windows.s3.amazonaws.com/)
```

With fix:
```
Compile requests                     3286
Compile requests executed            2899
Cache hits                           2471
Cache hits (C/C++)                   2471
Cache misses                          417
Cache misses (C/C++)                  417
Cache timeouts                          0
Cache read errors                       0
Forced recaches                         0
Cache write errors                      0
Compilation failures                    1
Cache errors                           10
Cache errors (C/C++)                   10
Non-cacheable compilations              0
Non-cacheable calls                   379
Non-compilation calls                   8
Unsupported compiler calls              0
Average cache write                 0.352 s
Average cache read miss           132.556 s
Average cache read hit              0.121 s
Failed distributed compilations         0

Non-cacheable reasons:
-M                                    379
```

As can be seen from the log, the CUDA compiler calls are added after the fix.

@walterddr @soumith @ezyang @malfet @seemethere 