### PR TITLE
Pre-install numpy when testing caffe2 on Darwin

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -78,7 +78,11 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
       retry conda update -yq --all -c defaults -c pytorch -c numba/label/dev ${EXTRA_CONDA_FLAGS}
     fi
     # Install the testing dependencies
-    retry conda install -yq ${EXTRA_CONDA_FLAGS} future hypothesis ninja protobuf pytest setuptools six typing_extensions pyyaml
+    retry conda install -yq ${EXTRA_CONDA_FLAGS} future hypothesis  protobuf pytest setuptools six typing_extensions pyyaml
+    if [[ "$package_type" == wheel ]]; then
+      # Numpy dependency is now dynamic but old caffe2 test assume its always there
+      retry conda install -yq ${EXTRA_CONDA_FLAGS} numpy
+    fi
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true


### PR DESCRIPTION
numpy dependency is dynamic for PyTorch but mandatory for caffe2