### PR TITLE
Determine min Python version based on PyTorch version

### DIFF
--- a/packaging/windows/build_pypi_pkg_download_proxy/setup.py
+++ b/packaging/windows/build_pypi_pkg_download_proxy/setup.py
@@ -3,6 +3,7 @@ import subprocess
 
 import setuptools.command.install
 from setuptools import find_packages, setup
+from distutils.version import LooseVersion
 import wheel.bdist_wheel
 
 pkg_name = "torch"
@@ -10,6 +11,10 @@ pkg_ver = "{{GENERATE_TORCH_PKG_VER}}"
 torch_download_url = "https://download.pytorch.org/whl/torch_stable.html"
 
 python_min_version = (3, 6, 1)
+
+if LooseVersion(pkg_ver) > LooseVersion('1.7'):
+    python_min_version = (3, 6, 2)
+
 python_min_version_str = '.'.join((str(num) for num in python_min_version))
 
 install_requires = [


### PR DESCRIPTION
For PyTorch version > 1.7, the min Python version should be `3.6.2`.  This aligns with the `setup.py` in current master https://github.com/pytorch/pytorch/blob/9e0102c10f57631000ebf28e55a055f480b9b780/setup.py#L179 .

If you're wondering what the meaning differences between `3.6.1` and `3.6.2` are, one of them would be [typing.NoReturn](https://docs.python.org/3/library/typing.html#typing.NoReturn), which was first added in Python 3.6.2. This actually causes build error if you are using `3.6.1` and try to install from source on current master.