### PR TITLE
Add llvm-9.0.1 to the docker images

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -78,6 +78,9 @@ COPY --from=cuda11.0  /usr/local/cuda-11.0 /usr/local/cuda-11.0
 COPY --from=cuda11.1  /usr/local/cuda-11.1 /usr/local/cuda-11.1
 COPY --from=cuda11.2  /usr/local/cuda-11.2 /usr/local/cuda-11.2
 
+# Install LLVM
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
+
 FROM ${BASE_TARGET} as final
 COPY --from=patchelf /patchelf            /usr/local/bin/patchelf
 COPY --from=conda    /opt/conda           /opt/conda

--- a/libtorch/ubuntu16.04/Dockerfile
+++ b/libtorch/ubuntu16.04/Dockerfile
@@ -49,6 +49,9 @@ FROM cuda as cuda11.2
 RUN bash ./install_cuda.sh 11.2
 RUN bash ./install_magma.sh 11.2
 
+# Install LLVM
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
+
 FROM ${BASE_TARGET} as final
 # Install patchelf
 ADD ./common/install_patchelf.sh install_patchelf.sh

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -130,6 +130,9 @@ RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=cuda     /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=magma    /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 
+# Install LLVM version
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
+
 FROM common as rocm_final
 ARG ROCM_VERSION=3.7
 # Install ROCm
@@ -142,4 +145,3 @@ RUN yum install -y cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 ADD ./common/install_miopen.sh install_miopen.sh
 RUN bash ./install_miopen.sh ${ROCM_VERSION} && rm install_miopen.sh
-


### PR DESCRIPTION
We're moving towards enabling the CPU compiler backend, which depends
on LLVM.  Locally I measured that this adds 11 MB to the wheel (27 for
the uncompressed libraries).

I also checked that it coexists nicely with numba/llvmlite (e.g., no
symbol conflicts when both are loaded).