### PR TITLE
aarch64 OpenBLAS: set NUM_THREADS=64 to support aarch64 instances upto 64 cores

### DIFF
--- a/build_aarch64_wheel.py
+++ b/build_aarch64_wheel.py
@@ -183,7 +183,7 @@ def install_condaforge(host: RemoteHost) -> None:
 def build_OpenBLAS(host: RemoteHost, git_clone_flags: str = "") -> None:
     print('Building OpenBLAS')
     host.run_cmd(f"git clone https://github.com/xianyi/OpenBLAS -b v0.3.15 {git_clone_flags}")
-    host.run_cmd("pushd OpenBLAS; make USE_OPENMP=1 NO_SHARED=1 -j8; sudo make USE_OPENMP=1 NO_SHARED=1 install; popd")
+    host.run_cmd("pushd OpenBLAS; make NUM_THREADS=64 USE_OPENMP=1 NO_SHARED=1 -j8; sudo make NUM_THREADS=64 USE_OPENMP=1 NO_SHARED=1 install; popd")
 
 
 def build_FFTW(host: RemoteHost, git_clone_flags: str = "") -> None:


### PR DESCRIPTION
This patch sets the max thread count allowed on any instance is 64.
However, the actual openblas threads used are controlled by application runtime
settings.