### PR TITLE
manywheel: Drop 7.5 for CUDA 10.2

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -70,7 +70,7 @@ case ${CUDA_VERSION} in
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     10.*)
-        TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST};7.5"
+        TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;
     9.*)


### PR DESCRIPTION
sm_75 should be forward compatible with sm_70 so dropping it shouldn't
make much of a difference while giving us 173MB to work with

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>