### PR TITLE
Pin mkl to 2020.2 for builds

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - numpy=1.19
     - setuptools
     - pyyaml
-    - mkl >=2019
+    - mkl=2020.2
     - mkl-include
     - typing_extensions
     - dataclasses # [py36]


### PR DESCRIPTION
Otherwise, mkl-2021.2 gets installed which contains both .so and .so.1 binaries