### PR TITLE
Add libpng build instructions to manylinux image

### DIFF
--- a/common/install_libpng.sh
+++ b/common/install_libpng.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+LIBPNG_VERSION=1.6.37
+
+mkdir -p libpng
+pushd libpng
+
+wget http://download.sourceforge.net/libpng/libpng-$LIBPNG_VERSION.tar.gz
+tar -xvzf libpng-$LIBPNG_VERSION.tar.gz
+
+./configure
+make
+make install
+
+popd
+rm -rf libpng

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -102,6 +102,12 @@ COPY --from=python   /opt/python/cp36-cp36m/bin/auditwheel /usr/local/bin/auditw
 COPY --from=intel    /opt/intel                            /opt/intel
 COPY --from=patchelf /usr/local/bin/patchelf               /usr/local/bin/patchelf
 COPY --from=jni      /usr/local/include/jni.h              /usr/local/include/jni.h
+COPY --from=libpng   /usr/local/bin/png*                   /usr/local/bin/
+COPY --from=libpng   /usr/local/bin/libpng*                /usr/local/bin/
+COPY --from=libpng   /usr/local/include/png*               /usr/local/include/
+COPY --from=libpng   /usr/local/include/libpng*            /usr/local/include/
+COPY --from=libpng   /usr/local/lib/libpng*                /usr/local/lib/
+COPY --from=libpng   /usr/local/lib/pkgconfig              /usr/local/lib/pkgconfig
 
 FROM common as cuda_final
 ARG BASE_CUDA_VERSION=10.1

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -66,6 +66,11 @@ ADD ./common/install_jni.sh install_jni.sh
 ADD ./java/jni.h jni.h
 RUN bash ./install_jni.sh && rm install_jni.sh
 
+FROM base as libpng
+# Install libpng
+ADD ./common/install_libpng.sh install_libpng.sh
+RUN bash ./install_libpng.sh && rm install_libpng.sh
+
 FROM ${GPU_IMAGE} as common
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
This is required by https://github.com/pytorch/vision/pull/2777, since torchvision wheels are not packaging libpng, due to the CentOS version being less than 1.6 