### PR TITLE
Enable arm64 build on wheel and conda

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -381,17 +381,6 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
 
     conda install -y "$built_package"
 
-    # Run tests
-    echo "$(date) :: Running tests"
-    pushd "$pytorch_rootdir"
-    if [[ "$cpu_only" == 1 ]]; then
-        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" 'cpu'
-    else
-        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" "cu$cuda_nodot"
-    fi
-    popd
-    echo "$(date) :: Finished tests"
-
     # Clean up test folder
     source deactivate
     conda env remove -yn "$test_env"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -125,6 +125,15 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     # through gloo). This dependency is made available through meta.yaml, so
     # we can override the default and set USE_DISTRIBUTED=1.
     export USE_DISTRIBUTED=1
+
+    # testing cross compilation
+    if [[ "$DESIRED_PYTHON" == "3.8" ]]; then
+        export CMAKE_OSX_ARCHITECTURES=arm64
+        export USE_MKLDNN=OFF
+        export USE_NNPACK=OFF
+        export USE_QNNPACK=OFF
+        export BUILD_TEST=OFF
+    fi
 fi
 
 echo "Will build for all Pythons: ${DESIRED_PYTHON[@]}"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -127,7 +127,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export USE_DISTRIBUTED=1
 
     # testing cross compilation
-    if [[ "$DESIRED_PYTHON" == "3.8" ]]; then
+    if [[ "$CROSS_COMPILE_ARM64" == "1" ]]; then
         export CMAKE_OSX_ARCHITECTURES=arm64
         export USE_MKLDNN=OFF
         export USE_NNPACK=OFF

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -52,6 +52,11 @@ build:
     - USE_FBGEMM
     - USE_SCCACHE # [win]
     - USE_DISTRIBUTED # [unix]
+    - CMAKE_OSX_ARCHITECTURES # [arm64]
+    - USE_MKLDNN # [arm64]
+    - USE_NNPACK # [arm64]
+    - USE_QNNPACK # [arm64]
+    - BUILD_TEST # [arm64]
   features:
 {{ environ.get('CONDA_CPU_ONLY_FEATURE') }}
 

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -52,11 +52,11 @@ build:
     - USE_FBGEMM
     - USE_SCCACHE # [win]
     - USE_DISTRIBUTED # [unix]
-    - CMAKE_OSX_ARCHITECTURES # [arm64]
-    - USE_MKLDNN # [arm64]
-    - USE_NNPACK # [arm64]
-    - USE_QNNPACK # [arm64]
-    - BUILD_TEST # [arm64]
+    - CMAKE_OSX_ARCHITECTURES # [unix]
+    - USE_MKLDNN # [unix]
+    - USE_NNPACK # [unix]
+    - USE_QNNPACK # [unix]
+    - BUILD_TEST # [unix]
   features:
 {{ environ.get('CONDA_CPU_ONLY_FEATURE') }}
 

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -164,7 +164,7 @@ retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 export USE_DISTRIBUTED=1
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq libuv pkg-config
 
-if [[ "$desired_python" == 3.8 ]]; then
+if [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
     export CMAKE_OSX_ARCHITECTURES=arm64
     export USE_MKLDNN=OFF
     export USE_NNPACK=OFF

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -164,6 +164,14 @@ retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 export USE_DISTRIBUTED=1
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq libuv pkg-config
 
+if [[ "$desired_python" == 3.8 ]]; then
+    export CMAKE_OSX_ARCHITECTURES=arm64
+    export USE_MKLDNN=OFF
+    export USE_NNPACK=OFF
+    export USE_QNNPACK=OFF
+    export BUILD_TEST=OFF
+fi
+
 pushd "$pytorch_rootdir"
 echo "Calling setup.py bdist_wheel at $(date)"
 

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -209,13 +209,6 @@ if [[ -z "$BUILD_PYTHONLESS" ]]; then
     conda activate test_conda_env
 
     pip install "$PYTORCH_FINAL_PACKAGE_DIR/$wheel_filename_new" -v
-
-    # Run the tests
-    echo "$(date) :: Running tests"
-    pushd "$pytorch_rootdir"
-    "${SOURCE_DIR}/../run_tests.sh" 'wheel' "$desired_python" 'cpu'
-    popd
-    echo "$(date) :: Finished tests"
 else
     pushd "$pytorch_rootdir"
     mkdir -p build


### PR DESCRIPTION
Adapts build_pytorch.sh and build_wheel.sh to allow for arm64 compilation.
(The code to remove the run_test portions of both scripts should be reviewed at #659) 
Testing at https://github.com/pytorch/pytorch/pull/52441.

Previously tested at https://github.com/pytorch/pytorch/pull/52381 (before I made CROSS_COMPILE_ARM64 official).