### PR TITLE
ROCm 4.3.1 manywheel image should use MIOpen branch release/rocm-rel-4.3-staging

### DIFF
--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -97,7 +97,7 @@ elif [[ ${ROCM_VERSION} == 4.2 ]]; then
     MIOPEN_BRANCH="rocm-4.2.x-staging"
 elif [[ ${ROCM_VERSION} == 4.3.1 ]]; then
     MIOPEN_CMAKE_DB_FLAGS="-DMIOPEN_EMBED_DB=gfx900_56;gfx900_64;gfx906_60;gfx906_64;gfx90878;gfx1030_36"
-    MIOPEN_BRANCH="release/rocm-rel-4.3"
+    MIOPEN_BRANCH="release/rocm-rel-4.3-staging"
 else
     echo "Unhandled ROCM_VERSION ${ROCM_VERSION}"
     exit 1


### PR DESCRIPTION
fixes:
https://github.com/RadeonOpenCompute/ROCm/issues/1572
https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1204

Signed-off-by: Kyle Chen <kylechen@amd.com>
@jeffdaily 