### PR TITLE
[libtorch] Populate /opt/python in docker images

### DIFF
--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -17,6 +17,11 @@ FROM base as openssl
 ADD ./common/install_openssl.sh install_openssl.sh
 RUN bash ./install_openssl.sh && rm install_openssl.sh
 
+# Install python
+FROM base as python
+COPY manywheel/build_scripts /build_scripts
+RUN bash build_scripts/build.sh && rm -r build_scripts
+
 FROM base as intel
 # Install MKL
 ADD ./common/install_mkl.sh install_mkl.sh


### PR DESCRIPTION
Loooking at this failing CI job:
https://app.circleci.com/pipelines/github/pytorch/pytorch/368932/workflows/1f95e9a9-04d4-4d30-866c-95c60bd62cc7/jobs/15575031

I see that even though `DESIRED_PYTHON` is 3.7m, the actual python on path is 3.9 from conda. This happens with all libtorch nightly builds. The build scripts add `/opt/python/$DESIRED_PYTHON` to the path, but the directory doesn't exist so conda's python is used instead.

cc @malfet 