### PR TITLE
Update the ROCm 4.1 miopen branch for nightly whls

### DIFF
--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -94,7 +94,7 @@ if [[ ${ROCM_VERSION} == 4.0.1 ]]; then
     MIOPEN_BRANCH="rocm-4.0.1"
 elif [[ ${ROCM_VERSION} == 4.1 ]]; then
     MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx803_36;gfx803_64;gfx900_56;gfx900_64;gfx906_60;gfx906_64;gfx90878"
-    MIOPEN_BRANCH="rocm-4.1.x"
+    MIOPEN_BRANCH="rocm-4.1.x-staging"
 else
     echo "Unhandled ROCM_VERSION ${ROCM_VERSION}"
     exit 1


### PR DESCRIPTION
 - Comgr from ROCm4.1 expect different compilation flags from MIOpen to some gfx targets. This is a hot fix to patch the PyTorch nightly whl build, to select the correct compilation flag for ROCm4.1. 