### PR TITLE
Fix PyTorch+Numpy integration in nightly builds

### DIFF
--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -56,11 +56,11 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
-    if "%%v" == "3.6" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing_extensions dataclasses python=%%v
-    if "%%v" == "3.7" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.8" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.9" conda create -n py!PYTHON_VERSION_STR! -y -q "numpy>=1.11" "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.6" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" cffi pyyaml boto3 cmake ninja typing_extensions dataclasses python=%%v
+    if "%%v" == "3.7" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" cffi pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.8" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.9" conda create -n py!PYTHON_VERSION_STR! -y -q "numpy>=1.11" "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
 )
 endlocal
 


### PR DESCRIPTION
Installing mkl-2021.2 renders numpy-11.1 unimportable on Windows:
From https://github.com/pytorch/builder/commit/da1928b8e919c362ada44ef5a9b2e10bc7f518f8
```
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "C:\w\b\windows\conda\envs\py36\lib\site-packages\numpy\__init__.py", line 142, in <module>
      from . import add_newdocs
    File "C:\w\b\windows\conda\envs\py36\lib\site-packages\numpy\add_newdocs.py", line 13, in <module>
      from numpy.lib import add_newdoc
    File "C:\w\b\windows\conda\envs\py36\lib\site-packages\numpy\lib\__init__.py", line 8, in <module>
      from .type_check import *
    File "C:\w\b\windows\conda\envs\py36\lib\site-packages\numpy\lib\type_check.py", line 11, in <module>
      import numpy.core.numeric as _nx
    File "C:\w\b\windows\conda\envs\py36\lib\site-packages\numpy\core\__init__.py", line 14, in <module>
      from . import multiarray
  ImportError: DLL load failed: The specified module could not be found.
  -- Could NOT find NumPy (missing: NUMPY_INCLUDE_DIR NUMPY_VERSION)
```