### PR TITLE
[Win] Call randomtemp from launcher wrapper script

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -51,7 +51,6 @@ IF "%USE_SCCACHE%" == "1" (
     mkdir %SRC_DIR%\tmp_bin
     curl -k https://s3.amazonaws.com/ossci-windows/sccache.exe --output %SRC_DIR%\tmp_bin\sccache.exe
     curl -k https://s3.amazonaws.com/ossci-windows/sccache-cl.exe --output %SRC_DIR%\tmp_bin\sccache-cl.exe
-    copy %SRC_DIR%\tmp_bin\sccache.exe %SRC_DIR%\tmp_bin\nvcc.exe
     set "PATH=%SRC_DIR%\tmp_bin;%PATH%"
     set SCCACHE_IDLE_TIMEOUT=1500
 )
@@ -66,10 +65,6 @@ curl https://s3.amazonaws.com/ossci-windows/magma_%MAGMA_VERSION%_cuda%desired_c
 7z x -aoa magma_%MAGMA_VERSION%_cuda%desired_cuda_nodot%_release.7z -omagma_cuda%desired_cuda_nodot%_release
 set MAGMA_HOME=%cd%\magma_cuda%desired_cuda_nodot%_release
 
-IF "%USE_SCCACHE%" == "1" (
-    set CUDA_NVCC_EXECUTABLE=%SRC_DIR%\tmp_bin\nvcc
-)
-
 set "PATH=%CUDA_BIN_PATH%;%PATH%"
 
 if "%desired_cuda_nodot%" == "80" (
@@ -81,15 +76,15 @@ if "%desired_cuda_nodot%" == "80" (
 :: code: https://github.com/peterjc123/randomtemp-rust
 :: issue: https://github.com/pytorch/pytorch/issues/25393
 ::
-:: Previously, CMake uses CUDA_NVCC_EXECUTABLE for finding nvcc and then
-:: the calls are redirected to sccache. sccache looks for the actual nvcc
-:: in PATH, and then pass the arguments to it.
-:: Currently, randomtemp is placed before sccache (%TMP_DIR_WIN%\bin\nvcc)
-:: so we are actually pretending sccache instead of nvcc itself.
-curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.3/randomtemp.exe --output %SRC_DIR%\tmp_bin\randomtemp.exe
-set RANDOMTEMP_EXECUTABLE=%SRC_DIR%\tmp_bin\nvcc.exe
-set CUDA_NVCC_EXECUTABLE=%SRC_DIR%\tmp_bin\randomtemp.exe
-set RANDOMTEMP_BASEDIR=%SRC_DIR%\tmp_bin
+:: CMake requires a single command as CUDA_NVCC_EXECUTABLE, so we push the wrappers
+:: randomtemp.exe and sccache.exe into a batch file which CMake invokes.
+curl -kL https://github.com/peterjc123/randomtemp-rust/releases/download/v0.4/randomtemp.exe --output %SRC_DIR%\tmp_bin\randomtemp.exe
+echo @"%SRC_DIR%\tmp_bin\randomtemp.exe" "%SRC_DIR%\tmp_bin\sccache.exe" "%CUDA_PATH%\bin\nvcc.exe" %%* > "%SRC_DIR%/tmp_bin/nvcc.bat"
+cat %SRC_DIR%/tmp_bin/nvcc.bat
+set CUDA_NVCC_EXECUTABLE=%SRC_DIR%/tmp_bin/nvcc.bat
+:: CMake doesn't accept back-slashes in the path
+for /F "usebackq delims=" %%n in (`cygpath -m "%CUDA_PATH%\bin\nvcc.exe"`) do set CMAKE_CUDA_COMPILER=%%n
+set CMAKE_CUDA_COMPILER_LAUNCHER=%SRC_DIR%\tmp_bin\randomtemp.exe;%SRC_DIR%\tmp_bin\sccache.exe
 
 :cuda_end
 

--- a/conda/setup_ccache.sh
+++ b/conda/setup_ccache.sh
@@ -27,3 +27,4 @@ fi
 
 export PATH=~/ccache/lib:$PATH
 export CUDA_NVCC_EXECUTABLE=~/ccache/cuda/nvcc
+export CMAKE_CUDA_COMPILER_LAUNCHER=~/ccache/bin/ccache


### PR DESCRIPTION
Tested in pytorch/pytorch#63782

This updates the windows builds to use `randomtemp.exe` as a compiler launcher, instead of trying to make it spoof nvcc. Since `CUDA_NVCC_EXECUTABLE` has to be a single file, I write `randomtemp.exe sccache.exe nvcc.exe [remaining args]` into a batch file, and pass that to CMake. 

This is needed for pytorch/pytorch#62445 since some CMake versions need `CMAKE_CUDA_COMPILER` to be the real nvcc, in order to find the CUDA toolkit directory.

cc @malfet