### PR TITLE
Add sm_86 arch to CUDA 11.0 builds

### DIFF
--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -39,9 +39,7 @@ if [[ -n "$build_with_cuda" ]]; then
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0"
     elif [[ $CUDA_VERSION == 10* ]]; then
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5"
-    elif [[ $CUDA_VERSION == 11.0* ]]; then
-        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0"
-    elif [[ $CUDA_VERSION == 11.1* ]]; then
+    elif [[ $CUDA_VERSION == 11* ]]; then
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0;8.6"
     fi
     export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -53,7 +53,7 @@ case ${CUDA_VERSION} in
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     11.0)
-        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5;8.0"
+        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5;8.0;8.6"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     10.*)


### PR DESCRIPTION
Enables `sm_86` on CUDA 11.0 builds since we are now building with CUDNN `v8.0.5` which should include better support for `sm_86`

change is being tested here: https://github.com/pytorch/pytorch/pull/48128

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>