### PR TITLE
wheel: Create clean conda environment for testing

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -76,7 +76,7 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
         fi
     fi
     if [[ "$(python --version 2>&1)" == *3.9.* ]]; then
-        retry conda install -yq -c conda-forge future hypothesis mkl>=2018 ninja numpy>=1.15 protobuf pytest setuptools six typing_extensions pyyaml
+        retry conda install -yq -c conda-forge hypothesis ninja protobuf pytest setuptools six typing_extensions pyyaml
     elif [[ "$(python --version 2>&1)" == *3.8.* ]]; then
         retry conda install -yq future hypothesis mkl>=2018 ninja numpy>=1.15 protobuf pytest setuptools six typing_extensions pyyaml
     elif [[ "$(python --version 2>&1)" == *3.6.* ]]; then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -76,7 +76,7 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
         fi
     fi
     if [[ "$(python --version 2>&1)" == *3.9.* ]]; then
-        retry conda install -yq -c conda-forge hypothesis ninja protobuf pytest setuptools six typing_extensions pyyaml
+        retry conda install -yq -c conda-forge future hypothesis ninja protobuf pytest setuptools six typing_extensions pyyaml
     elif [[ "$(python --version 2>&1)" == *3.8.* ]]; then
         retry conda install -yq future hypothesis mkl>=2018 ninja numpy>=1.15 protobuf pytest setuptools six typing_extensions pyyaml
     elif [[ "$(python --version 2>&1)" == *3.6.* ]]; then

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -196,8 +196,11 @@ if [[ -z "$BUILD_PYTHONLESS" ]]; then
     pip uninstall -y "$TORCH_PACKAGE_NAME" || true
     pip uninstall -y "$TORCH_PACKAGE_NAME" || true
 
-    # Only one binary is built, so it's safe to just specify the whl directory
-    pip install "$TORCH_PACKAGE_NAME" --no-index -f "$whl_tmp_dir" --no-dependencies -v
+    # Create new "clean" conda environment for testing
+    conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "test_conda_env" python="$desired_python"
+    conda activate test_conda_env
+
+    pip install "$PYTORCH_FINAL_PACKAGE_DIR/$wheel_filename_new" -v
 
     # Run the tests
     echo "$(date) :: Running tests"

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -237,9 +237,3 @@ else
     cp "$PYTORCH_FINAL_PACKAGE_DIR/libtorch-macos-$PYTORCH_BUILD_VERSION.zip"  \
        "$PYTORCH_FINAL_PACKAGE_DIR/libtorch-macos-latest.zip"
 fi
-
-# Now delete the temporary build folder and temporary env
-# $whl_tmp_dir is not deleted since it will be the only place to find the whl
-# if PYTORCH_FINAL_PACKAGE_DIR isn't specified
-source deactivate
-conda env remove -yn "$tmp_env_name"


### PR DESCRIPTION
There was an issue where libiomp.dylib was specified in multiple
packages within the conda environment (with `llvm-openmp` being added as a dependency for libopenblas, which is a dependency of `numpy>=19` so let's just create a brand new
conda environment for testing so we can avoid all of these issues.

This should resolve issues of binaries built with Python 3.9 on macOS

cc @peterjc123 the same will have to be done with windows, but my batch scripting skills seems to be failing me right now.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>