### PR TITLE
conda: Pin conda-package-handling to 1.6.0

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -29,6 +29,9 @@ FROM base as conda
 # Install Anaconda
 ADD ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh
+# conda-package-handling fails out for larger tarballs,
+# see: https://github.com/conda/conda-package-handling/issues/71
+RUN /opt/conda/bin/conda install -y conda-package-handling=1.6.0
 
 # Install CUDA
 FROM base as cuda


### PR DESCRIPTION
This is to deal with issues where tars above a certain size are
uninstallable with the latest version of conda-package-handling

Relates to https://github.com/conda/conda-package-handling/issues/71

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>