### PR TITLE
Enable push for libtorch and conda Docker images

### DIFF
--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -1,14 +1,25 @@
 name: Build conda docker images
 
 on:
+  push:
+    branches:
+      master
+    paths:
+      - conda/Dockerfile
+      - 'common/*'
+      - .github/workflows/build-conda-images.yml
   pull_request:
     paths:
       - conda/Dockerfile
       - 'common/*'
+      - .github/workflows/build-conda-images.yml
 
 env:
   DOCKER_REGISTRY: "docker.io"
   DOCKER_BUILDKIT: 1
+  DOCKER_ID: ${{ secrets.DOCKER_ID }}
+  DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+  WITH_PUSH: ${{ github.event_name == 'push' }}
 
 jobs:
   build-docker:
@@ -19,8 +30,13 @@ jobs:
     env:
       CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
-      - name: Checkout PyTorch
+      - name: Checkout PyTorch builder
         uses: actions/checkout@v2
+      - name: Authenticate if WITH_PUSH
+        run: |
+          if [[ "${WITH_PUSH}" == true ]]; then
+            echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password-stdin
+          fi
       - name: Build Docker Image
         run: |
           conda/build_docker.sh

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -1,14 +1,25 @@
 name: Build libtorch docker images
 
 on:
+  push:
+    branches:
+      master
+    paths:
+      - libtorch/Dockerfile
+      - 'common/*'
+      - .github/workflows/build-libtorch-images.yml
   pull_request:
     paths:
       - libtorch/Dockerfile
       - 'common/*'
+      - .github/workflows/build-libtorch-images.yml
 
 env:
   DOCKER_REGISTRY: "docker.io"
   DOCKER_BUILDKIT: 1
+  DOCKER_ID: ${{ secrets.DOCKER_ID }}
+  DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+  WITH_PUSH: ${{ github.event_name == 'push' }}
 
 jobs:
   build-docker:
@@ -19,8 +30,13 @@ jobs:
     env:
       CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
-      - name: Checkout PyTorch
+      - name: Checkout PyTorch builder
         uses: actions/checkout@v2
+      - name: Authenticate if WITH_PUSH
+        run: |
+          if [[ "${WITH_PUSH}" == true ]]; then
+            echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password-stdin
+          fi
       - name: Build Docker Image
         run: |
           libtorch/build_docker.sh

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -33,7 +33,7 @@ jobs:
       GPU_ARCH_TYPE: cuda
       GPU_ARCH_VERSION: ${{ matrix.cuda_version }}
     steps:
-      - name: Checkout PyTorch
+      - name: Checkout PyTorch builder
         uses: actions/checkout@v2
       - name: Authenticate if WITH_PUSH
         run: |

--- a/conda/build_docker.sh
+++ b/conda/build_docker.sh
@@ -33,19 +33,35 @@ esac
     ${TOPDIR}
 )
 
+DOCKER_IMAGE="pytorch/conda-builder:${DOCKER_TAG}"
+GITHUB_REF=${GITHUB_REF:-$(git symbolic-ref -q HEAD || git describe --tags --exact-match)}
+GIT_BRANCH_NAME=${GITHUB_REF##*/}
+GIT_COMMIT_SHA=${GITHUB_SHA:-$(git rev-parse HEAD)}
+DOCKER_IMAGE_BRANCH_TAG=${DOCKER_IMAGE}-${GIT_BRANCH_NAME}
+DOCKER_IMAGE_SHA_TAG=${DOCKER_IMAGE}-${GIT_COMMIT_SHA}
+
 if [[ "${DOCKER_TAG}" =~ ^cuda* ]]; then
   # Meant for legacy scripts since they only do the version without the "."
   # TODO: Eventually remove this
   (
     set -x
-    docker tag "pytorch/conda-builder:${DOCKER_TAG}" "pytorch/conda-builder:cuda${CUDA_VERSION/./}"
+    docker tag ${DOCKER_IMAGE} "pytorch/conda-builder:cuda${CUDA_VERSION/./}"
   )
+fi
+
+if [[ -n ${GITHUB_REF} ]]; then
+    docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_BRANCH_TAG}
+    docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_SHA_TAG}
 fi
 
 if [[ "${WITH_PUSH:-}" == true ]]; then
   (
     set -x
-    docker push "pytorch/conda-builder:${DOCKER_TAG}"
+    docker push "${DOCKER_IMAGE}"
+    if [[ -n ${GITHUB_REF} ]]; then
+        docker push "${DOCKER_IMAGE_BRANCH_TAG}"
+        docker push "${DOCKER_IMAGE_SHA_TAG}"
+    fi
     if [[ "${DOCKER_TAG}" =~ ^cuda* ]]; then
       docker push "pytorch/conda-builder:cuda${CUDA_VERSION/./}"
     fi


### PR DESCRIPTION
Using credentials to push conda and libtorch images (manywheel already done) in GHA.

Tags them with branch name and commit SHA--this PR also fixes #772