### PR TITLE
enable credentials for pushing manylinux images

### DIFF
--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       master
+    paths:
+      - windows/internal/build_magma.bat
   pull_request:
     paths:
       - windows/internal/build_magma.bat

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -1,6 +1,9 @@
 name: Build manywheel docker images
 
 on:
+  push:
+    branches:
+      master
   pull_request:
     paths:
       - manywheel/Dockerfile
@@ -9,6 +12,9 @@ on:
 env:
   DOCKER_REGISTRY: "docker.io"
   DOCKER_BUILDKIT: 1
+  DOCKER_ID: ${{ secrets.DOCKER_ID }}
+  DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+  WITH_PUSH: ${{ github.event_name == 'push' }}
 
 jobs:
   build-docker-cuda:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       master
+    paths:
+      - manywheel/Dockerfile
+      - 'common/*'
   pull_request:
     paths:
       - manywheel/Dockerfile
@@ -28,6 +31,11 @@ jobs:
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
+      - name: Authenticate if WITH_PUSH
+        run: |
+          if [[ "${WITH_PUSH}" == true ]]; then
+            echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password--stdin
+          fi
       - name: Build Docker Image
         run: |
           manywheel/build_docker.sh
@@ -42,6 +50,11 @@ jobs:
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
+      - name: Authenticate if WITH_PUSH
+        run: |
+          if [[ "${WITH_PUSH}" == true ]]; then
+            echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password--stdin
+          fi
       - name: Build Docker Image
         run: |
           manywheel/build_docker.sh
@@ -50,6 +63,11 @@ jobs:
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
+      - name: Authenticate if WITH_PUSH
+        run: |
+          if [[ "${WITH_PUSH}" == true ]]; then
+            echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password--stdin
+          fi
       - name: Build Docker Image
         run: |
           manywheel/build_docker.sh

--- a/conda/build_docker.sh
+++ b/conda/build_docker.sh
@@ -42,7 +42,7 @@ if [[ "${DOCKER_TAG}" =~ ^cuda* ]]; then
   )
 fi
 
-if [[ -n "${WITH_PUSH:-}" ]]; then
+if [[ "${WITH_PUSH:-}" == true ]]; then
   (
     set -x
     docker push "pytorch/conda-builder:${DOCKER_TAG}"

--- a/libtorch/build_docker.sh
+++ b/libtorch/build_docker.sh
@@ -28,7 +28,7 @@ esac
 )
 
 
-if [[ -n "${WITH_PUSH:-}" ]]; then
+if [[ "${WITH_PUSH:-}" == true ]]; then
   (
     set -x
     docker push pytorch/libtorch-cxx11-builder:${DOCKER_TAG}

--- a/manywheel/README.md
+++ b/manywheel/README.md
@@ -8,7 +8,7 @@ To build all docker images you can use the convenience script:
 # Build without pushing
 manywheel/build_all_docker.sh
 # Build with pushing
-WITH_PUSH=1 manywheel/build_all_docker.sh
+WITH_PUSH=true manywheel/build_all_docker.sh
 ```
 
 To build a specific docker image use:
@@ -17,5 +17,12 @@ To build a specific docker image use:
 # GPU_ARCH_VERSION is GPU_ARCH_TYPE dependent, see manywheel/build_all_docker.sh for examples
 GPU_ARCH_TYPE=cuda GPU_ARCH_VERSION=11.1 manywheel/build_docker.sh
 # Build with pushing
-WITH_PUSH=1 GPU_ARCH_TYPE=cuda GPU_ARCH_VERSION=11.1 manywheel/build_docker.sh
+WITH_PUSH=true GPU_ARCH_TYPE=cuda GPU_ARCH_VERSION=11.1 manywheel/build_docker.sh
 ```
+
+**DISCLAIMER for WITH_PUSH**:
+If you'd like to use WITH_PUSH, you must set it to exactly `true`, not `1` nor `ON` nor even `TRUE`, as our scripts
+check for exact string equality to enable push functionality. The reason for this rigidity is due to the how we
+calculate WITH_PUSH in our GHA workflow YAMLs. Currently, we usually enable push based on the workflow trigger, which
+when we query with an expression like `${{ github.event_name == 'push' }}` returns either `true` or `false`. Thus, we
+adapt our scripts to fit with this model.

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -60,7 +60,6 @@ DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/manylinux-builder:${DOCKER_TAG}
 if [[ "${WITH_PUSH}" == true ]]; then
     (
         set -x
-        echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password--stdin
         docker push "${DOCKER_IMAGE}"
         docker push "${LEGACY_DOCKER_IMAGE}"
     )

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -57,9 +57,10 @@ DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/manylinux-builder:${DOCKER_TAG}
     docker tag ${DOCKER_IMAGE} ${LEGACY_DOCKER_IMAGE}
 )
 
-if [[ -n ${WITH_PUSH} ]]; then
+if [[ "${WITH_PUSH}" == true ]]; then
     (
         set -x
+        echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password--stdin
         docker push "${DOCKER_IMAGE}"
         docker push "${LEGACY_DOCKER_IMAGE}"
     )


### PR DESCRIPTION
Adds a mechanism so that the build jobs will push the images when the PR is merged to master.

Uses secrets DOCKER_ID and DOCKER_TOKEN for Docker Hub.