### PR TITLE
Remove conda forge flag from run_tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -61,7 +61,6 @@ fi
 
 # Environment initialization
 if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
-    EXTRA_CONDA_FLAGS="-c=conda-forge"
     # Why are there two different ways to install dependencies after installing an offline package?
     # The "cpu" conda package for pytorch doesn't actually depend on "cpuonly" which means that
     # when we attempt to update dependencies using "conda update --all" it will attempt to install


### PR DESCRIPTION
This flag is causing CI to fail on Mac because it's installing an older version of Pytorch 1.4 https://app.circleci.com/pipelines/github/pytorch/pytorch/356250/workflows/d8631609-61fc-4433-858e-b878df989356/jobs/15143481/steps?invite=true#step-107-2709

This PR is a partial cherry pick of https://github.com/pytorch/builder/commit/b4dc2d614e436fe3d2ac6a4c288849cfe0310026