### PR TITLE
manywheel: update CUDA_VERSION autodetect on CUDA 11.x

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -42,7 +42,7 @@ if [[ -n "$DESIRED_CUDA" ]]; then
         /builder/conda/switch_cuda_version.sh "${DESIRED_CUDA}"
     fi
 else
-    CUDA_VERSION=$(nvcc --version|tail -n1|cut -f5 -d" "|cut -f1 -d",")
+    CUDA_VERSION=$(nvcc --version|grep release|cut -f5 -d" "|cut -f1 -d",")
     echo "CUDA $CUDA_VERSION Detected"
 fi
 


### PR DESCRIPTION
Output of `nvcc --version` on CUDA 11.1:

```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2020 NVIDIA Corporation
Built on Mon_Oct_12_20:09:46_PDT_2020
Cuda compilation tools, release 11.1, V11.1.105
Build cuda_11.1.TC455_06.29190527_0
```

Output of `nvcc --version` on CUDA 11.0:
```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2020 NVIDIA Corporation
Built on Wed_Jul_22_19:09:09_PDT_2020
Cuda compilation tools, release 11.0, V11.0.221
Build cuda_11.0_bu.TC445_37.28845127_0
```

This is just a simple patch :slightly_smiling_face: 