### PR TITLE
[builder] Keep dot in CUDA_VERSION

### DIFF
--- a/conda/switch_cuda_version.sh
+++ b/conda/switch_cuda_version.sh
@@ -18,11 +18,10 @@ rm -fr /usr/local/cuda
 ln -s "$CUDA_DIR" /usr/local/cuda
 
 # Using nvcc instead of deducing from cudart version since it's unreliable (was 110 for cuda11.1 and 11.2)
-CUDA_VERSION_DOT=$(nvcc --version | sed -n 4p | cut -f5 -d" " | cut -f1 -d",")
-export CUDA_VERSION=${CUDA_VERSION_DOT/./}
+CUDA_VERSION=$(nvcc --version | sed -n 4p | cut -f5 -d" " | cut -f1 -d",")
 if [[ "$OSTYPE" == "msys" ]]; then
     # we want CUDNN_VERSION=8.1 for CUDA 11.2, not just 8
-    if [[ "$CUDA_VERSION" == '112' ]]; then
+    if [[ "$CUDA_VERSION" == '11.2*' ]]; then
         CUDNN_MAJOR=$(find /usr/local/cuda/ -name cudnn_version.h -exec grep 'define CUDNN_MAJOR' {} + | cut -d' ' -f3)
         CUDNN_MINOR=$(find /usr/local/cuda/ -name cudnn_version.h -exec grep 'define CUDNN_MINOR' {} + | cut -d' ' -f3)
         CUDNN_VERSION=$CUDNN_MAJOR.$CUDNN_MINOR


### PR DESCRIPTION
As `pytorch-nightly/build.sh` depends on dot to determine
TORCH_ARCH_LIST