### PR TITLE
windows: Ensure we're copying uv.dll

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -10,7 +10,7 @@ if "%USE_CUDA%" == "0" (
     set build_with_cuda=
 ) else (
     set build_with_cuda=1
-    set desired_cuda=%CUDA_VERSION:~0,-1%.%CUDA_VERSION:~-1,1%
+    set desired_cuda=%CUDA_VERSION%
 )
 
 if "%build_with_cuda%" == "" goto cuda_flags_end

--- a/windows/internal/copy.bat
+++ b/windows/internal/copy.bat
@@ -10,4 +10,5 @@ copy "%CUDA_PATH%\bin\nvrtc*64_*.dll*" pytorch\torch\lib
 
 copy "C:\Program Files\NVIDIA Corporation\NvToolsExt\bin\x64\nvToolsExt64_1.dll*" pytorch\torch\lib
 copy "%CONDA_LIB_PATH%\libiomp*5md.dll" pytorch\torch\lib
-copy "%CONDA_LIB_PATH%\uv.dll" pytorch\torch\lib
+:: Should be set in build_pytorch.bat
+copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib

--- a/windows/internal/copy_cpu.bat
+++ b/windows/internal/copy_cpu.bat
@@ -1,2 +1,3 @@
 copy "%CONDA_LIB_PATH%\libiomp*5md.dll" pytorch\torch\lib
-copy "%CONDA_LIB_PATH%\uv.dll" pytorch\torch\lib
+:: Should be set in build_pytorch.bat
+copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib


### PR DESCRIPTION
Turns out we were copying libuv from wrong spot all along since it was
getting installed in our build conda environment as a side effect. We
actually set libuv_ROOT in the `build_pytorch.bat` script so it'd
probably be best that we actually use it.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>