### PR TITLE
Persist environment variables across build steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,18 +35,9 @@ jobs:
             NUM_CPUS=$(( $(nproc) - 2 )) 
             export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
             bash manywheel/build_cpu.sh
-#   test:
-#     docker:
-#       - image: pytorch/manylinux-builder:cpu
-#     steps:
-#       - checkout
-#       - run:
-#           name: "Test"
-#           command: echo "this is the test job"
 
 # Orchestrate our job run sequence
 workflows:
   build_and_test:
     jobs:
       - binary_linux_build
-#       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # Checks out PyTorch and builder repo
 binary_checkout: &binary_checkout
-  name: Checkout pytorch/builder repo
+  name: Checkout pytorch/pytorch and pytorch/builder
   command: .circleci/scripts/binary_checkout.sh
 
 binary_populate_env: &binary_populate_env
@@ -31,7 +31,7 @@ jobs:
             MEMORY_LIMIT_MAX_JOBS=18
             NUM_CPUS=$(( $(nproc) - 2 )) 
             export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
-            source manywheel/build_cpu.sh
+            bash manywheel/build_cpu.sh
 #   test:
 #     docker:
 #       - image: pytorch/manylinux-builder:cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
       - run:  
           name: "Build"
           command: |
+            echo "RUNNING ON $(uname -a) WITH $(nproc) CPUS AND $(free -m)"
+            set -eux -o pipefail
+            source ${WORK_DIR}/env  
             MEMORY_LIMIT_MAX_JOBS=18
             NUM_CPUS=$(( $(nproc) - 2 )) 
             export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,49 @@
 version: 2.1
 
+# Checks out PyTorch and builder repo
+binary_checkout: &binary_checkout
+  name: Checkout pytorch/builder repo
+  command: .circleci/scripts/binary_checkout.sh
+
+binary_populate_env: &binary_populate_env
+  name: Set up binary env variables
+  command: .circleci/scripts/binary_populate_env.sh
+
 # Define the jobs we want to run for this project
 jobs:
-  build:
+  binary_linux_build:
+    environment:
+      BUILD_ENVIRONMENT: "manywheel 3.8m cpu devtoolset7"  
+      LIBTORCH_VARIANT: ""
+      ANACONDA_USER: pytorch
     docker:
-      - image: pytorch/manylinux-builder:cpu
+      - image: "pytorch/manylinux-builder:cpu"
     resource_class: 2xlarge+
     steps:
       - checkout
       - run:
-          name: "Checking out PyTorch"
-          command: |   
-            git clone --depth 1 https://github.com/pytorch/pytorch /home/circleci/project/pytorch
-            export PACKAGE_TYPE=manywheel
-            export DESIRED_CUDA=cpu
-            export DESIRED_PYTHON=3.7m
-            export DESIRED_DEVTOOLSET=devtoolset7
+          <<: *binary_checkout
+      - run:
+          <<: *binary_populate_env
+      - run:  
+          name: "Build"
+          command: |
             MEMORY_LIMIT_MAX_JOBS=18
             NUM_CPUS=$(( $(nproc) - 2 )) 
             export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
-            bash manywheel/build_cpu.sh
-  # test:
-  #   docker:
-  #     - image: circleci/python:3.7
-  #   steps:
-  #     - checkout
-  #     - run: echo "this is the test job"
+            source manywheel/build_cpu.sh
+#   test:
+#     docker:
+#       - image: pytorch/manylinux-builder:cpu
+#     steps:
+#       - checkout
+#       - run:
+#           name: "Test"
+#           command: echo "this is the test job"
 
 # Orchestrate our job run sequence
 workflows:
   build_and_test:
     jobs:
-      - build
-    #  - test
+      - binary_linux_build
+#       - test

--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -13,33 +13,29 @@ if [[ "$OSTYPE" == "msys" ]]; then
   # windows executor (builds and tests)
   rm -rf /c/w
   ln -s "${HOME}" /c/w
-  workdir="/c/w"
+  WORK_DIR="/c/w"
 elif [[ -d "/home/circleci/project" ]]; then
   # machine executor (binary tests)
-  workdir="${HOME}/project"
+  WORK_DIR="${HOME}/project"
 else
   # macos executor (builds and tests)
   # docker executor (binary builds)
-  workdir="${HOME}"
+  WORK_DIR="${HOME}"
 fi
 
 if [[ "$OSTYPE" == "msys" ]]; then
   # We need to make the paths as short as possible on Windows
-  PYTORCH_ROOT="$workdir/p"
-  BUILDER_ROOT="$workdir/b"
+  PYTORCH_ROOT="$WORK_DIR/p"
+  BUILDER_ROOT="$WORK_DIR/b"
 else
-  PYTORCH_ROOT="$workdir/pytorch"
-  BUILDER_ROOT="$workdir/builder"
+  PYTORCH_ROOT="$WORK_DIR/pytorch"
+  BUILDER_ROOT="$WORK_DIR/builder"
 fi
 
 # Persist these variables for the subsequent steps
+echo "export WORK_DIR=${WORK_DIR}" >> ${BASH_ENV}
 echo "export PYTORCH_ROOT=${PYTORCH_ROOT}" >> ${BASH_ENV}
 echo "export BUILDER_ROOT=${BUILDER_ROOT}" >> ${BASH_ENV}
-
-# Try to extract PR number from branch if not already set
-if [[ -z "${CIRCLE_PR_NUMBER:-}" ]]; then
-  CIRCLE_PR_NUMBER="$(echo ${CIRCLE_BRANCH} | sed -E -n 's/pull\/([0-9]*).*/\1/p')"
-fi
 
 # Clone the Pytorch branch
 retry git clone --depth 1 https://github.com/pytorch/pytorch.git "$PYTORCH_ROOT"

--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -9,31 +9,32 @@ retry () {
 
 
 # This step runs on multiple executors with different envfile locations
-if [[ "$(uname)" == Darwin ]]; then
-  # macos executor (builds and tests)
-  workdir="/Users/distiller/project"
-elif [[ "$OSTYPE" == "msys" ]]; then
+if [[ "$OSTYPE" == "msys" ]]; then
   # windows executor (builds and tests)
   rm -rf /c/w
-  ln -s "/c/Users/circleci/project" /c/w
+  ln -s "${HOME}" /c/w
   workdir="/c/w"
 elif [[ -d "/home/circleci/project" ]]; then
   # machine executor (binary tests)
-  workdir="/home/circleci/project"
+  workdir="${HOME}/project"
 else
+  # macos executor (builds and tests)
   # docker executor (binary builds)
-  workdir="/"
+  workdir="${HOME}"
 fi
 
-# It is very important that this stays in sync with binary_populate_env.sh
 if [[ "$OSTYPE" == "msys" ]]; then
   # We need to make the paths as short as possible on Windows
-  export PYTORCH_ROOT="$workdir/p"
-  export BUILDER_ROOT="$workdir/b"
+  PYTORCH_ROOT="$workdir/p"
+  BUILDER_ROOT="$workdir/b"
 else
-  export PYTORCH_ROOT="$workdir/pytorch"
-  export BUILDER_ROOT="$workdir/builder"
+  PYTORCH_ROOT="$workdir/pytorch"
+  BUILDER_ROOT="$workdir/builder"
 fi
+
+# Persist these variables for the subsequent steps
+echo "export PYTORCH_ROOT=${PYTORCH_ROOT}" >> ${BASH_ENV}
+echo "export BUILDER_ROOT=${BUILDER_ROOT}" >> ${BASH_ENV}
 
 # Try to extract PR number from branch if not already set
 if [[ -z "${CIRCLE_PR_NUMBER:-}" ]]; then
@@ -41,23 +42,12 @@ if [[ -z "${CIRCLE_PR_NUMBER:-}" ]]; then
 fi
 
 # Clone the Pytorch branch
-retry git clone https://github.com/pytorch/pytorch.git "$PYTORCH_ROOT"
-pushd "$PYTORCH_ROOT"
-if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
-  # "smoke" binary build on PRs
-  git fetch --force origin "pull/${CIRCLE_PR_NUMBER}/head:remotes/origin/pull/${CIRCLE_PR_NUMBER}"
-  git reset --hard "$CIRCLE_SHA1"
-  git checkout -q -B "$CIRCLE_BRANCH"
-  git reset --hard "$CIRCLE_SHA1"
-elif [[ -n "${CIRCLE_SHA1:-}" ]]; then
-  # Scheduled workflows & "smoke" binary build on master on PR merges
-  git reset --hard "$CIRCLE_SHA1"
-  git checkout -q -B master
-else
-  echo "Can't tell what to checkout"
-  exit 1
-fi
+retry git clone --depth 1 https://github.com/pytorch/pytorch.git "$PYTORCH_ROOT"
+# Removed checking out pytorch/pytorch using CIRCLE_PR_NUMBER and CIRCLE_SHA1 as
+# those environment variables are tied to the host repo where the build is being
+# triggered. 
 retry git submodule update --init --recursive --jobs 0
+pushd "$PYTORCH_ROOT"
 echo "Using Pytorch from "
 git --no-pager log --max-count 1
 popd

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -7,9 +7,9 @@ tagged_version() {
   # Grabs version from either the env variable CIRCLE_TAG
   # or the pytorch git described version
   if [[ "$OSTYPE" == "msys" ]]; then
-    GIT_DESCRIBE="git --git-dir ${workdir}/p/.git describe"
+    GIT_DESCRIBE="git --git-dir ${WORK_DIR}/p/.git describe"
   else
-    GIT_DESCRIBE="git --git-dir ${workdir}/pytorch/.git describe"
+    GIT_DESCRIBE="git --git-dir ${WORK_DIR}/pytorch/.git describe"
   fi
   if [[ -n "${CIRCLE_TAG:-}" ]]; then
     echo "${CIRCLE_TAG}"
@@ -20,7 +20,7 @@ tagged_version() {
   fi
 }
 
-envfile="$workdir/env"
+envfile="$WORK_DIR/env"
 touch "$envfile"
 chmod +x "$envfile"
 
@@ -153,17 +153,17 @@ export BUILD_JNI=$BUILD_JNI
 export PIP_UPLOAD_FOLDER="$PIP_UPLOAD_FOLDER"
 export DOCKER_IMAGE="$DOCKER_IMAGE"
 
-export workdir="$workdir"
-export MAC_PACKAGE_WORK_DIR="$workdir"
+export WORK_DIR="$WORK_DIR"
+export MAC_PACKAGE_WORK_DIR="$WORK_DIR"
 if [[ "$OSTYPE" == "msys" ]]; then
-  export PYTORCH_ROOT="$workdir/p"
-  export BUILDER_ROOT="$workdir/b"
+  export PYTORCH_ROOT="$WORK_DIR/p"
+  export BUILDER_ROOT="$WORK_DIR/b"
 else
-  export PYTORCH_ROOT="$workdir/pytorch"
-  export BUILDER_ROOT="$workdir/builder"
+  export PYTORCH_ROOT="$WORK_DIR/pytorch"
+  export BUILDER_ROOT="$WORK_DIR/builder"
 fi
-export MINICONDA_ROOT="$workdir/miniconda"
-export PYTORCH_FINAL_PACKAGE_DIR="$workdir/final_pkgs"
+export MINICONDA_ROOT="$WORK_DIR/miniconda"
+export PYTORCH_FINAL_PACKAGE_DIR="$WORK_DIR/final_pkgs"
 
 export CIRCLE_TAG="${CIRCLE_TAG:-}"
 export CIRCLE_SHA1="$CIRCLE_SHA1"

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -20,30 +20,15 @@ tagged_version() {
   fi
 }
 
-# We need to write an envfile to persist these variables to following
-# steps, but the location of the envfile depends on the circleci executor
-if [[ "$(uname)" == Darwin ]]; then
-  # macos executor (builds and tests)
-  workdir="/Users/distiller/project"
-elif [[ "$OSTYPE" == "msys" ]]; then
-  # windows executor (builds and tests)
-  workdir="/c/w"
-elif [[ -d "/home/circleci/project" ]]; then
-  # machine executor (binary tests)
-  workdir="/home/circleci/project"
-else
-  # docker executor (binary builds)
-  workdir="/"
-fi
 envfile="$workdir/env"
 touch "$envfile"
 chmod +x "$envfile"
 
 # Parse the BUILD_ENVIRONMENT to package type, python, and cuda
 configs=($BUILD_ENVIRONMENT)
-export PACKAGE_TYPE="${configs[0]}"
-export DESIRED_PYTHON="${configs[1]}"
-export DESIRED_CUDA="${configs[2]}"
+PACKAGE_TYPE="${configs[0]}"
+DESIRED_PYTHON="${configs[1]}"
+DESIRED_CUDA="${configs[2]}"
 if [[ "${BUILD_FOR_SYSTEM:-}" == "windows" ]]; then
   export DESIRED_DEVTOOLSET=""
   export LIBTORCH_CONFIG="${configs[3]:-}"
@@ -57,8 +42,12 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   export BUILD_PYTHONLESS=1
 fi
 
+echo "export PACKAGE_TYPE=${PACKAGE_TYPE}" >> ${BASH_ENV}
+echo "export DESIRED_PYTHON=${DESIRED_PYTHON}" >> ${BASH_ENV}
+echo "export DESIRED_CUDA=${DESIRED_CUDA}" >> ${BASH_ENV}
+
 # Pick docker image
-export DOCKER_IMAGE=${DOCKER_IMAGE:-}
+DOCKER_IMAGE=${DOCKER_IMAGE:-}
 if [[ -z "$DOCKER_IMAGE" ]]; then
   if [[ "$PACKAGE_TYPE" == conda ]]; then
     export DOCKER_IMAGE="pytorch/conda-cuda"

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -42,10 +42,6 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   export BUILD_PYTHONLESS=1
 fi
 
-echo "export PACKAGE_TYPE=${PACKAGE_TYPE}" >> ${BASH_ENV}
-echo "export DESIRED_PYTHON=${DESIRED_PYTHON}" >> ${BASH_ENV}
-echo "export DESIRED_CUDA=${DESIRED_CUDA}" >> ${BASH_ENV}
-
 # Pick docker image
 DOCKER_IMAGE=${DOCKER_IMAGE:-}
 if [[ -z "$DOCKER_IMAGE" ]]; then
@@ -153,15 +149,8 @@ export BUILD_JNI=$BUILD_JNI
 export PIP_UPLOAD_FOLDER="$PIP_UPLOAD_FOLDER"
 export DOCKER_IMAGE="$DOCKER_IMAGE"
 
-export WORK_DIR="$WORK_DIR"
+# Remove WORKD_DIR, PYTORCH_ROOT, BUILDER_ROOT defined & persisted in binary_checkout.sh
 export MAC_PACKAGE_WORK_DIR="$WORK_DIR"
-if [[ "$OSTYPE" == "msys" ]]; then
-  export PYTORCH_ROOT="$WORK_DIR/p"
-  export BUILDER_ROOT="$WORK_DIR/b"
-else
-  export PYTORCH_ROOT="$WORK_DIR/pytorch"
-  export BUILDER_ROOT="$WORK_DIR/builder"
-fi
 export MINICONDA_ROOT="$WORK_DIR/miniconda"
 export PYTORCH_FINAL_PACKAGE_DIR="$WORK_DIR/final_pkgs"
 

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -99,6 +99,10 @@ fi
 ########################################################
 # Compile wheels as well as libtorch
 #######################################################
+if [[ -z "$PYTORCH_ROOT" ]]; then
+    echo "Need to set PYTORCH_ROOT env variable"
+    exit 1
+fi
 pushd "$PYTORCH_ROOT"
 python setup.py clean
 retry pip install -qr requirements.txt

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -88,20 +88,6 @@ echo "Will build for Python version: ${DESIRED_PYTHON} with ${python_installatio
 
 mkdir -p /tmp/$WHEELHOUSE_DIR
 
-# Clone pytorch source code
-pytorch_rootdir="/pytorch"
-if [[ ! -d "$pytorch_rootdir" ]]; then
-    # TODO probably safe to completely remove this
-    git clone https://github.com/pytorch/pytorch $pytorch_rootdir
-    pushd $pytorch_rootdir
-    if ! git checkout v${PYTORCH_BUILD_VERSION}; then
-          git checkout tags/v${PYTORCH_BUILD_VERSION}
-    fi
-else
-    pushd $pytorch_rootdir
-fi
-git submodule update --init --recursive --jobs 0
-
 export PATCHELF_BIN=/usr/local/bin/patchelf
 patchelf_version=$($PATCHELF_BIN --version)
 echo "patchelf version: " $patchelf_version
@@ -113,6 +99,7 @@ fi
 ########################################################
 # Compile wheels as well as libtorch
 #######################################################
+pushd "$PYTORCH_ROOT"
 python setup.py clean
 retry pip install -qr requirements.txt
 case ${DESIRED_PYTHON} in
@@ -196,7 +183,7 @@ if [[ -n "$BUILD_PYTHONLESS" ]]; then
     rm -rf any_wheel
 
     echo $PYTORCH_BUILD_VERSION > libtorch/build-version
-    echo "$(pushd $pytorch_rootdir && git rev-parse HEAD)" > libtorch/build-hash
+    echo "$(pushd $PYTORCH_ROOT && git rev-parse HEAD)" > libtorch/build-hash
 
     mkdir -p /tmp/$LIBTORCH_HOUSE_DIR
 
@@ -420,7 +407,7 @@ fi
 # Test that all the wheels work
 if [[ -z "$BUILD_PYTHONLESS" ]]; then
   export OMP_NUM_THREADS=4 # on NUMA machines this takes too long
-  pushd $pytorch_rootdir/test
+  pushd $PYTORCH_ROOT/test
 
   # Install the wheel for this Python version
   pip uninstall -y "$TORCH_PACKAGE_NAME"
@@ -437,7 +424,7 @@ if [[ -z "$BUILD_PYTHONLESS" ]]; then
 
   # Run the tests
   echo "$(date) :: Running tests"
-  pushd "$pytorch_rootdir"
+  pushd "$PYTORCH_ROOT"
   LD_LIBRARY_PATH=/usr/local/nvidia/lib64 \
           "${SOURCE_DIR}/../run_tests.sh" manywheel "${py_majmin}" "$DESIRED_CUDA"
   popd

--- a/manywheel/build_cpu.sh
+++ b/manywheel/build_cpu.sh
@@ -43,13 +43,10 @@ DEPS_SONAME=(
 
 rm -rf /usr/local/cuda*
 
-# builder/test.sh requires DESIRED_CUDA to know what tests to exclude
-export DESIRED_CUDA='cpu'
-
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 if [[ -z "$BUILD_PYTHONLESS" ]]; then
     BUILD_SCRIPT=build_common.sh
 else
     BUILD_SCRIPT=build_libtorch.sh
 fi
-source $SCRIPTPATH/${BUILD_SCRIPT}
+source ${SOURCE_DIR}/${BUILD_SCRIPT}


### PR DESCRIPTION
This PR is meant to persist top level environment variables across steps within a binary linux build job and thus to avoid repetition or inconsistency.

Test Plan:
- Build success in `pytorch/builder`
- Build success for`binary_linux_build` series of workflows in `pytorch/pytorch`: [see pull request](https://github.com/pytorch/pytorch/pull/66032)