### PR TITLE
Cherry pick numpy fix

### DIFF
--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -95,7 +95,7 @@ if errorlevel 1 exit /b 1
 call %CONDA_HOME%\condabin\activate.bat testenv
 if errorlevel 1 exit /b 1
 
-call conda install %CONDA_EXTRA_ARGS% -yq future protobuf six
+call conda install %CONDA_EXTRA_ARGS% -yq future protobuf six numpy
 if ERRORLEVEL 1 exit /b 1
 
 set /a CUDA_VER=%CUDA_VERSION%


### PR DESCRIPTION
Numpy is an optional dependency for PyTorch, but not for caffe2.

This is causing build errors in the LTS branch as can be seen here
https://app.circleci.com/pipelines/github/pytorch/pytorch/351608/workflows/8a9ddd77-7145-40ac-b6c7-ed5052875e10/jobs/14944090