### PR TITLE
free space for nightly binary debug build

### DIFF
--- a/windows/internal/setup.bat
+++ b/windows/internal/setup.bat
@@ -74,6 +74,10 @@ IF "%DEBUG%" == "" (
     set LIBTORCH_PREFIX=libtorch-win-%VARIANT%-debug
 )
 
+:: remove files to save space.
+rmdir /s /q "C:/Program Files/NVIDIA GPU Computing Toolkit/"
+rmdir /s /q "C:/Program Files (x86)/Microsoft Visual Studio/"
+
 7z a -tzip "%LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip" libtorch\*
 :: Cleanup raw data to save space
 rmdir /s /q libtorch


### PR DESCRIPTION
nightly binary cu11.1 debug build always failed due to no enough space.
remove some files to free space before packaging.

verification link
https://app.circleci.com/pipelines/github/pytorch/pytorch/306696/workflows/96bcf837-4d03-4051-83df-28ca937b7ff5/jobs/12667153

https://github.com/pytorch/pytorch/pull/56478