### PR TITLE
Nvcc parallelize 11.3 conda, unpin conda-package-handling

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -353,7 +353,7 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     # Build the package
     echo "Build $build_folder for Python version $py_ver"
     conda config --set anaconda_upload no
-    conda install -y "conda-package-handling=1.7.3"
+    conda install -y conda-package-handling
 
     ADDITIONAL_CHANNELS=""
     echo "Calling conda-build at $(date)"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -353,10 +353,7 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     # Build the package
     echo "Build $build_folder for Python version $py_ver"
     conda config --set anaconda_upload no
-    # There was a bug that was introduced in conda-package-handling >= 1.6.1 that makes archives
-    # above a certain size fail out when attempting to extract
-    # see: https://github.com/conda/conda-package-handling/issues/71
-    conda install -y "conda-package-handling=1.6.0"
+    conda install -y "conda-package-handling=1.7.3"
 
     ADDITIONAL_CHANNELS=""
     echo "Calling conda-build at $(date)"

--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -19,6 +19,7 @@ if "%build_with_cuda%" == "" goto cuda_flags_end
 
 set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%desired_cuda%
 set CUDA_BIN_PATH=%CUDA_PATH%\bin
+set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
 set TORCH_CUDA_ARCH_LIST=3.7+PTX;5.0
 if "%desired_cuda%" == "8.0" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1
 if "%desired_cuda%" == "9.0" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;7.0
@@ -29,8 +30,10 @@ if "%desired_cuda%" == "10.2" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.
 if "%desired_cuda%" == "11.0" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1;7.0;7.5;8.0
 if "%desired_cuda%" == "11.1" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1;7.0;7.5;8.0;8.6
 if "%desired_cuda%" == "11.2" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1;7.0;7.5;8.0;8.6
-if "%desired_cuda%" == "11.3" set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1;7.0;7.5;8.0;8.6
-set TORCH_NVCC_FLAGS=-Xfatbin -compress-all
+if "%desired_cuda%" == "11.3" (
+    set TORCH_CUDA_ARCH_LIST=%TORCH_CUDA_ARCH_LIST%;6.0;6.1;7.0;7.5;8.0;8.6
+    set TORCH_NVCC_FLAGS=-Xfatbin -compress-all --threads 2
+)
 
 :cuda_flags_end
 


### PR DESCRIPTION
Will be tested in pytorch/pytorch#61867.

This is an attempt to fix timeouts in binary windows conda for cuda 11.3, like https://app.circleci.com/pipelines/github/pytorch/pytorch/352825/workflows/5d28fc77-70de-48a1-ab33-abdd6315e24d/jobs/14874640

This also unpins conda-package-handling, as the 1.6 version was no longer compatible with python 3.9, and the updated versions resolve previous issues we had with 1.6.1. (see https://github.com/conda/conda-package-handling/issues/71 for more context).