### PR TITLE
Build nightly pytorch with llvm included

### DIFF
--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -6,6 +6,8 @@ export CMAKE_PREFIX_PATH=$PREFIX
 export TH_BINARY_BUILD=1 # links CPU BLAS libraries thrice in a row (was needed for some MKL static linkage)
 export PYTORCH_BUILD_VERSION=$PKG_VERSION
 export PYTORCH_BUILD_NUMBER=$PKG_BUILDNUM
+export USE_LLVM="/opt/llvm_no_cxx11_abi"
+export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
 
 # set OPENSSL_ROOT_DIR=/opt/openssl if it exists
 if [[ -e /opt/openssl ]]; then

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -130,8 +130,12 @@ esac
 
 if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
     export _GLIBCXX_USE_CXX11_ABI=1
+    export USE_LLVM="/opt/llvm"
+    export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
 else
     export _GLIBCXX_USE_CXX11_ABI=0
+    export USE_LLVM="/opt/llvm_no_cxx11_abi"
+    export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
 fi
 
 if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -111,8 +111,12 @@ fi
 
 if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
     export _GLIBCXX_USE_CXX11_ABI=1
+    export USE_LLVM="/opt/llvm"
+    export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
 else
     export _GLIBCXX_USE_CXX11_ABI=0
+    export USE_LLVM="/opt/llvm_no_cxx11_abi"
+    export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
 fi
 
 if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then


### PR DESCRIPTION
Enable LLVM in the nightly build.  This shouldn't enabled anything by default, but should make the LLVM-based CPU fuser available so that we can kick the proverbial tires.