### PR TITLE
[Conda] convert osx-arm64 packages

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -372,6 +372,11 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     # Extract the package for testing
     ls -lah "$output_folder"
     built_package="$(find $output_folder/ -name '*pytorch*.tar.bz2')"
+    # Set correct platform for cross compiled package
+    if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
+      conda convert "$built_package" -p osx-arm64 -f --output-dir "$output_folder"
+      built_package="$(find $output_folder/osx-arm64 -name '*pytorch*.tar.bz2')"
+    fi
 
     # Copy the built package to the host machine for persistence before testing
     if [[ -n "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -17,8 +17,8 @@ requirements:
     - numpy=1.19
     - setuptools
     - pyyaml
-    - mkl=2020.2
-    - mkl-include
+    - mkl=2020.2 # [x86_64]
+    - mkl-include # [x86_64]
     - typing_extensions
     - dataclasses # [py36]
     - ninja
@@ -29,7 +29,7 @@ requirements:
 
   run:
     - python
-    - mkl >=2018
+    - mkl >=2018 # [x86_64]
     - dataclasses # [py36]
     - libuv # [win]
     - intel-openmp # [win]

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -29,7 +29,6 @@ requirements:
 
   run:
     - python
-    - numpy >=1.19
     - mkl >=2018
     - dataclasses # [py36]
     - libuv # [win]


### PR DESCRIPTION
Conda does not correctly understand the way our cross-compilation is set up
Fix that by explicitly calling `conda convert -p osx-arm64`

Also delete numpy install dependency (as it is dynamic) and make `mkl` dependency x86_64 only