### PR TITLE
github_analyze.py works with any Pytorch repo

### DIFF
--- a/analytics/github_analyze.py
+++ b/analytics/github_analyze.py
@@ -283,7 +283,7 @@ def print_contributor_stats(commits, repo, delta: Optional[timedelta] = None) ->
     authors: Dict[str, int] = {}
     now = datetime.now()
     if delta is None:
-        delta = timedelta(days=365) #till July 1 2020
+        delta = timedelta(days=365)
     for commit in commits:
         date, author = commit.commit_date, commit.author
         if now - date > delta:

--- a/analytics/github_analyze.py
+++ b/analytics/github_analyze.py
@@ -322,7 +322,7 @@ def main():
     repo = GitRepo(args.repo_path, remote)
     print("Parsing git history...", end='', flush=True)
     start_time = time.time()
-    if repo_path == "ort":
+    if repo_path in ["ort", "kineto"]:
         x = repo._run_git_log(f"{remote}/main")
     else:
         x = repo._run_git_log(f"{remote}/master")


### PR DESCRIPTION
#799 
Made it easier to get telemetry for any public Pytorch project

So now you can you do something like
1. `gh repo clone pytorch/vision`
2. `python3 github_analyze.py --contributor-stats --repo-path vision`