### PR TITLE
Add numpy for caffe2 conda mac installation

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -77,11 +77,7 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
       retry conda update -yq --all -c defaults -c pytorch -c numba/label/dev
     fi
     # Install the testing dependencies
-    retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
-    if [[ "$package_type" == wheel ]]; then
-      # Numpy dependency is now dynamic but old caffe2 test assume its always there
-      retry conda install -yq numpy
-    fi
+    retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml numpy
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true


### PR DESCRIPTION
Caffe2 does not actually assume that numpy is already installed https://app.circleci.com/pipelines/github/pytorch/pytorch/356250/workflows/d8631609-61fc-4433-858e-b878df989356/jobs/15168742

From the logs 

The command `conda install -y -c pytorch cpuonly` is upgrading pytorch from 1.8.2 to 1.9.0

And then it's running

`conda install -yq future hypothesis protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml` without numpy 