### PR TITLE
Add breakpad to nightly images

### DIFF
--- a/common/install_breakpad.sh
+++ b/common/install_breakpad.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -ex
+
+git clone https://github.com/driazati/breakpad.git
+pushd breakpad
+
+# breakpad has no actual releases, so this is pinned to the top commit from
+# main when this was forked (including the one patch commit). This uses a fork
+# of the breakpad mainline that automatically daisy-chains out to any previously
+# installed signal handlers (instead of overwriting them).
+git checkout 5485e473ed46d065e05489e50dfc59d90dfd7e22
+
+git clone https://chromium.googlesource.com/linux-syscall-support src/third_party/lss
+pushd src/third_party/lss
+# same as with breakpad, there are no real releases for this repo so use a
+# commit as the pin
+git checkout e1e7b0ad8ee99a875b272c8e33e308472e897660
+popd
+
+./configure
+make
+make install
+popd
+rm -rf breakpad

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -62,6 +62,10 @@ ADD ./common/install_patchelf.sh install_patchelf.sh
 RUN bash ./install_patchelf.sh && rm install_patchelf.sh
 RUN cp $(which patchelf) /patchelf
 
+FROM base as breakpad
+ADD ./common/install_breakpad.sh install_breakpad.sh
+RUN bash ./install_breakpad.sh
+
 FROM base as magma
 ARG BASE_CUDA_VERSION=10.1
 # Install magma
@@ -124,6 +128,8 @@ COPY --from=libpng             /usr/local/include/png*               /usr/local/
 COPY --from=libpng             /usr/local/include/libpng*            /usr/local/include/
 COPY --from=libpng             /usr/local/lib/libpng*                /usr/local/lib/
 COPY --from=libpng             /usr/local/lib/pkgconfig              /usr/local/lib/pkgconfig
+COPY --from=breakpad           /usr/local/lib/libbreakpad*           /usr/local/lib
+COPY --from=breakpad           /usr/local/include/breakpad           /usr/local/include/
 
 FROM common as cpu_final
 ARG BASE_CUDA_VERSION=10.1


### PR DESCRIPTION
Right now we include this library on CI images which gets picked up and built in the master binary builds, but not on nightlies which people actually use. This adds it there as well so that users can send in crash reports (and putting it here will make it be picked up for 1.10)

https://github.com/pytorch/pytorch/blob/1054ad5af3308959940971a1ebd12279befb6635/.circleci/docker/ubuntu/Dockerfile#L86-L90