### PR TITLE
Update okay repo from 1.1 to 1.5

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -144,7 +144,7 @@ RUN yum install -y cmake3 && \
     ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 # ninja
-RUN yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm
+RUN yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-5.el7.noarch.rpm
 RUN yum install -y ninja-build
 
 FROM cpu_final as cuda_final


### PR DESCRIPTION
Should fix `Public key for lame-3.100-6.el7.x86_64.rpm is not installed` as seen here: https://app.circleci.com/pipelines/github/pytorch/vision/9406/workflows/2d6246b3-7b22-4e20-8254-7f5f279933bc/jobs/693099