### PR TITLE
update package names for both wheel and conda for cross compiled arm64

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -385,10 +385,10 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
         cp "$built_package" "$PYTORCH_FINAL_PACKAGE_DIR/"
     fi
 
-    conda install -y "$built_package"
-
+    # Install the built package and run tests, unless it's for mac cross compiled arm64
     if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
-        # Run tests, unless it's for mac cross compiled arm64
+        conda install -y "$built_package"
+
         echo "$(date) :: Running tests"
         pushd "$pytorch_rootdir"
         if [[ "$cpu_only" == 1 ]]; then

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -66,8 +66,8 @@ if [[ -n "$OVERRIDE_PACKAGE_VERSION" ]]; then
     build_number=0
 fi
 
-# testing cross compilation
-if [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
+# differentiate package name for cross compilation to avoid collision
+if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
     build_version="$build_version.arm64"
 fi
 
@@ -133,7 +133,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export USE_DISTRIBUTED=1
 
     # testing cross compilation
-    if [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
+    if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
         export CMAKE_OSX_ARCHITECTURES=arm64
         export USE_MKLDNN=OFF
         export USE_NNPACK=OFF

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -65,6 +65,12 @@ if [[ -n "$OVERRIDE_PACKAGE_VERSION" ]]; then
     build_version="$OVERRIDE_PACKAGE_VERSION"
     build_number=0
 fi
+
+# testing cross compilation
+if [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
+    build_version="$build_version.arm64"
+fi
+
 export PYTORCH_BUILD_VERSION=$build_version
 export PYTORCH_BUILD_NUMBER=$build_number
 
@@ -127,7 +133,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export USE_DISTRIBUTED=1
 
     # testing cross compilation
-    if [[ "$CROSS_COMPILE_ARM64" == "1" ]]; then
+    if [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
         export CMAKE_OSX_ARCHITECTURES=arm64
         export USE_MKLDNN=OFF
         export USE_NNPACK=OFF

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -202,18 +202,17 @@ if [[ -z "$BUILD_PYTHONLESS" ]]; then
     cp "$whl_tmp_dir/$wheel_filename_gen" "$PYTORCH_FINAL_PACKAGE_DIR/$wheel_filename_new"
 
     ##########################
-    # now test the binary
-    pip uninstall -y "$TORCH_PACKAGE_NAME" || true
-    pip uninstall -y "$TORCH_PACKAGE_NAME" || true
-
-    # Create new "clean" conda environment for testing
-    conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "test_conda_env" python="$desired_python"
-    conda activate test_conda_env
-
-    pip install "$PYTORCH_FINAL_PACKAGE_DIR/$wheel_filename_new" -v
-
+    # now test the binary, unless it's cross compiled arm64
     if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
-        # Run the tests, unless it's cross compiled arm64
+        pip uninstall -y "$TORCH_PACKAGE_NAME" || true
+        pip uninstall -y "$TORCH_PACKAGE_NAME" || true
+
+        # Create new "clean" conda environment for testing
+        conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "test_conda_env" python="$desired_python"
+        conda activate test_conda_env
+
+        pip install "$PYTORCH_FINAL_PACKAGE_DIR/$wheel_filename_new" -v
+
         echo "$(date) :: Running tests"
         pushd "$pytorch_rootdir"
         "${SOURCE_DIR}/../run_tests.sh" 'wheel' "$desired_python" 'cpu'

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -101,6 +101,8 @@ if [[ "$desired_python" == 3.5 ]]; then
     mac_version='macosx_10_6_x86_64'
 elif [[ "$desired_python" == 2.7 ]]; then
     mac_version='macosx_10_7_x86_64'
+elif [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
+    mac_version='macosx_11_1_arm64'
 else
     mac_version='macosx_10_9_x86_64'
 fi

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -101,7 +101,7 @@ if [[ "$desired_python" == 3.5 ]]; then
     mac_version='macosx_10_6_x86_64'
 elif [[ "$desired_python" == 2.7 ]]; then
     mac_version='macosx_10_7_x86_64'
-elif [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
+elif [[ -n "$CROSS_COMPILE_ARM64" ]]; then
     mac_version='macosx_11_1_arm64'
 else
     mac_version='macosx_10_9_x86_64'
@@ -166,7 +166,7 @@ retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 export USE_DISTRIBUTED=1
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq libuv pkg-config
 
-if [[ "$CROSS_COMPILE_ARM64" == 1 ]]; then
+if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
     export CMAKE_OSX_ARCHITECTURES=arm64
     export USE_MKLDNN=OFF
     export USE_NNPACK=OFF


### PR DESCRIPTION
Tested at https://github.com/pytorch/pytorch/pull/52624

Attempts to differentiate package names for regular mac builds and arm64 ones by:
- tagging arm64 for conda package version (I tried to look for an architecture variant, but didn't find one). [docs here](https://conda.io/projects/conda-build/en/latest/concepts/package-naming-conv.html#:~:text=Package%20name,are%20referred%20to%20by%20package_name%20.)
- revising the name for wheels, which was easy enough.
