### PR TITLE
Parallelize submodule fetches

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -182,7 +182,7 @@ if [[ ! -d "$pytorch_rootdir" ]]; then
     popd
 fi
 pushd "$pytorch_rootdir"
-git submodule update --init --recursive
+git submodule update --init --recursive --jobs 0
 echo "Using Pytorch from "
 git --no-pager log --max-count 1
 popd

--- a/cron/nightly_defaults.sh
+++ b/cron/nightly_defaults.sh
@@ -120,7 +120,7 @@ if [[ ! -d "$NIGHTLIES_PYTORCH_ROOT" ]]; then
         export PYTORCH_BRANCH="$last_commit"
     fi
     git checkout "$PYTORCH_BRANCH"
-    git submodule update
+    git submodule update --jobs 0
     popd
 fi
 

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -95,7 +95,7 @@ if [[ ! -d "$pytorch_rootdir" ]]; then
 else
     pushd $pytorch_rootdir
 fi
-git submodule update --init --recursive
+git submodule update --init --recursive --jobs 0
 
 export PATCHELF_BIN=/usr/local/bin/patchelf
 patchelf_version=`$PATCHELF_BIN --version`

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -81,7 +81,7 @@ else
     pushd $pytorch_rootdir
 fi
 pushd $pytorch_rootdir
-git submodule update --init --recursive
+git submodule update --init --recursive --jobs 0
 
 export PATCHELF_BIN=/usr/local/bin/patchelf
 patchelf_version=`$PATCHELF_BIN --version`

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -123,7 +123,7 @@ if [[ ! -d "$pytorch_rootdir" ]]; then
     popd
 fi
 pushd "$pytorch_rootdir"
-git submodule update --init --recursive
+git submodule update --init --recursive --jobs 0
 popd
 
 ##########################


### PR DESCRIPTION
This makes all `git submodule update`s on Mac/Linux parallel using `--jobs 0`, which uses ["some reasonable default"](https://git-scm.com/docs/git-config#Documentation/git-config.txt-submodulefetchJobs) instead of doing them all serially.