### PR TITLE
upgrade conda-package-handling to 1.7.3

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -353,10 +353,10 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     # Build the package
     echo "Build $build_folder for Python version $py_ver"
     conda config --set anaconda_upload no
-    # There was a bug that was introduced in conda-package-handling >= 1.6.1 that makes archives
-    # above a certain size fail out when attempting to extract
-    # see: https://github.com/conda/conda-package-handling/issues/71
-    conda install -y "conda-package-handling=1.6.0"
+
+    conda env list
+    python --version
+    conda install -y "conda-package-handling=1.7.3"
 
     ADDITIONAL_CHANNELS=""
     echo "Calling conda-build at $(date)"


### PR DESCRIPTION
1. It looks https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe become to install python3.9 in some regions. It will break ci/binary.
https://app.circleci.com/pipelines/github/pytorch/pytorch/354210/workflows/3a013fa5-f09d-45ff-80e9-6f42342212ce/jobs/14929904
![image](https://user-images.githubusercontent.com/16190118/126606193-2b6c05dc-3f40-4f54-9a36-ee9383a3abec.png)
![image](https://user-images.githubusercontent.com/16190118/126606236-dbe11a8c-666e-4aba-8a91-19e6ea71c4ec.png)
![image](https://user-images.githubusercontent.com/16190118/126606256-15926801-e868-4176-9253-d4855bc226dd.png)

2. one solution is to upgrade conda-package-handling to 1.7.3, since the https://github.com/conda/conda-package-handling/issues/71 is fixed in 1.7.3
https://github.com/conda/conda-package-handling/releases/tag/1.7.3

verification link
https://app.circleci.com/pipelines/github/pytorch/pytorch/354210/workflows/3a013fa5-f09d-45ff-80e9-6f42342212ce/jobs/14930205