### PR TITLE
updating how we get cuda and cudnn version in switch_cuda_version.sh

### DIFF
--- a/conda/switch_cuda_version.sh
+++ b/conda/switch_cuda_version.sh
@@ -17,13 +17,22 @@ mkdir -p /usr/local
 rm -fr /usr/local/cuda
 ln -s "$CUDA_DIR" /usr/local/cuda
 
+# Using nvcc instead of deducing from cudart version since it's unreliable (was 110 for cuda11.1 and 11.2)
+CUDA_VERSION_DOT=$(nvcc --version | sed -n 4p | cut -f5 -d" " | cut -f1 -d",")
+export CUDA_VERSION=${CUDA_VERSION_DOT/./}
 if [[ "$OSTYPE" == "msys" ]]; then
-    export CUDA_VERSION=`ls /usr/local/cuda/bin/cudart64*.dll | head -1 | tr '._' ' ' | cut -d ' ' -f2`
-    export CUDNN_VERSION=`ls /usr/local/cuda/bin/cudnn64*.dll | head -1 | tr '._' ' ' | cut -d ' ' -f2`
+    # we want CUDNN_VERSION=8.1 for CUDA 11.2, not just 8
+    if [[ "$CUDA_VERSION" == '112' ]]; then
+        CUDNN_MAJOR=$(find /usr/local/cuda/ -name cudnn_version.h -exec grep 'define CUDNN_MAJOR' {} + | cut -d' ' -f3)
+        CUDNN_MINOR=$(find /usr/local/cuda/ -name cudnn_version.h -exec grep 'define CUDNN_MINOR' {} + | cut -d' ' -f3)
+        CUDNN_VERSION=$CUDNN_MAJOR.$CUDNN_MINOR
+    else
+        CUDNN_VERSION=$(find /usr/local/cuda/bin/cudnn64*.dll | head -1 | tr '._' ' ' | cut -d ' ' -f2)
+    fi
 else
-    export CUDA_VERSION=$(ls /usr/local/cuda/lib64/libcudart.so.*|sort|tac | head -1 | rev | cut -d"." -f -3 | rev)
-    export CUDNN_VERSION=$(ls /usr/local/cuda/lib64/libcudnn.so.*|sort|tac | head -1 | rev | cut -d"." -f -3 | rev)
+    CUDNN_VERSION=$(find /usr/local/cuda/lib64/libcudnn.so.* | sort | tac | head -1 | rev | cut -d"." -f -3 | rev)
 fi
+export CUDNN_VERSION
 
 ls -alh /usr/local/cuda
 


### PR DESCRIPTION
For CUDA 11.2, the current cudnn version logic on windows only returns 8, instead of 8.1, which is misleading. Instead, we now use the version defined in cudnn_version.h in the CUDA install, which should be more accurate.

The current cuda version logic also incorrectly returns 110 because cudart.dll in 11.2 (and 11.1) is labeled with 110. I updated this to use nvcc instead, which should be more reliable.

This has been tested in https://github.com/pytorch/pytorch/pull/51611 with CUDA 11.2