### PR TITLE
Build wheels with debug info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ node_modules
 
 # Analytics cache folder
 cache/
+.vscode/


### PR DESCRIPTION
This edits the wheel build to also make `libtorch_cpu.so.dbg` (and build `libtorch_cpu` in RelWithDebInfo) as an artifact (similar to what we already do for libtorch builds).

NB: This relies on https://github.com/pytorch/pytorch/pull/58685, which needs to land first (that one is a no-op when there is no debug info but this one will break tests without that PR)