### PR TITLE
Use DESIRED_CUDA var in magma-cuda*/build.sh

### DIFF
--- a/magma/magma-cuda101/build.sh
+++ b/magma/magma-cuda101/build.sh
@@ -2,9 +2,9 @@ export CMAKE_LIBRARY_PATH=$PREFIX/lib:$PREFIX/include:$CMAKE_LIBRARY_PATH
 export CMAKE_PREFIX_PATH=$PREFIX
 export PATH=$PREFIX/bin:$PATH
 
-CUDA__VERSION=$(nvcc --version|tail -n1|cut -f5 -d" "|cut -f1 -d",")
-if [ "$CUDA__VERSION" != "10.1" ]; then
-    echo "CUDA Version is not 10.1. CUDA Version found: $CUDA__VERSION"
+CUDA__VERSION=$(nvcc --version|sed -n 4p|cut -f5 -d" "|cut -f1 -d",")
+if [ "$CUDA__VERSION" != "$DESIRED_CUDA" ]; then
+    echo "CUDA Version is not $DESIRED_CUDA. CUDA Version found: $CUDA__VERSION"
     exit 1
 fi
 

--- a/magma/magma-cuda101/meta.yaml
+++ b/magma/magma-cuda101/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 1
+  script_env:
+    - DESIRED_CUDA
 
 about:
   home: http://icl.cs.utk.edu/magma/software/index.html

--- a/magma/magma-cuda102/build.sh
+++ b/magma/magma-cuda102/build.sh
@@ -2,9 +2,9 @@ export CMAKE_LIBRARY_PATH=$PREFIX/lib:$PREFIX/include:$CMAKE_LIBRARY_PATH
 export CMAKE_PREFIX_PATH=$PREFIX
 export PATH=$PREFIX/bin:$PATH
 
-CUDA__VERSION=$(nvcc --version|tail -n1|cut -f5 -d" "|cut -f1 -d",")
-if [ "$CUDA__VERSION" != "10.2" ]; then
-    echo "CUDA Version is not 10.2. CUDA Version found: $CUDA__VERSION"
+CUDA__VERSION=$(nvcc --version|sed -n 4p|cut -f5 -d" "|cut -f1 -d",")
+if [ "$CUDA__VERSION" != "$DESIRED_CUDA" ]; then
+    echo "CUDA Version is not $DESIRED_CUDA. CUDA Version found: $CUDA__VERSION"
     exit 1
 fi
 

--- a/magma/magma-cuda102/meta.yaml
+++ b/magma/magma-cuda102/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 1
+  script_env:
+    - DESIRED_CUDA
 
 about:
   home: http://icl.cs.utk.edu/magma/software/index.html

--- a/magma/magma-cuda110/build.sh
+++ b/magma/magma-cuda110/build.sh
@@ -3,8 +3,8 @@ export CMAKE_PREFIX_PATH=$PREFIX
 export PATH=$PREFIX/bin:$PATH
 
 CUDA__VERSION=$(nvcc --version|sed -n 4p|cut -f5 -d" "|cut -f1 -d",")
-if [ "$CUDA__VERSION" != "11.0" ]; then
-    echo "CUDA Version is not 11.0. CUDA Version found: $CUDA__VERSION"
+if [ "$CUDA__VERSION" != "$DESIRED_CUDA" ]; then
+    echo "CUDA Version is not $DESIRED_CUDA. CUDA Version found: $CUDA__VERSION"
     exit 1
 fi
 

--- a/magma/magma-cuda110/meta.yaml
+++ b/magma/magma-cuda110/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 1
+  script_env:
+    - DESIRED_CUDA
 
 about:
   home: http://icl.cs.utk.edu/magma/software/index.html

--- a/magma/magma-cuda111/build.sh
+++ b/magma/magma-cuda111/build.sh
@@ -3,8 +3,8 @@ export CMAKE_PREFIX_PATH=$PREFIX
 export PATH=$PREFIX/bin:$PATH
 
 CUDA__VERSION=$(nvcc --version|sed -n 4p|cut -f5 -d" "|cut -f1 -d",")
-if [ "$CUDA__VERSION" != "11.1" ]; then
-    echo "CUDA Version is not 11.1. CUDA Version found: $CUDA__VERSION"
+if [ "$CUDA__VERSION" != "$DESIRED_CUDA" ]; then
+    echo "CUDA Version is not $DESIRED_CUDA. CUDA Version found: $CUDA__VERSION"
     exit 1
 fi
 

--- a/magma/magma-cuda111/meta.yaml
+++ b/magma/magma-cuda111/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 1
+  script_env:
+    - DESIRED_CUDA
 
 about:
   home: http://icl.cs.utk.edu/magma/software/index.html

--- a/magma/magma-cuda92/build.sh
+++ b/magma/magma-cuda92/build.sh
@@ -2,9 +2,9 @@ export CMAKE_LIBRARY_PATH=$PREFIX/lib:$PREFIX/include:$CMAKE_LIBRARY_PATH
 export CMAKE_PREFIX_PATH=$PREFIX
 export PATH=$PREFIX/bin:$PATH
 
-CUDA__VERSION=$(nvcc --version|tail -n1|cut -f5 -d" "|cut -f1 -d",")
-if [ "$CUDA__VERSION" != "9.2" ]; then
-    echo "CUDA Version is not 9.2. CUDA Version found: $CUDA__VERSION"
+CUDA__VERSION=$(nvcc --version|sed -n 4p|cut -f5 -d" "|cut -f1 -d",")
+if [ "$CUDA__VERSION" != "$DESIRED_CUDA" ]; then
+    echo "CUDA Version is not $DESIRED_CUDA. CUDA Version found: $CUDA__VERSION"
     exit 1
 fi
 

--- a/magma/magma-cuda92/meta.yaml
+++ b/magma/magma-cuda92/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 1
+  script_env:
+    - DESIRED_CUDA
 
 about:
   home: http://icl.cs.utk.edu/magma/software/index.html


### PR DESCRIPTION
This is a first step in consolidating our MAGMA directory as there is a lot of repetition across the folders there. Using the DESIRED_CUDA environment variable would be a step in the direction of having one directory for magma instead of however many versions of CUDA we are supporting. 

I am less sure about how to consolidate the `.patch` and `.yaml` files and would love any pointers on that. 

Getting tested in https://github.com/pytorch/pytorch/pull/48259