### PR TITLE
conda: Downgrade conda-package-handling to 1.6.0

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -323,6 +323,10 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     # Build the package
     echo "Build $build_folder for Python version $py_ver"
     conda config --set anaconda_upload no
+    # There was a bug that was introduced in conda-package-handling >= 1.6.1 that makes archives
+    # above a certain size fail out when attempting to extract
+    # see: https://github.com/conda/conda-package-handling/issues/71
+    conda install -y "conda-package-handling=1.6.0"
 
     ADDITIONAL_CHANNELS=""
     # TODO: Remove ADDITIONAL_CHANNELS


### PR DESCRIPTION
There were issues when attempting to build CUDA 11.0 binaries for conda
since the conda-package-handling library introduced a bug in v1.6.1 for
packages above a certain size.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>