### PR TITLE
Add other relevant files as triggers to pushing the manywheel images

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -5,12 +5,16 @@ on:
     branches:
       master
     paths:
+      - .github/workflows/build-manywheel-images.yml
       - manywheel/Dockerfile
+      - manywheel/build_docker.sh
       - 'common/*'
   pull_request:
     paths:
+      - .github/workflows/build-manywheel-images.yml
       - manywheel/Dockerfile
       - 'common/*'
+      - manywheel/build_docker.sh
 
 env:
   DOCKER_REGISTRY: "docker.io"


### PR DESCRIPTION
This way, I can finally actually push the 11.3 image.

This PR when merged will also push the rocm and cpu images (the update is they will now have ninja), which may not be a desired side effect.