### PR TITLE
Fix cross compiled Mac package name for arm64

### DIFF
--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -102,7 +102,7 @@ if [[ "$desired_python" == 3.5 ]]; then
 elif [[ "$desired_python" == 2.7 ]]; then
     mac_version='macosx_10_7_x86_64'
 elif [[ -n "$CROSS_COMPILE_ARM64" ]]; then
-    mac_version='macosx_11_1_arm64'
+    mac_version='macosx_11_0_arm64'
 else
     mac_version='macosx_10_9_x86_64'
 fi


### PR DESCRIPTION
The current 11_1 is too restrictive as this actual min version is 11_0. 

Run tested here: https://github.com/pytorch/pytorch/pull/53714, successful job with artifact: https://app.circleci.com/pipelines/github/pytorch/pytorch/283389/workflows/27423215-1d95-4afa-8f45-c88ec214d273/jobs/11433273