### PR TITLE
Remove "features" from pytorch conda package

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -75,8 +75,6 @@ build:
     - BUILD_TEST # [unix]
     - USE_PYTORCH_METAL_EXPORT # [osx]
     - USE_COREML_DELEGATE # [osx]
-  features:
-{{ environ.get('CONDA_CPU_ONLY_FEATURE', '    - cpuonly # [not osx]') }}
 
 test:
  imports:


### PR DESCRIPTION
`CONDA_CPU_ONLY_FEATURE` and `features` section were initially removed in https://github.com/pytorch/builder/pull/823, but merge conflict was resolved incorrectly with https://github.com/pytorch/builder/pull/823/commits/a3909beec432dd640d5c5074b1b57cd4124a6412.