### PR TITLE
Ignore deprecation warnings

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -123,6 +123,8 @@ fi
 
     time CMAKE_ARGS=${CMAKE_ARGS[@]} \
         EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
+        # TODO: Remove this flag once https://github.com/pytorch/pytorch/issues/55952 is closed
+        CFLAGS='-Wno-deprecated-declarations' \
         python setup.py install
 
     mkdir -p libtorch/{lib,bin,include,share}

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -222,7 +222,8 @@ else
     pushd "$pytorch_rootdir"
     mkdir -p build
     pushd build
-    python ../tools/build_libtorch.py
+    # TODO: Remove this flag once https://github.com/pytorch/pytorch/issues/55952 is closed
+    CFLAGS='-Wno-deprecated-declarations' python ../tools/build_libtorch.py
     popd
 
     mkdir -p libtorch/{lib,bin,include,share}


### PR DESCRIPTION
This adds `-Wno-deprecated-declarations` to the build scripts for each platform. https://github.com/pytorch/pytorch/issues/55952 tracks fixing these for real but this will help debugging immediately since these aren't really looked at in CI runs at all.

Test is in https://github.com/pytorch/pytorch/pull/56062