### PR TITLE
Add hack for debug info for release

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -143,6 +143,13 @@ fi
 # for master / release branches)
 BUILD_DEBUG_INFO=${BUILD_DEBUG_INFO:=0}
 
+# TODO: Delete within a few days of 6/15/21! This is a hack to get debug info
+# building on PRs without merging in the change to PyTorch proper that sets
+# BUILD_DEBUG_INFO=1
+if [[ $CIRCLE_BRANCH == release/1.9 ]]; then
+    export BUILD_DEBUG_INFO=1
+fi
+
 if [[ $BUILD_DEBUG_INFO == "1" ]]; then
     echo "Building wheel and debug info"
 else


### PR DESCRIPTION
This adds a temporary fix to kick off debug builds for the release. Once we land this we can re-run the relevant CircleCI jobs and they'll build debug info without having to change anything in PyTorch. Once those are done we need to save the artifacts and we can revert this change.

This is against master instead of release/1.9 since the branch pinning on the PyTorch release branch is actually broken, see [this log](https://app.circleci.com/pipelines/github/pytorch/pytorch/336681/workflows/a76057f8-742b-4a45-a61e-12c674916506/jobs/14139734), the commit from "Checkout pytorch/builder repo" is on master and not release/1.9
