### PR TITLE
[re-merge] Build libtorch_cpu.so in debug mode in Linux

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -125,9 +125,14 @@ fi
         EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
         # TODO: Remove this flag once https://github.com/pytorch/pytorch/issues/55952 is closed
         CFLAGS='-Wno-deprecated-declarations' \
+        REL_WITH_DEB_INFO=1 \
         python setup.py install
 
     mkdir -p libtorch/{lib,bin,include,share}
+
+    # Make debug folder separate so it doesn't get zipped up with the rest of
+    # libtorch
+    mkdir debug
 
     # Copy over all lib files
     cp -rv build/lib/*                libtorch/lib/
@@ -139,6 +144,26 @@ fi
 
     # Copy over all of the cmake files
     cp -rv build/lib*/torch/share/*   libtorch/share/
+
+    # Split libtorch into debug / release version
+    cp libtorch/lib/libtorch_cpu.so libtorch/lib/libtorch_cpu.so.dbg
+
+    # Remove debug symbols on release lib
+    strip --strip-debug libtorch/lib/libtorch_cpu.so
+
+    # Keep debug symbols on debug lib
+    strip --only-keep-debug libtorch/lib/libtorch_cpu.so.dbg
+
+    # Add a debug link to the release lib to the debug lib (debuggers will then
+    # search for symbols in a file called libtorch_cpu.so.dbg in some 
+    # predetermined locations) and embed a CRC32 of the debug library into the .so
+    cd libtorch/lib
+    objcopy libtorch_cpu.so --add-gnu-debuglink=libtorch_cpu.so.dbg
+    cd ../..
+
+    # Move the debug symbols to its own directory so it doesn't get processed /
+    # zipped with all the other libraries
+    mv libtorch/lib/libtorch_cpu.so.dbg debug/libtorch_cpu.so.dbg
 
     echo "${PYTORCH_BUILD_VERSION}" > libtorch/build-version
     echo "$(pushd $pytorch_rootdir && git rev-parse HEAD)" > libtorch/build-hash
@@ -155,6 +180,17 @@ fi
     set -x
 
     mkdir -p /tmp/$LIBTORCH_HOUSE_DIR
+
+    # objcopy installs a CRC32 into libtorch above (it can be extracted with the
+    # command:
+    #    readelf --hex-dump=.gnu_debuglink a.stripped | tail -n 2 | head -n 1 | awk '{print $4}'
+    # so, so add that to the name here
+    CRC32=$(cat debug/libtorch_cpu.so.dbg | gzip -c | tail -c8 | hexdump -n4 -e '"%x"')
+
+    # Zip debug symbols
+    zip /tmp/$LIBTORCH_HOUSE_DIR/debug-libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION-$CRC32.zip debug/libtorch_cpu.so.dbg
+
+    # Zip and copy libtorch
     zip -rq /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION.zip libtorch
     cp /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION.zip \
        /tmp/$LIBTORCH_HOUSE_DIR/libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-latest.zip
@@ -300,4 +336,5 @@ done
 # Copy wheels to host machine for persistence before testing
 if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
     cp /$LIBTORCH_HOUSE_DIR/libtorch*.zip "$PYTORCH_FINAL_PACKAGE_DIR"
+    cp /$LIBTORCH_HOUSE_DIR/debug-libtorch*.zip "$PYTORCH_FINAL_PACKAGE_DIR"
 fi

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -187,11 +187,8 @@ fi
 
     mkdir -p /tmp/$LIBTORCH_HOUSE_DIR
 
-    # objcopy installs a CRC32 into libtorch above (it can be extracted with the
-    # command:
-    #    readelf --hex-dump=.gnu_debuglink a.stripped | tail -n 2 | head -n 1 | awk '{print $4}'
-    # so, so add that to the name here
-    CRC32=$(cat debug/libtorch_cpu.so.dbg | gzip -c | tail -c8 | xxd -l 4 -p)
+    # objcopy installs a CRC32 into libtorch_cpu above so, so add that to the name here
+    CRC32=$(readelf --wide --debug-dump libtorch_cpu.so | grep CRC | sed 's/.*CRC value: 0x//g')
 
     # Zip debug symbols
     zip /tmp/$LIBTORCH_HOUSE_DIR/debug-libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION-$CRC32.zip debug/libtorch_cpu.so.dbg

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -157,7 +157,8 @@ fi
     cd libtorch/lib
 
     # Clean out debug symbols from all the libs
-    find . -name "*.so*" -exec strip --strip-debug {} \;
+    find . -name "*.so.1" -exec strip --strip-debug {} \;
+    find . -name "*.so" -exec strip --strip-debug {} \;
     find . -name "*.a" -exec strip --strip-debug {} \;
 
     objcopy libtorch_cpu.so --add-gnu-debuglink=libtorch_cpu.so.dbg

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -160,9 +160,9 @@ fi
     cd libtorch/lib
 
     # Clean out debug symbols from the rest of the libs
-    strip ./*.so.1
-    strip ./*.so
-    strip ./*.a
+    find . -name "*.so.1" -exec strip {} \;
+    find . -name "*.a" -exec strip {} \;
+    find . -name "*.so" -exec strip {} \;
 
     objcopy libtorch_cpu.so --add-gnu-debuglink=libtorch_cpu.so.dbg
     cd ../..

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -148,9 +148,6 @@ fi
     # Split libtorch into debug / release version
     cp libtorch/lib/libtorch_cpu.so libtorch/lib/libtorch_cpu.so.dbg
 
-    # Remove debug symbols on release lib
-    strip --strip-debug libtorch/lib/libtorch_cpu.so
-
     # Keep debug symbols on debug lib
     strip --only-keep-debug libtorch/lib/libtorch_cpu.so.dbg
 
@@ -159,10 +156,9 @@ fi
     # predetermined locations) and embed a CRC32 of the debug library into the .so
     cd libtorch/lib
 
-    # Clean out debug symbols from the rest of the libs
-    find . -name "*.so.1" -exec strip {} \;
-    find . -name "*.a" -exec strip {} \;
-    find . -name "*.so" -exec strip {} \;
+    # Clean out debug symbols from all the libs
+    find . -name "*.so*" -exec strip --strip-debug {} \;
+    find . -name "*.a" -exec strip --strip-debug {} \;
 
     objcopy libtorch_cpu.so --add-gnu-debuglink=libtorch_cpu.so.dbg
     cd ../..

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -158,6 +158,12 @@ fi
     # search for symbols in a file called libtorch_cpu.so.dbg in some 
     # predetermined locations) and embed a CRC32 of the debug library into the .so
     cd libtorch/lib
+
+    # Clean out debug symbols from the rest of the libs
+    strip ./*.so.1
+    strip ./*.so
+    strip ./*.a
+
     objcopy libtorch_cpu.so --add-gnu-debuglink=libtorch_cpu.so.dbg
     cd ../..
 
@@ -185,7 +191,7 @@ fi
     # command:
     #    readelf --hex-dump=.gnu_debuglink a.stripped | tail -n 2 | head -n 1 | awk '{print $4}'
     # so, so add that to the name here
-    CRC32=$(cat debug/libtorch_cpu.so.dbg | gzip -c | tail -c8 | hexdump -n4 -e '"%x"')
+    CRC32=$(cat debug/libtorch_cpu.so.dbg | gzip -c | tail -c8 | xxd -l 4 -p)
 
     # Zip debug symbols
     zip /tmp/$LIBTORCH_HOUSE_DIR/debug-libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION-$CRC32.zip debug/libtorch_cpu.so.dbg


### PR DESCRIPTION
This is a redo of #694, that PR was missing the `find` + `strip --strip-debug` lines which made the resulting binaries [huge](https://app.circleci.com/pipelines/github/pytorch/pytorch/308252/workflows/6555ea42-6f91-46ba-967e-cf0616f78f42/jobs/12748469). It also had a dependency on `hexdump`, which this PR swaps out for `readelf`. 

This time using `ci-all` the binary sizes are correct, libtorch is the same and the debug zip is ~ 800 MB which is expected. See https://github.com/pytorch/pytorch/pull/56810 and relevant CircleCI jobs:
* [binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_shared-with-deps_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/310704/workflows/4baac311-f827-431c-99a1-00fcf857b895/jobs/12873452)
* [binary_linux_libtorch_3_7m_cpu_devtoolset7_shared-with-deps_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/310704/workflows/4baac311-f827-431c-99a1-00fcf857b895/jobs/12873461)

The debug scripts should get picked up automatically by the s3 upload job since they are in the same directory as libtorch.