### PR TITLE
Fix CRC32 extraction in libtorch build

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -185,7 +185,7 @@ fi
     mkdir -p /tmp/$LIBTORCH_HOUSE_DIR
 
     # objcopy installs a CRC32 into libtorch_cpu above so, so add that to the name here
-    CRC32=$(readelf --wide --debug-dump libtorch_cpu.so | grep CRC | sed 's/.*CRC value: 0x//g')
+    CRC32=$(objcopy --dump-section .gnu_debuglink=>(tail -c4 | od -t x4 -An | xargs echo) libtorch_cpu.so)
 
     # Zip debug symbols
     zip /tmp/$LIBTORCH_HOUSE_DIR/debug-libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION-$CRC32.zip debug/libtorch_cpu.so.dbg

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -185,7 +185,7 @@ fi
     mkdir -p /tmp/$LIBTORCH_HOUSE_DIR
 
     # objcopy installs a CRC32 into libtorch_cpu above so, so add that to the name here
-    CRC32=$(objcopy --dump-section .gnu_debuglink=>(tail -c4 | od -t x4 -An | xargs echo) libtorch_cpu.so)
+    CRC32=$(objcopy --dump-section .gnu_debuglink=>(tail -c4 | od -t x4 -An | xargs echo) libtorch/lib/libtorch_cpu.so)
 
     # Zip debug symbols
     zip /tmp/$LIBTORCH_HOUSE_DIR/debug-libtorch-$LIBTORCH_ABI$LIBTORCH_VARIANT-$PYTORCH_BUILD_VERSION-$CRC32.zip debug/libtorch_cpu.so.dbg


### PR DESCRIPTION
This was relying on parsing the output of `readelf --debug-dump` which
supposedly reads the debug prints out the debug sections of the library,
but on the CI machines it wasn't showing anything (maybe a version
problem, the one on CI is a couple releases behind). Either way parsing
human-readable output isn't great so this replaces it with `objdump`
which outputs the binary of the relevant ELF section, of which the last
4 bytes are the CRC32 value calculated by `objdump --add-gnu-debuglink`

[Example problematic build](https://app.circleci.com/pipelines/github/pytorch/pytorch/311511/workflows/29542bde-1de3-4f77-a287-40071f12f083/jobs/12917363/artifacts), the name ends with `cpu-.zip` since `$CRC32` is empty 