### PR TITLE
Enable binaries to be built with split torch_cuda 

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -40,6 +40,7 @@ build:
   detect_binary_files_with_prefix: False
   string: "{{ environ.get('PYTORCH_BUILD_STRING') }}"
   script_env:
+    - BUILD_SPLIT_CUDA
     - CUDA_VERSION
     - CUDNN_VERSION
     - CONDA_CUDATOOLKIT_CONSTRAINT

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -222,7 +222,11 @@ if "%NVIDIA_GPU_EXISTS%" == "0" (
     goto end
 )
 
-cl %BUILDER_ROOT%\test_example_code\check-torch-cuda.cpp torch_cpu.lib c10.lib torch_cuda.lib /EHsc /link /INCLUDE:?warp_size@cuda@at@@YAHXZ
+if "%BUILD_SPLIT_CUDA%" == "ON" (
+    cl %BUILDER_ROOT%\test_example_code\check-torch-cuda.cpp torch_cpu.lib c10.lib torch_cuda_cu.lib torch_cuda_cpp.lib /EHsc /link /INCLUDE:?warp_size@cuda@at@@YAHXZ /INCLUDE:?searchsorted_cuda@native@at@@YA?AVTensor@2@AEBV32@0_N1@Z
+) else (
+    cl %BUILDER_ROOT%\test_example_code\check-torch-cuda.cpp torch_cpu.lib c10.lib torch_cuda.lib /EHsc /link /INCLUDE:?warp_size@cuda@at@@YAHXZ
+)
 .\check-torch-cuda.exe
 if ERRORLEVEL 1 exit /b 1
 


### PR DESCRIPTION
Changes check_binary.sh to find the split torch_cuda libraries while refactoring a duplicated chunk into a bash function setup_link_flags.
Edits windows/internal/smoke_test.bat to link against the right libraries when BUILD_SPLIT_CUDA=ON. (This build option was introduced by https://github.com/pytorch/pytorch/pull/49050.)

Disclaimer: does NOT change the cubinsizes.py script to account for the fact that torch_cuda may be split (and thus will cause the libtorch_cuda.so to not be found).