### PR TITLE
Use packaging.Version to compare version numbers instead of direct string comparison

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -7,6 +7,7 @@ from os import path
 from collections import defaultdict
 from typing import List, Type, Dict, Set, TypeVar, Generator, Optional
 from re import sub, match
+from packaging.version import parse
 
 import botocore
 import boto3
@@ -61,6 +62,7 @@ class S3Index:
         # sorting, sorts in reverse to put the most recent versions first
         all_sorted_packages = sorted(
             {self.normalize_package_version(obj) for obj in self.objects},
+            key=lambda v: parse(v.split('-')[1]),
             reverse=True,
         )
         packages: Dict[str, int] = defaultdict(int)

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -62,7 +62,7 @@ class S3Index:
         # sorting, sorts in reverse to put the most recent versions first
         all_sorted_packages = sorted(
             {self.normalize_package_version(obj) for obj in self.objects},
-            key=lambda v: parse(v.split('-')[1]),
+            key=lambda name_ver: parse(name_ver.split('-', 1)[-1]),
             reverse=True,
         )
         packages: Dict[str, int] = defaultdict(int)

--- a/s3_management/requirements.txt
+++ b/s3_management/requirements.txt
@@ -1,1 +1,2 @@
 boto3
+packaging


### PR DESCRIPTION
This fixes the recent torchtext nightlies with version 0.10.x to be incorrectly hidden.