### PR TITLE
libtorch: Move libtorch images to bionic

### DIFF
--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -1,5 +1,7 @@
 ARG BASE_TARGET=base
-FROM nvidia/cuda:9.2-devel-ubuntu16.04 as base
+FROM nvidia/cuda:10.2-devel-ubuntu18.04 as base
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get clean && apt-get update
 RUN apt-get install -y curl locales git-all autoconf automake make cmake wget unzip

--- a/libtorch/build_docker.sh
+++ b/libtorch/build_docker.sh
@@ -16,14 +16,16 @@ case ${CUDA_VERSION} in
     ;;
 esac
 
+DOCKER=${DOCKER:-docker}
+
 (
   set -x
-  docker build \
+  ${DOCKER} build \
     --target final \
     --build-arg "BASE_TARGET=${BASE_TARGET}" \
     --build-arg "CUDA_VERSION=${CUDA_VERSION}" \
     -t "pytorch/libtorch-cxx11-builder:${DOCKER_TAG}" \
-    -f "${TOPDIR}/libtorch/ubuntu16.04/Dockerfile" \
+    -f "${TOPDIR}/libtorch/Dockerfile" \
     ${TOPDIR}
 )
 
@@ -35,25 +37,25 @@ DOCKER_IMAGE_BRANCH_TAG=${DOCKER_IMAGE}-${GIT_BRANCH_NAME}
 DOCKER_IMAGE_SHA_TAG=${DOCKER_IMAGE}-${GIT_COMMIT_SHA}
 
 if [[ -n ${GITHUB_REF} ]]; then
-    docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_BRANCH_TAG}
-    docker tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_SHA_TAG}
+    ${DOCKER} tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_BRANCH_TAG}
+    ${DOCKER} tag ${DOCKER_IMAGE} ${DOCKER_IMAGE_SHA_TAG}
 fi
 
 if [[ "${WITH_PUSH:-}" == true ]]; then
   (
     set -x
-    docker push "${DOCKER_IMAGE}"
+    ${DOCKER} push "${DOCKER_IMAGE}"
     if [[ -n ${GITHUB_REF} ]]; then
-        docker push "${DOCKER_IMAGE_BRANCH_TAG}"
-        docker push "${DOCKER_IMAGE_SHA_TAG}"
+        ${DOCKER} push "${DOCKER_IMAGE_BRANCH_TAG}"
+        ${DOCKER} push "${DOCKER_IMAGE_SHA_TAG}"
     fi
   )
   # For legacy .circleci/config.yml generation scripts
   if [[ "${CUDA_VERSION}" != "cpu" ]]; then
     (
       set -x
-      docker tag ${DOCKER_IMAGE} pytorch/libtorch-cxx11-builder:${DOCKER_TAG/./}
-      docker push pytorch/libtorch-cxx11-builder:${DOCKER_TAG/./}
+      ${DOCKER} tag ${DOCKER_IMAGE} pytorch/libtorch-cxx11-builder:${DOCKER_TAG/./}
+      ${DOCKER} push pytorch/libtorch-cxx11-builder:${DOCKER_TAG/./}
     )
   fi
 fi


### PR DESCRIPTION
Xenial is EOL, let's move to bionic

Relates to https://github.com/pytorch/pytorch/issues/61460

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>