### PR TITLE
Remove conda-forge from our testing scripts

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -61,7 +61,6 @@ fi
 
 # Environment initialization
 if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
-    EXTRA_CONDA_FLAGS="-c=conda-forge"
     # Why are there two different ways to install dependencies after installing an offline package?
     # The "cpu" conda package for pytorch doesn't actually depend on "cpuonly" which means that
     # when we attempt to update dependencies using "conda update --all" it will attempt to install
@@ -72,13 +71,13 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
     # TODO (maybe): Make the "cpu" package of pytorch depend on "cpuonly"
     if [[ "$cuda_ver" = 'cpu' ]]; then
       # Installing cpuonly will also install dependencies as well
-      retry conda install -y -c pytorch ${EXTRA_CONDA_FLAGS} cpuonly
+      retry conda install -y -c pytorch cpuonly
     else
       # Install dependencies from installing the pytorch conda package offline
-      retry conda update -yq --all -c defaults -c pytorch -c numba/label/dev ${EXTRA_CONDA_FLAGS}
+      retry conda update -yq --all -c defaults -c pytorch -c numba/label/dev
     fi
     # Install the testing dependencies
-    retry conda install -yq ${EXTRA_CONDA_FLAGS} future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
+    retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
     if [[ "$package_type" == wheel ]]; then
       # Numpy dependency is now dynamic but old caffe2 test assume its always there
       retry conda install -yq numpy

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -100,10 +100,6 @@ if [[ "$PACKAGE_TYPE" == 'conda' || "$(uname)" == 'Darwin' ]]; then
     *3.6.*)
       dependencies="${dependencies} future dataclasses"
       ;;
-    # TODO: Remove this once Python 3.9 is workable through the default conda channels
-    *3.9.*)
-      dependencies="-c=conda-forge ${dependencies}"
-      ;;
   esac
   conda install -yq ${dependencies}
 else
@@ -137,9 +133,9 @@ which python
 #  retry curl "https://download.pytorch.org/whl/nightly/$DESIRED_CUDA/torch_nightly.html" -v
 #fi
 
-# CUDA Toolkit 11.1 and 11.2 are both in conda-forge
+# CUDA Toolkit 11.1 and 11.2 are both in nvidia
 if [[ "$DESIRED_CUDA" == cu111 || "$DESIRED_CUDA" == cu112 ]]; then
-  EXTRA_CONDA_FLAGS="-c=conda-forge"
+  EXTRA_CONDA_FLAGS="-c=nvidia"
 elif
   EXTRA_CONDA_FLAGS=""
 fi

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -71,14 +71,11 @@ set "CONDA_HOME=%CD%\conda"
 set "tmp_conda=%CONDA_HOME%"
 set "miniconda_exe=%CD%\miniconda.exe"
 set "CONDA_EXTRA_ARGS="
-if "%DESIRED_PYTHON%" == "3.9" (
-    set "CONDA_EXTRA_ARGS=-c=conda-forge"
-)
 if "%CUDA_VERSION%" == "111" (
-    set "CONDA_EXTRA_ARGS=-c=conda-forge"
+    set "CONDA_EXTRA_ARGS=-c=nvidia"
 )
 if "%CUDA_VERSION%" == "112" (
-    set "CONDA_EXTRA_ARGS=-c=conda-forge"
+    set "CONDA_EXTRA_ARGS=-c=nvidia"
 )
 
 rmdir /s /q conda


### PR DESCRIPTION
We shouldn't be relying on conda-forge for our testing purposes since it
contains packages that can conflict with the current way we build
pytorch.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>