### PR TITLE
Install ninja in manywheel images

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: linux.2xlarge
     strategy:
       matrix:
-        cuda_version: ["10.2", "11.1"]
+        cuda_version: ["11.3"]
     env:
       GPU_ARCH_TYPE: cuda
       GPU_ARCH_VERSION: ${{ matrix.cuda_version }}
@@ -25,6 +25,8 @@ jobs:
       - name: Build Docker Image
         run: |
           manywheel/build_docker.sh
+        env:
+          WITH_PUSH: true
   build-docker-rocm:
     runs-on: linux.2xlarge
     strategy:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Build Docker Image
         run: |
           manywheel/build_docker.sh
-        env:
-          WITH_PUSH: true
   build-docker-rocm:
     runs-on: linux.2xlarge
     strategy:

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -137,6 +137,9 @@ ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/roo
 RUN yum install -y cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 
+# ninja
+RUN pip install ninja
+
 FROM cpu_final as cuda_final
 RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}
 COPY --from=cuda     /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -138,7 +138,8 @@ RUN yum install -y cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 # ninja
-RUN pip install ninja
+RUN yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm
+RUN yum install -y ninja-build
 
 FROM cpu_final as cuda_final
 RUN rm -rf /usr/local/cuda-${BASE_CUDA_VERSION}


### PR DESCRIPTION
This way we can use ninja in our binary builds for manywheel, based on instructions from: https://centos.pkgs.org/7/okey-x86_64/ninja-build-1.8.2-1.el7.x86_64.rpm.html