### PR TITLE
removing sm_75 from TORCH_ARCH_LIST for 11.1 to enable CI to pass

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -49,7 +49,7 @@ fi
 export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;7.0"
 case ${CUDA_VERSION} in
     11.1)
-        export TORCH_CUDA_ARCH_LIST="5.0;7.0;7.5;8.0;8.6"   # removing some to prevent bloated binary size
+        export TORCH_CUDA_ARCH_LIST="5.0;7.0;8.0;8.6"   # removing some to prevent bloated binary size
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     11.0)


### PR DESCRIPTION
This should be a temporary fix. The hope is to come up with a better solution that allows us to build with more architectures for CUDA 11.1. Currently, we run into relocation marker issues in https://github.com/pytorch/pytorch/pull/47938. 

Example: https://app.circleci.com/pipelines/github/pytorch/pytorch/239822/workflows/13c89e88-53c8-4c85-9cc3-5926814c4624/jobs/8998487