### PR TITLE
Make aarch64 wheels RHEL8 compatible

### DIFF
--- a/build_aarch64_wheel.py
+++ b/build_aarch64_wheel.py
@@ -9,8 +9,12 @@ from typing import List, Optional, Tuple, Union
 
 
 # AMI images for us-east-1, change the following based on your ~/.aws/config
-ubuntu18_04_ami = "ami-0f2b111fdc1647918"
-ubuntu20_04_ami = "ami-0ea142bd244023692"
+os_amis = {
+        'ubuntu18_04': "ami-0f2b111fdc1647918", # login_name: ubuntu
+        'ubuntu20_04': "ami-0ea142bd244023692", # login_name: ubuntu
+        'redhat8':  "ami-0698b90665a2ddcf1", # login_name: ec2-user
+        }
+ubuntu18_04_ami = os_amis['ubuntu18_04']
 
 
 def compute_keyfile_path(key_name: Optional[str] = None) -> Tuple[str, str]:
@@ -424,7 +428,7 @@ def parse_arguments():
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--build-only", action="store_true")
     parser.add_argument("--test-only", type=str)
-    parser.add_argument("--os", type=str, choices=['ubuntu18_04', 'ubuntu20_04'], default='ubuntu18_04')
+    parser.add_argument("--os", type=str, choices=list(os_amis.keys()), default='ubuntu18_04')
     parser.add_argument("--python-version", type=str, choices=['3.6', '3.7', '3.8', '3.9'], default=None)
     parser.add_argument("--alloc-instance", action="store_true")
     parser.add_argument("--list-instances", action="store_true")
@@ -439,7 +443,7 @@ def parse_arguments():
 
 if __name__ == '__main__':
     args = parse_arguments()
-    ami = ubuntu20_04_ami if args.os == 'ubuntu20_04' else ubuntu18_04_ami
+    ami = os_amis[args.os]
     keyfile_path, key_name = compute_keyfile_path(args.key_name)
 
     if args.list_instances:

--- a/build_aarch64_wheel.py
+++ b/build_aarch64_wheel.py
@@ -312,6 +312,7 @@ def start_build(host: RemoteHost, *,
 
     host.run_cmd(f"cd vision; {build_vars} python3 setup.py bdist_wheel")
     vision_wheel_name = host.list_dir("vision/dist")[0]
+    embed_libgomp(host, use_conda, os.path.join('vision', 'dist', vision_wheel_name))
     print('Copying TorchVision wheel')
     host.download_file(os.path.join('vision', 'dist', vision_wheel_name))
 

--- a/build_aarch64_wheel.py
+++ b/build_aarch64_wheel.py
@@ -274,6 +274,8 @@ def start_build(host: RemoteHost, *,
         build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={version}.dev{build_date} PYTORCH_BUILD_NUMBER=1"
     if branch.startswith("v1."):
         build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={branch[1:branch.find('-')]} PYTORCH_BUILD_NUMBER=1"
+    if host.using_docker():
+        build_vars += " CMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=0x10000"
     host.run_cmd(f"cd pytorch ; {build_vars} python3 setup.py bdist_wheel")
     pytorch_wheel_name = host.list_dir("pytorch/dist")[0]
     embed_libgomp(host, use_conda, os.path.join('pytorch', 'dist', pytorch_wheel_name))
@@ -285,6 +287,8 @@ def start_build(host: RemoteHost, *,
         host.run_cmd(f"git clone https://github.com/pytorch/vision -b v0.8.2-rc2 {git_clone_flags}")
     if branch.startswith("v1.8.0"):
         host.run_cmd(f"git clone https://github.com/pytorch/vision -b v0.9.0-rc3 {git_clone_flags}")
+    if branch.startswith("v1.8.1"):
+        host.run_cmd(f"git clone https://github.com/pytorch/vision -b v0.9.1-rc1 {git_clone_flags}")
     else:
         host.run_cmd(f"git clone https://github.com/pytorch/vision {git_clone_flags}")
     print('Installing PyTorch wheel')
@@ -299,6 +303,12 @@ def start_build(host: RemoteHost, *,
         build_vars += f"BUILD_VERSION={version}.dev{build_date}"
     if branch.startswith("v1.7.1"):
         build_vars += f"BUILD_VERSION=0.8.2"
+    if branch.startswith("v1.8.0"):
+        build_vars += f"BUILD_VERSION=0.9.0"
+    if branch.startswith("v1.8.1"):
+        build_vars += f"BUILD_VERSION=0.9.1"
+    if host.using_docker():
+        build_vars += " CMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=0x10000"
 
     host.run_cmd(f"cd vision; {build_vars} python3 setup.py bdist_wheel")
     vision_wheel_name = host.list_dir("vision/dist")[0]


### PR DESCRIPTION
RedHat-8 on aarch64 expects all loadable segments of shared libraries to be 64KB aligned.
Modify build_aarch64_wheel.py to:
 - Pass `-Wl,-z,max-page-size=0x10000` to the linker flags
 - Ensure that page-alignment is not change when patchelf is running
 - Add option to allocate rhel8 machine
 - Assign default tags to allocated machines
 
Fixes https://github.com/pytorch/pytorch/issues/53597