### PR TITLE
Add support for building aarch64-wheels in Docker

### DIFF
--- a/build_aarch64_wheel.py
+++ b/build_aarch64_wheel.py
@@ -274,6 +274,8 @@ def start_build(host: RemoteHost, *,
     print('Checking out TorchVision repo')
     if branch.startswith("v1.7.1"):
         host.run_cmd(f"git clone https://github.com/pytorch/vision -b v0.8.2-rc2 {git_clone_flags}")
+    if branch.startswith("v1.8.0"):
+        host.run_cmd(f"git clone https://github.com/pytorch/vision -b v0.9.0-rc3 {git_clone_flags}")
     else:
         host.run_cmd(f"git clone https://github.com/pytorch/vision {git_clone_flags}")
     print('Installing PyTorch wheel')

--- a/build_aarch64_wheel.py
+++ b/build_aarch64_wheel.py
@@ -15,7 +15,10 @@ ubuntu20_04_ami = "ami-0ea142bd244023692"
 
 def compute_keyfile_path(key_name: Optional[str] = None) -> Tuple[str, str]:
     if key_name is None:
-        key_name = os.getenv("AWS_KEY_NAME", "")
+        key_name = os.getenv("AWS_KEY_NAME")
+        if key_name is None:
+            return os.getenv("SSH_KEY_PATH", ""), ""
+
     homedir_path = os.path.expanduser("~")
     default_path = os.path.join(homedir_path, ".ssh", f"{key_name}.pem")
     return os.getenv("SSH_KEY_PATH", default_path), key_name
@@ -411,11 +414,11 @@ if __name__ == '__main__':
         terminate_instances(args.instance_type)
         sys.exit(0)
 
-    if key_name is None:
+    if len(key_name) == 0:
         raise Exception("""
             Cannot start build without key_name, please specify
             --key-name argument or AWS_KEY_NAME environment variable.""")
-    if keyfile_path is None or not os.path.exists(keyfile_path):
+    if len(keyfile_path) == 0 or not os.path.exists(keyfile_path):
         raise Exception(f"""
             Cannot find keyfile with name: [{key_name}] in path: [{keyfile_path}], please
             check `~/.ssh/` folder or manually set SSH_KEY_PATH environment variable.""")


### PR DESCRIPTION
Refactor existing codebase to have RemoteHost abstraction
After that, most of the build script will work without a change inside or outside of docker
Add "--use-docker" option to build true manylinux2014 compatible wheels inside official pypa docker