### PR TITLE
adding back sm_50 for CUDA 11.1 to make CI pass

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -49,7 +49,7 @@ fi
 export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;7.0"
 case ${CUDA_VERSION} in
     11.1)
-        export TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6"   # removing some to prevent bloated binary size
+        export TORCH_CUDA_ARCH_LIST="5.0;7.0;7.5;8.0;8.6"   # removing some to prevent bloated binary size
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     11.0)


### PR DESCRIPTION
CircleCI machines are all sm_52, so removing it in #585 caused failures.