### PR TITLE
CUDA 11.1 usues libcudart11.0 for backwards compat

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -189,7 +189,7 @@ DEPS_SONAME=(
 )
 elif [[ $CUDA_VERSION == "11.1" ]]; then
 DEPS_LIST=(
-    "/usr/local/cuda/lib64/libcudart.so.11.1"
+    "/usr/local/cuda/lib64/libcudart.so.11.0"   # CUDA 11.1 usues libcudart11.0 for backwards compat
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
     "/usr/local/cuda/lib64/libnvrtc.so.11.1"
     "/usr/local/cuda/lib64/libnvrtc-builtins.so"
@@ -197,7 +197,7 @@ DEPS_LIST=(
 )
 
 DEPS_SONAME=(
-    "libcudart.so.11.1"
+    "libcudart.so.11.0"
     "libnvToolsExt.so.1"
     "libnvrtc.so.11.1"
     "libnvrtc-builtins.so"


### PR DESCRIPTION
Should fix this failure https://app.circleci.com/pipelines/github/pytorch/pytorch/239814/workflows/2dd7d5fc-c75f-46ab-903a-cf4886177e36/jobs/8972368 in [47938](https://github.com/pytorch/pytorch/pull/47938).