### PR TITLE
Allow to override TORCH_CUDA_ARCH_LIST environment variable

### DIFF
--- a/common/install_cuda.sh
+++ b/common/install_cuda.sh
@@ -157,6 +157,11 @@ function prune_92 {
     export GENCODE="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70"
     export GENCODE_CUDNN="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70"
 
+    if [[ -n "$OVERRIDE_GENCODE" ]]; then
+        export GENCODE=$OVERRIDE_GENCODE
+        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
+    fi
+
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
     ls $CUDA_LIB_DIR/ | grep "\.a" | grep -v "culibos" | grep -v "cudart" | grep -v "cudnn" | grep -v "cublas" | grep -v "cusolver" \
 	| xargs -I {} bash -c \
@@ -186,6 +191,11 @@ function prune_101 {
     export GENCODE="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
     export GENCODE_CUDNN="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
 
+    if [[ -n "$OVERRIDE_GENCODE" ]]; then
+        export GENCODE=$OVERRIDE_GENCODE
+        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
+    fi
+
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
     ls $CUDA_LIB_DIR/ | grep "\.a" | grep -v "culibos" | grep -v "cudart" | grep -v "cudnn" | grep -v "cublas" | grep -v "metis"  \
 	| xargs -I {} bash -c \
@@ -213,6 +223,11 @@ function prune_102 {
 
     export GENCODE="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
     export GENCODE_CUDNN="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75"
+
+    if [[ -n "$OVERRIDE_GENCODE" ]]; then
+        export GENCODE=$OVERRIDE_GENCODE
+        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
+    fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
     ls $CUDA_LIB_DIR/ | grep "\.a" | grep -v "culibos" | grep -v "cudart" | grep -v "cudnn" | grep -v "cublas" | grep -v "metis"  \
@@ -243,6 +258,10 @@ function prune_110 {
     export GENCODE="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80"
     export GENCODE_CUDNN="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80"
 
+    if [[ -n "$OVERRIDE_GENCODE" ]]; then
+        export GENCODE=$OVERRIDE_GENCODE
+        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
+    fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
     ls $CUDA_LIB_DIR/ | grep "\.a" | grep -v "culibos" | grep -v "cudart" | grep -v "cudnn" | grep -v "cublas" | grep -v "metis"  \
@@ -272,6 +291,10 @@ function prune_111 {
     export GENCODE="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86"
     export GENCODE_CUDNN="-gencode arch=compute_35,code=sm_35 -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86"
 
+    if [[ -n "$OVERRIDE_GENCODE" ]]; then
+        export GENCODE=$OVERRIDE_GENCODE
+        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
+    fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
     ls $CUDA_LIB_DIR/ | grep "\.a" | grep -v "culibos" | grep -v "cudart" | grep -v "cudnn" | grep -v "cublas" | grep -v "metis"  \

--- a/common/install_cuda.sh
+++ b/common/install_cuda.sh
@@ -159,7 +159,6 @@ function prune_92 {
 
     if [[ -n "$OVERRIDE_GENCODE" ]]; then
         export GENCODE=$OVERRIDE_GENCODE
-        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
     fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
@@ -193,7 +192,6 @@ function prune_101 {
 
     if [[ -n "$OVERRIDE_GENCODE" ]]; then
         export GENCODE=$OVERRIDE_GENCODE
-        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
     fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
@@ -226,7 +224,6 @@ function prune_102 {
 
     if [[ -n "$OVERRIDE_GENCODE" ]]; then
         export GENCODE=$OVERRIDE_GENCODE
-        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
     fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
@@ -260,7 +257,6 @@ function prune_110 {
 
     if [[ -n "$OVERRIDE_GENCODE" ]]; then
         export GENCODE=$OVERRIDE_GENCODE
-        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
     fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)
@@ -293,7 +289,6 @@ function prune_111 {
 
     if [[ -n "$OVERRIDE_GENCODE" ]]; then
         export GENCODE=$OVERRIDE_GENCODE
-        export GENCODE_CUDNN=$OVERRIDE_GENCODE_CUDNN
     fi
 
     # all CUDA libs except CuDNN and CuBLAS (cudnn and cublas need arch 3.7 included)

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -84,7 +84,6 @@ if [[ -n "$OVERRIDE_TORCH_CUDA_ARCH_LIST" ]]; then
     done
 
     export OVERRIDE_GENCODE=$override_gencode
-    export OVERRIDE_GENCODE_CUDNN=$override_gencode
     bash "$(dirname "$SCRIPTPATH")"/common/install_cuda.sh "${CUDA_VERSION}"
 fi
 

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P ))"
+
 export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 export NCCL_ROOT_DIR=/usr/local/cuda
 export TH_BINARY_BUILD=1
@@ -46,31 +48,48 @@ else
     echo "CUDA $CUDA_VERSION Detected"
 fi
 
-export TORCH_CUDA_ARCH_LIST="3.7;5.0;6.0;7.0"
+cuda_version_nodot=$(echo $CUDA_VERSION | tr -d '.')
+
+torch_cuda_arch_list="3.7;5.0;6.0;7.0"
 case ${CUDA_VERSION} in
     11.1)
-        export TORCH_CUDA_ARCH_LIST="5.0;7.0;8.0;8.6"   # removing some to prevent bloated binary size
+        torch_cuda_arch_list="5.0;7.0;8.0;8.6"  # removing some to prevent bloated binary size
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     11.0)
-        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5;8.0"
+        torch_cuda_arch_list="$TORCH_CUDA_ARCH_LIST;7.5;8.0"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     10.*)
-        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;7.5"
+        torch_cuda_arch_list="$TORCH_CUDA_ARCH_LIST;7.5"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     9.*)
-        export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
+        torch_cuda_arch_list="${TORCH_CUDA_ARCH_LIST}"
         ;;
     *)
         echo "unknown cuda version $CUDA_VERSION"
         exit 1
         ;;
 esac
-echo $TORCH_CUDA_ARCH_LIST
 
-cuda_version_nodot=$(echo $CUDA_VERSION | tr -d '.')
+if [[ -n "$OVERRIDE_TORCH_CUDA_ARCH_LIST" ]]; then
+    torch_cuda_arch_list="$OVERRIDE_TORCH_CUDA_ARCH_LIST"
+
+    # Prune CUDA again with new arch list. Unfortunately, we need to re-install CUDA to prune it again
+    override_gencode=""
+    for arch in ${torch_cuda_arch_list//;/ } ; do
+      arch_code=$(echo "$arch" | tr -d .)
+      override_gencode="${override_gencode}-gencode arch=compute_$arch_code,code=sm_$arch_code "
+    done
+
+    export OVERRIDE_GENCODE=$override_gencode
+    export OVERRIDE_GENCODE_CUDNN=$override_gencode
+    bash "$(dirname "$SCRIPTPATH")"/common/install_cuda.sh "${CUDA_VERSION}"
+fi
+
+export TORCH_CUDA_ARCH_LIST=$torch_cuda_arch_list
+echo "$TORCH_CUDA_ARCH_LIST"
 
 # Package directories
 WHEELHOUSE_DIR="wheelhouse$cuda_version_nodot"


### PR DESCRIPTION
Allow to override `TORCH_CUDA_ARCH_LIST` environment variable by using `OVERRIDE_TORCH_CUDA_ARCH_LIST`. If the value is set, it will re-install the desired CUDA and prune it again (necessary as we have no guarantee the default pruning is not removing the arch we want).

To test it: 

```
docker run --runtime=nvidia --rm -it \
    -v "/path/to/builder":/builder \
    -v "/path/to/pytorch":/pytorch \
    -v "$(pwd)/out":/remote \
    -e DESIRED_CUDA=cu110 \
    -e DESIRED_PYTHON=3.7m \
    -e OVERRIDE_TORCH_CUDA_ARCH_LIST="5.2;6.1;7.5" \
    pytorch/manylinux-cuda110 /builder/manywheel/build.sh
```
