### PR TITLE
Removing testing in build scripts as the testing happens later anyway

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -381,6 +381,19 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
 
     conda install -y "$built_package"
 
+    if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
+        # Run tests, unless it's for mac cross compiled arm64
+        echo "$(date) :: Running tests"
+        pushd "$pytorch_rootdir"
+        if [[ "$cpu_only" == 1 ]]; then
+            "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" 'cpu'
+        else
+            "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" "cu$cuda_nodot"
+        fi
+        popd
+        echo "$(date) :: Finished tests"
+    fi
+
     # Clean up test folder
     source deactivate
     conda env remove -yn "$test_env"

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -209,6 +209,15 @@ if [[ -z "$BUILD_PYTHONLESS" ]]; then
     conda activate test_conda_env
 
     pip install "$PYTORCH_FINAL_PACKAGE_DIR/$wheel_filename_new" -v
+
+    if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
+        # Run the tests, unless it's cross compiled arm64
+        echo "$(date) :: Running tests"
+        pushd "$pytorch_rootdir"
+        "${SOURCE_DIR}/../run_tests.sh" 'wheel' "$desired_python" 'cpu'
+        popd
+        echo "$(date) :: Finished tests"
+    fi
 else
     pushd "$pytorch_rootdir"
     mkdir -p build


### PR DESCRIPTION
Removes the "run_test.sh" call in `build_pytorch.sh` and `build_wheel.sh` for arm64 cross compilation.

* In actuality, for mac: https://github.com/pytorch/pytorch/blob/master/.circleci/scripts/binary_macos_test.sh#L33 makes the call anyway

* For linux: https://github.com/pytorch/pytorch/blob/master/.circleci/scripts/binary_linux_test.sh#L88 calls check_binary.sh
* For windows: https://github.com/pytorch/pytorch/blob/master/.circleci/scripts/binary_windows_test.sh#L17 calls smoke_test.bat

There aren't many differences from [check_binary.sh](https://github.com/pytorch/builder/blob/master/check_binary.sh) and [smoke_test.bat](https://github.com/pytorch/builder/blob/master/windows/internal/smoke_test.bat) EXCEPT that they both do not call run_test.py whereas run_test.sh does. This might matter so we don't disable test running for those builds.
 