### PR TITLE
Build llvm both with and without _GLIBCXX_USE_CXX11_ABI

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -80,6 +80,7 @@ COPY --from=cuda11.2  /usr/local/cuda-11.2 /usr/local/cuda-11.2
 
 # Install LLVM
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm_no_cxx_abi /opt/llvm_no_cxx_abi
 
 FROM ${BASE_TARGET} as final
 COPY --from=patchelf /patchelf            /usr/local/bin/patchelf

--- a/libtorch/ubuntu16.04/Dockerfile
+++ b/libtorch/ubuntu16.04/Dockerfile
@@ -51,6 +51,7 @@ RUN bash ./install_magma.sh 11.2
 
 # Install LLVM
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm_no_cxx_abi /opt/llvm_no_cxx_abi
 
 FROM ${BASE_TARGET} as final
 # Install patchelf

--- a/llvm/Dockerfile
+++ b/llvm/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
         python3-dev \
         xz-utils
 
+# Build LLVM with CXX11 ABI (default)
 RUN mkdir -p /opt/llvm /tmp/llvm/build
 WORKDIR /tmp/llvm
 RUN curl -fL -o llvm.tar.xz "${LLVM_URL}" && \
@@ -27,5 +28,22 @@ RUN cmake -G "Unix Makefiles" \
         ../
 RUN make -j"$(nproc --ignore=2)" && make install
 
+# Build LLVM without CXX11 ABI
+RUN mkdir -p /opt/llvm_no_cxx11_abi /tmp/llvm/build_no_cxx11_abi
+WORKDIR /tmp/llvm/build_no_cxx11_abi
+RUN cmake -G "Unix Makefiles" \
+        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DLLVM_ENABLE_ASSERTIONS=ON \
+        -DCMAKE_INSTALL_PREFIX=/opt/llvm_no_cxx11_abi \
+        -DLLVM_TARGETS_TO_BUILD="host" \
+        -DLLVM_BUILD_TOOLS=OFF \
+        -DLLVM_BUILD_UTILS=OFF \
+        -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON \
+	-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 \
+        ../
+RUN make -j"$(nproc --ignore=2)" && make install
+
+
 FROM scratch as final
 COPY --from=dev /opt/llvm /opt/llvm
+COPY --from=dev /opt/llvm_no_cxx11_abi /opt/llvm_no_cxx11_abi

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -132,6 +132,7 @@ COPY --from=magma    /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BAS
 
 # Install LLVM version
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm_no_cxx11_abi /opt/llvm_no_cxx11_abi
 
 FROM common as rocm_final
 ARG ROCM_VERSION=3.7


### PR DESCRIPTION
* Build llvm both with and without _GLIBCXX_USE_CXX11_ABI
* Add llvm without CXX11 ABI to docker images