### PR TITLE
check why start /wait not working

### DIFF
--- a/windows/internal/cuda_install.bat
+++ b/windows/internal/cuda_install.bat
@@ -184,8 +184,22 @@ if not exist "%SRC_DIR%\temp_build\gpu_driver_dlls.zip" (
 echo Installing CUDA toolkit...
 7z x %CUDA_SETUP_FILE% -o"%SRC_DIR%\temp_build\cuda"
 pushd "%SRC_DIR%\temp_build\cuda"
+
+rem Why find ":", if no process, the output is INFO: No tasks are running which match the specified criteria.
+tasklist /fi "imagename eq msiexec.exe" | find ":" > nul
+if %ERRORLEVEL% NEQ 0 (
+    echo There's another installer running.
+)
+
 start /wait setup.exe -s %ARGS%
+
+tasklist /fi "imagename eq setup.exe" | find ":" > nul
+if %ERRORLEVEL% NEQ 0 (
+    echo start /wait not working.
+)
+
 popd
+
 
 echo Installing VS integration...
 if "%VC_YEAR%" == "2017" (

--- a/windows/internal/cuda_install.bat
+++ b/windows/internal/cuda_install.bat
@@ -186,14 +186,14 @@ echo Installing CUDA toolkit...
 pushd "%SRC_DIR%\temp_build\cuda"
 
 rem Why find ":", if no process, the output is INFO: No tasks are running which match the specified criteria.
-tasklist /fi "imagename eq msiexec.exe" | find ":" > nul
+tasklist /fi "imagename eq msiexec.exe" | find ":"
 if %ERRORLEVEL% NEQ 0 (
     echo There's another installer running.
 )
 
 start /wait setup.exe -s %ARGS%
 
-tasklist /fi "imagename eq setup.exe" | find ":" > nul
+tasklist /fi "imagename eq setup.exe" | find ":"
 if %ERRORLEVEL% NEQ 0 (
     echo start /wait not working.
 )


### PR DESCRIPTION
For nightly build, the CI might be broken due to random error
![image](https://user-images.githubusercontent.com/16190118/128455202-eb69973a-3ec2-4190-8061-0491b927e235.png)
https://app.circleci.com/pipelines/github/pytorch/pytorch/360491/workflows/6939cfb1-689b-4af6-a3fe-31b1b9faddc9/jobs/15203767.

The reason might be there's another installer running or windows is upgrading.

@malfet @seemethere @janeyx99 
since it's a random error, I need to add some logs to detect what's happened at that time as the first step.

It's verified that this PR won't break current CI.
https://app.circleci.com/pipelines/github/pytorch/pytorch/361040/workflows/c2ce37f9-7b85-46f4-92a5-98352488a0ca/jobs/15226815
https://github.com/pytorch/pytorch/pull/62874