### PR TITLE
Reverse ci trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,19 @@ jobs:
   build:
     docker:
       - image: pytorch/manylinux-builder:cpu
+    resource_class: 2xlarge+
     steps:
       - checkout
       - run:
           name: "Checking out PyTorch"
           command: |
             git clone --depth 1 https://github.com/pytorch/pytorch /home/circleci/project/pytorch
+            export PACKAGE_TYPE=manywheel
             export DESIRED_CUDA=cpu
             export DESIRED_PYTHON=3.7m
             export DESIRED_DEVTOOLSET=devtoolset7
-            export DOCKER_IMAGE=pytorch/manylinux-cpu
+            export DOCKER_IMAGE=pytorch/manylinux-cpu 
+            export MAX_JOBS=18
             bash manywheel/build_cpu.sh
   test:
     docker:
@@ -29,3 +32,4 @@ workflows:
     jobs:
       - build
       - test
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,14 @@ jobs:
       - checkout
       - run:
           name: "Checking out PyTorch"
-          command: |
+          command: |   
             git clone --depth 1 https://github.com/pytorch/pytorch /home/circleci/project/pytorch
             export PACKAGE_TYPE=manywheel
             export DESIRED_CUDA=cpu
             export DESIRED_PYTHON=3.7m
             export DESIRED_DEVTOOLSET=devtoolset7
-            export DOCKER_IMAGE=pytorch/manylinux-cpu 
-            export MAX_JOBS=18
+            export DOCKER_IMAGE=pytorch/manylinux-cpu # this may not be needed since we are inside the docker image 
+            export MAX_JOBS=18  # this is ideally a calculated number
             bash manywheel/build_cpu.sh
   test:
     docker:
@@ -32,4 +32,3 @@ workflows:
     jobs:
       - build
       - test
-      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,19 +16,20 @@ jobs:
             export DESIRED_CUDA=cpu
             export DESIRED_PYTHON=3.7m
             export DESIRED_DEVTOOLSET=devtoolset7
-            export DOCKER_IMAGE=pytorch/manylinux-cpu # this may not be needed since we are inside the docker image 
-            export MAX_JOBS=$(nproc --ignore=2) 
+            MEMORY_LIMIT_MAX_JOBS=18
+            NUM_CPUS=$(( $(nproc) - 2 )) 
+            export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
             bash manywheel/build_cpu.sh
-  test:
-    docker:
-      - image: circleci/python:3.7
-    steps:
-      - checkout
-      - run: echo "this is the test job"
+  # test:
+  #   docker:
+  #     - image: circleci/python:3.7
+  #   steps:
+  #     - checkout
+  #     - run: echo "this is the test job"
 
 # Orchestrate our job run sequence
 workflows:
   build_and_test:
     jobs:
       - build
-      - test
+    #  - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+
+# Define the jobs we want to run for this project
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: "Checking out PyTorch"
+          command: |
+            git clone --depth 1 https://github.com/pytorch/pytorch /home/circleci/project/pytorch
+            export DESIRED_CUDA=cpu
+            export DESIRED_PYTHON=3.7m
+            export DESIRED_DEVTOOLSET=devtoolset7
+            export DOCKER_IMAGE=pytorch/manylinux-cpu
+            bash manywheel/build_cpu.sh
+  test:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run: echo "this is the test job"
+
+# Orchestrate our job run sequence
+workflows:
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7
+      - image: pytorch/manylinux-builder:cpu
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             export DESIRED_PYTHON=3.7m
             export DESIRED_DEVTOOLSET=devtoolset7
             export DOCKER_IMAGE=pytorch/manylinux-cpu # this may not be needed since we are inside the docker image 
-            export MAX_JOBS=18  # this is ideally a calculated number
+            export MAX_JOBS=$(nproc --ignore=2) 
             bash manywheel/build_cpu.sh
   test:
     docker:

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -107,7 +107,7 @@ if [[ -z "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
 fi
 mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
 
-OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
 elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -89,7 +89,7 @@ echo "Will build for Python version: ${DESIRED_PYTHON} with ${python_installatio
 mkdir -p /tmp/$WHEELHOUSE_DIR
 
 # Clone pytorch source code
-pytorch_rootdir="/pytorch"
+pytorch_rootdir="/home/circleci/project/pytorch"
 if [[ ! -d "$pytorch_rootdir" ]]; then
     # TODO probably safe to completely remove this
     git clone https://github.com/pytorch/pytorch $pytorch_rootdir
@@ -103,7 +103,7 @@ fi
 git submodule update --init --recursive --jobs 0
 
 export PATCHELF_BIN=/usr/local/bin/patchelf
-patchelf_version=`$PATCHELF_BIN --version`
+patchelf_version=$($PATCHELF_BIN --version)
 echo "patchelf version: " $patchelf_version
 if [[ "$patchelf_version" == "patchelf 0.9" ]]; then
     echo "Your patchelf version is too old. Please use version >= 0.10."

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -89,21 +89,21 @@ echo "Will build for Python version: ${DESIRED_PYTHON} with ${python_installatio
 mkdir -p /tmp/$WHEELHOUSE_DIR
 
 # Clone pytorch source code
-# pytorch_rootdir="/pytorch"
-# if [[ ! -d "$pytorch_rootdir" ]]; then
-#     # TODO probably safe to completely remove this
-#     git clone https://github.com/pytorch/pytorch $pytorch_rootdir
-#     pushd $pytorch_rootdir
-#     if ! git checkout v${PYTORCH_BUILD_VERSION}; then
-#           git checkout tags/v${PYTORCH_BUILD_VERSION}
-#     fi
-# else
-#     pushd $pytorch_rootdir
-# fi
-# git submodule update --init --recursive --jobs 0
+pytorch_rootdir="/pytorch"
+if [[ ! -d "$pytorch_rootdir" ]]; then
+    # TODO probably safe to completely remove this
+    git clone https://github.com/pytorch/pytorch $pytorch_rootdir
+    pushd $pytorch_rootdir
+    if ! git checkout v${PYTORCH_BUILD_VERSION}; then
+          git checkout tags/v${PYTORCH_BUILD_VERSION}
+    fi
+else
+    pushd $pytorch_rootdir
+fi
+git submodule update --init --recursive --jobs 0
 
 export PATCHELF_BIN=/usr/local/bin/patchelf
-patchelf_version=$($PATCHELF_BIN --version)
+patchelf_version=`$PATCHELF_BIN --version`
 echo "patchelf version: " $patchelf_version
 if [[ "$patchelf_version" == "patchelf 0.9" ]]; then
     echo "Your patchelf version is too old. Please use version >= 0.10."

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -147,13 +147,6 @@ fi
 # for master / release branches)
 BUILD_DEBUG_INFO=${BUILD_DEBUG_INFO:=0}
 
-# TODO: Delete within a few days of 6/15/21! This is a hack to get debug info
-# building on PRs without merging in the change to PyTorch proper that sets
-# BUILD_DEBUG_INFO=1
-if [[ $CIRCLE_BRANCH == release/1.9 ]]; then
-    export BUILD_DEBUG_INFO=1
-fi
-
 if [[ $BUILD_DEBUG_INFO == "1" ]]; then
     echo "Building wheel and debug info"
 else

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -22,7 +22,7 @@ retry () {
 }
 
 # TODO move this into the Docker images
-OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
     retry yum install -q -y zip openssl
 elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
@@ -359,7 +359,7 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
     done
 
     # regenerate the RECORD file with new hashes
-    record_file=`echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g'`
+    record_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g')
     if [[ -e $record_file ]]; then
         echo "Generating new record file $record_file"
         rm -f $record_file

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -89,21 +89,21 @@ echo "Will build for Python version: ${DESIRED_PYTHON} with ${python_installatio
 mkdir -p /tmp/$WHEELHOUSE_DIR
 
 # Clone pytorch source code
-pytorch_rootdir="/pytorch"
-if [[ ! -d "$pytorch_rootdir" ]]; then
-    # TODO probably safe to completely remove this
-    git clone https://github.com/pytorch/pytorch $pytorch_rootdir
-    pushd $pytorch_rootdir
-    if ! git checkout v${PYTORCH_BUILD_VERSION}; then
-          git checkout tags/v${PYTORCH_BUILD_VERSION}
-    fi
-else
-    pushd $pytorch_rootdir
-fi
-git submodule update --init --recursive --jobs 0
+# pytorch_rootdir="/pytorch"
+# if [[ ! -d "$pytorch_rootdir" ]]; then
+#     # TODO probably safe to completely remove this
+#     git clone https://github.com/pytorch/pytorch $pytorch_rootdir
+#     pushd $pytorch_rootdir
+#     if ! git checkout v${PYTORCH_BUILD_VERSION}; then
+#           git checkout tags/v${PYTORCH_BUILD_VERSION}
+#     fi
+# else
+#     pushd $pytorch_rootdir
+# fi
+# git submodule update --init --recursive --jobs 0
 
 export PATCHELF_BIN=/usr/local/bin/patchelf
-patchelf_version=`$PATCHELF_BIN --version`
+patchelf_version=$($PATCHELF_BIN --version)
 echo "patchelf version: " $patchelf_version
 if [[ "$patchelf_version" == "patchelf 0.9" ]]; then
     echo "Your patchelf version is too old. Please use version >= 0.10."

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -89,7 +89,7 @@ echo "Will build for Python version: ${DESIRED_PYTHON} with ${python_installatio
 mkdir -p /tmp/$WHEELHOUSE_DIR
 
 # Clone pytorch source code
-pytorch_rootdir="/home/circleci/project/pytorch"
+pytorch_rootdir="/pytorch"
 if [[ ! -d "$pytorch_rootdir" ]]; then
     # TODO probably safe to completely remove this
     git clone https://github.com/pytorch/pytorch $pytorch_rootdir

--- a/manywheel/build_cpu.sh
+++ b/manywheel/build_cpu.sh
@@ -26,7 +26,7 @@ if [[ -z "$PYTORCH_FINAL_PACKAGE_DIR" ]]; then
 fi
 mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR" || true
 
-OS_NAME=`awk -F= '/^NAME/{print $2}' /etc/os-release`
+OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 if [[ "$OS_NAME" == *"CentOS Linux"* ]]; then
     LIBGOMP_PATH="/usr/lib64/libgomp.so.1"
 elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then


### PR DESCRIPTION
Trigger linux binary build from pytorch/pytorch inside pytorch/builder.
This is an initial PR leading to migration of more circleCI workflows from pytorch core to builder.