### PR TITLE
Revert "free space for nightly binary debug build"

### DIFF
--- a/windows/internal/setup.bat
+++ b/windows/internal/setup.bat
@@ -74,10 +74,6 @@ IF "%DEBUG%" == "" (
     set LIBTORCH_PREFIX=libtorch-win-%VARIANT%-debug
 )
 
-:: remove files to save space.
-rmdir /s /q "C:/Program Files/NVIDIA GPU Computing Toolkit/"
-rmdir /s /q "C:/Program Files (x86)/Microsoft Visual Studio/"
-
 7z a -tzip "%LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip" libtorch\*
 :: Cleanup raw data to save space
 rmdir /s /q libtorch


### PR DESCRIPTION
Reverts pytorch/builder#702

We started observing failures within our windows builders that seem to coincide with this commit, just to be safe I'm going to go ahead and revert this. I think this may have lead to failures where CircleCI runners may not be as ephemeral as we once thought. If we're going to save space I think we should find a way to do it without being destructive to the underlying runner itself.

cc @mszhanyi

Logs for context:
* https://app.circleci.com/pipelines/github/pytorch/pytorch/306922/workflows/a5247011-7e70-4ab7-a606-9aa15ee6d597/jobs/12679611/steps