### PR TITLE
Fix conda build cupti copying

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -116,7 +116,7 @@ if NOT "%build_with_cuda%" == "" (
     copy "%CUDA_BIN_PATH%\cudnn*64_*.dll*" %SP_DIR%\torch\lib
     :: cupti library file name changes aggressively, bundle it to avoid
     :: potential file name mismatch.
-    copy "%CUDA_PATH%\extras\CUPTI\lib64\cupti64_*.dll*" pytorch\torch\lib
+    copy "%CUDA_PATH%\extras\CUPTI\lib64\cupti64_*.dll*" %SP_DIR%\torch\lib
 )
 
 exit /b 0


### PR DESCRIPTION
Previously, the line is directly copied from
https://github.com/pytorch/builder/blob/064455871ad4326c02e3d27662fbd6d18b750542/windows/internal/copy.bat#L10
but the path is should be adapted.