### PR TITLE
ROCm 4.2 manywheel image should use MIOpen branch rocm-4.2.x-staging

### DIFF
--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -97,7 +97,7 @@ elif [[ ${ROCM_VERSION} == 4.1 ]]; then
     MIOPEN_BRANCH="rocm-4.1.x-staging"
 elif [[ ${ROCM_VERSION} == 4.2 ]]; then
     MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx803_36;gfx803_64;gfx900_56;gfx900_64;gfx906_60;gfx906_64;gfx90878"
-    MIOPEN_BRANCH="rocm-4.2.x"
+    MIOPEN_BRANCH="rocm-4.2.x-staging"
 else
     echo "Unhandled ROCM_VERSION ${ROCM_VERSION}"
     exit 1


### PR DESCRIPTION
Fixes the interaction of the miopen kernels deb package when installed with the torch+rocm4.2 wheel.  The base image for rocm centos was also recently updated to fix a rocm thunk bug affecting linux cgroups.  This PR will force the rebuild of the image and pick up the underlying fix.