### PR TITLE
conda: Remove conda-package-handling pin from dockerfile

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -37,9 +37,6 @@ FROM base as conda
 # Install Anaconda
 ADD ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh
-# conda-package-handling fails out for larger tarballs,
-# see: https://github.com/conda/conda-package-handling/issues/71
-RUN /opt/conda/bin/conda install -y conda-package-handling=1.6.0
 
 # Install CUDA
 FROM base as cuda


### PR DESCRIPTION
Should've been taken care of upstream

Follow up to https://github.com/pytorch/builder/pull/807

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>