### PR TITLE
Add retry to download miniconda

### DIFF
--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -44,7 +44,7 @@ set "tmp_conda=%CONDA_HOME%"
 set "miniconda_exe=%CD%\miniconda.exe"
 rmdir /s /q conda
 del miniconda.exe
-curl -k https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o "%miniconda_exe%"
+curl --retry 3 -k https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o "%miniconda_exe%"
 call ..\conda\install_conda.bat
 if ERRORLEVEL 1 exit /b 1
 set "ORIG_PATH=%PATH%"


### PR DESCRIPTION
On Sep 4, One workflow is broken due to failed to download miniconda3.
https://app.circleci.com/pipelines/github/pytorch/pytorch/376129/workflows/8671e78d-3e0e-484f-ac5b-cdb6ebacd085/jobs/15856411
![image](https://user-images.githubusercontent.com/16190118/132644817-fd4307a1-93b0-4909-96dd-23695162a50f.png)


The complete miniconda package is 58.1M
![image](https://user-images.githubusercontent.com/16190118/132644351-9d3c160b-0cb9-42e9-8f06-429f39c92484.png)

To avoid this error, add retry to download miniconda


testing PR https://github.com/pytorch/pytorch/pull/62015
