### PR TITLE
Conda Mac package should not `run_constrained` to cpu

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -38,13 +38,13 @@ requirements:
     - intel-openmp # [win]
     - typing_extensions
     - blas * mkl
-    - pytorch-mutex 1.0 {{ build_variant }}
+    - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT', '') }}
 
   {% if build_variant == 'cpu' %}
   run_constrained:
     - cpuonly
-  {% else %}
+  {% elif not osx %}
   run_constrained:
      - cpuonly <0
   {% endif %}


### PR DESCRIPTION
As there are no non-cpu variants of the package

Fixes https://github.com/pytorch/pytorch/issues/65591
