### PR TITLE
Add thrust_11.3 explicitly and remove bad quotes

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -242,6 +242,9 @@ DEPS_SONAME=(
     "libnvrtc-builtins.so"
     "libgomp.so.1"
 )
+
+# Try parallelizing nvcc as well
+export TORCH_NVCC_FLAGS="-Xfatbin -compress-all --threads 2"
 else
     echo "Unknown cuda version $CUDA_VERSION"
     exit 1

--- a/windows/internal/cuda_install.bat
+++ b/windows/internal/cuda_install.bat
@@ -150,15 +150,15 @@ goto cuda_common
 
 :cuda113
 
-set CUDA_INSTALL_EXE="cuda_11.3.0_465.89_win10.exe"
+set CUDA_INSTALL_EXE=cuda_11.3.0_465.89_win10.exe
 if not exist "%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%" (
     curl -k -L "https://ossci-windows.s3.amazonaws.com/%CUDA_INSTALL_EXE%" --output "%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%"
     if errorlevel 1 exit /b 1
     set "CUDA_SETUP_FILE=%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%"
-    set "ARGS=nvcc_11.3 cuobjdump_11.3 nvprune_11.3 nvprof_11.3 cupti_11.3 cublas_11.3 cublas_dev_11.3 cudart_11.3 cufft_11.3 cufft_dev_11.3 curand_11.3 curand_dev_11.3 cusolver_11.3 cusolver_dev_11.3 cusparse_11.3 cusparse_dev_11.3 npp_11.3 npp_dev_11.3 nvrtc_11.3 nvrtc_dev_11.3 nvml_dev_11.3"
+    set "ARGS=thrust_11.3 nvcc_11.3 cuobjdump_11.3 nvprune_11.3 nvprof_11.3 cupti_11.3 cublas_11.3 cublas_dev_11.3 cudart_11.3 cufft_11.3 cufft_dev_11.3 curand_11.3 curand_dev_11.3 cusolver_11.3 cusolver_dev_11.3 cusparse_11.3 cusparse_dev_11.3 npp_11.3 npp_dev_11.3 nvrtc_11.3 nvrtc_dev_11.3 nvml_dev_11.3"
 )
 
-set CUDNN_INSTALL_ZIP="cudnn-11.3-windows-x64-v8.2.0.53.zip"
+set CUDNN_INSTALL_ZIP=cudnn-11.3-windows-x64-v8.2.0.53.zip
 if not exist "%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%" (
     curl -k -L "http://s3.amazonaws.com/ossci-windows/%CUDNN_INSTALL_ZIP%" --output "%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%"
     if errorlevel 1 exit /b 1

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -2,10 +2,7 @@ set SRC_DIR=%~dp0
 
 pushd %SRC_DIR%\..
 
-if "%CUDA_VERSION%" == "102" call internal\driver_update.bat
-if "%CUDA_VERSION%" == "110" call internal\driver_update.bat
-if "%CUDA_VERSION%" == "111" call internal\driver_update.bat
-if "%CUDA_VERSION%" == "112" call internal\driver_update.bat
+if DEFINED CUDA_VERSION call internal\driver_update.bat
 if errorlevel 1 exit /b 1
 
 set "ORIG_PATH=%PATH%"

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -2,7 +2,7 @@ set SRC_DIR=%~dp0
 
 pushd %SRC_DIR%\..
 
-if DEFINED CUDA_VERSION call internal\driver_update.bat
+if not "%CUDA_VERSION%" == "cpu" call internal\driver_update.bat
 if errorlevel 1 exit /b 1
 
 set "ORIG_PATH=%PATH%"


### PR DESCRIPTION
thrust_11.3 was moved into its separate package so we need to explicitly put it as an argument.

The quotes break installation, so removing them as they're not actually necessary