### PR TITLE
manywheel: Fix for suffixed DESIRED_PYTHON

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -67,7 +67,7 @@ export CMAKE_INCLUDE_PATH="/opt/intel/include:$CMAKE_INCLUDE_PATH"
 if [[ -n "$DESIRED_PYTHON" && "$DESIRED_PYTHON" != cp* ]]; then
     python_nodot="$(echo $DESIRED_PYTHON | tr -d m.u)"
     case ${DESIRED_PYTHON} in
-      3.[6-7])
+      3.[6-7]*)
         DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}m"
         ;;
       # Should catch 3.8+


### PR DESCRIPTION
Adds a glob at the end of the case statement to account for
DESIRED_PYTHON with suffixed 'm'

The current pytorch build pipeline suffixes DESIRED_PYTHON like so:
- 3.7m
- 3.6m

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>