### PR TITLE
Fix M1 conda build

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -69,6 +69,7 @@ fi
 # differentiate package name for cross compilation to avoid collision
 if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
     build_version="$build_version.arm64"
+    export PYTORCH_LLVM_PACKAGE=""
 fi
 
 export PYTORCH_BUILD_VERSION=$build_version

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -24,10 +24,10 @@ requirements:
     - typing_extensions
     - dataclasses # [py36]
     - ninja
-    - llvmdev=9
     - libuv # [win]
     - libuv # [unix]
     - pkg-config # [unix]
+{{ environ.get('PYTORCH_LLVM_PACKAGE', '    - llvmdev=9') }}
 {{ environ.get('MAGMA_PACKAGE', '') }}
 
   run:


### PR DESCRIPTION
Do not attempt to compile PyTorch with llvm dependency for M1

Fixes https://github.com/pytorch/pytorch/issues/64649