### PR TITLE
conda: Pin numpy to 1.19 to avoid issues

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -13,8 +13,8 @@ requirements:
   host:
     - python
     # Conda has some pretty unpredictable behavior when it comes to channel priority
-    # so to be safe on which numpy version we want we default to the defaults
-    - defaults::numpy >=1.11.*
+    # so to be safe on which numpy version we want we default to 1.19
+    - numpy=1.19
     - setuptools
     - pyyaml
     - mkl >=2019
@@ -29,7 +29,7 @@ requirements:
 
   run:
     - python
-    - defaults::numpy >=1.11.*
+    - numpy=1.19
     - mkl >=2018
     - dataclasses # [py36]
     - libuv # [win]


### PR DESCRIPTION
`conda` has unpredictable when it comes to resolving dependencies so let's just pin our `numpy` version to a version that every version of python that we support can install. (numpy 1.20 doesn't install for python 3.6)

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>