### PR TITLE
Build macOS conda binary with llvm

### DIFF
--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -26,6 +26,8 @@ export INSTALL_TEST=0 # dont install test binaries into site-packages
 
 # MacOS build is simple, and will not be for CUDA
 if [[ "$OSTYPE" == "darwin"* ]]; then
+    export USE_LLVM=$CMAKE_PREFIX_PATH
+    export LLVM_DIR=$USE_LLVM/lib/cmake/llvm
     MACOSX_DEPLOYMENT_TARGET=10.9 \
         CXX=clang++ \
         CC=clang \

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - typing_extensions
     - dataclasses # [py36]
     - ninja
+    - llvmdev=9
     - libuv # [win]
     - libuv # [unix]
     - pkg-config # [unix]


### PR DESCRIPTION
Enabling llvm/cpu fusion on macOS conda builds.