### PR TITLE
Repo dispatch of CircleCI binary builds of pytorch/pytorch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,27 @@ jobs:
             NUM_CPUS=$(( $(nproc) - 2 )) 
             export MAX_JOBS=${MAX_JOBS:-$(( ${NUM_CPUS} > ${MEMORY_LIMIT_MAX_JOBS} ? ${MEMORY_LIMIT_MAX_JOBS} : ${NUM_CPUS} ))}
             bash manywheel/build_cpu.sh
+  pytorch_binary_build:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - run:
+          name: "Send POST request to pytorch"
+          command : |
+            echo "Circle PR Number: "$CIRCLE_PR_NUMBER
+            echo "Circle SHA1: "$CIRCLE_SHA1
+            curl --request POST \
+            --url "https://circleci.com/api/v2/project/github/pytorch/pytorch/pipeline" \
+            --header "Circle-Token: $CIRCLECI_API_TOKEN" \
+            --header "Content-Type: application/json" \
+            --data '{
+                    "branch":"lan/test_builder",
+                    "parameters": {"run_binary_tests": true, "run_build": false, "run_master_build": false, "run_slow_gradcheck_build": false}
+                    }'
 
 # Orchestrate our job run sequence
 workflows:
   build_and_test:
     jobs:
       - binary_linux_build
+      - pytorch_binary_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,15 +42,19 @@ jobs:
       - run:
           name: "Send POST request to pytorch"
           command : |
-            echo "Circle PR Number: "$CIRCLE_PR_NUMBER
-            echo "Circle SHA1: "$CIRCLE_SHA1
             curl --request POST \
             --url "https://circleci.com/api/v2/project/github/pytorch/pytorch/pipeline" \
             --header "Circle-Token: $CIRCLECI_API_TOKEN" \
             --header "Content-Type: application/json" \
             --data '{
                     "branch":"lan/test_builder",
-                    "parameters": {"run_binary_tests": true, "run_build": false, "run_master_build": false, "run_slow_gradcheck_build": false}
+                    "parameters": {
+                                  "run_binary_tests": true, 
+                                  "run_build": false, 
+                                  "run_master_build": false, 
+                                  "run_slow_gradcheck_build": false,
+                                  "builder_circle_sha1": $CIRCLE_SHA1
+                                  }
                     }'
 
 # Orchestrate our job run sequence

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run:
           name: "Send POST request to pytorch"
           command : |
+            # TODO: Use a post data generation function to replace manual input
             curl --request POST \
             --url "https://circleci.com/api/v2/project/github/pytorch/pytorch/pipeline" \
             --header "Circle-Token: $CIRCLECI_API_TOKEN" \
@@ -53,7 +54,7 @@ jobs:
                                   "run_build": false, 
                                   "run_master_build": false, 
                                   "run_slow_gradcheck_build": false,
-                                  "builder_circle_sha1": $CIRCLE_SHA1
+                                  "builder_circle_sha1": "'"$CIRCLE_SHA1"'"
                                   }
                     }'
 


### PR DESCRIPTION
Purpose:
- Enable triggering of CI workflow in a dependent repo due to changes in `pytorch/builder`
- Initial work to make `pytorch/builder` the central repo of e2e CI workflow of pytorch and domain libs

Test plan: 
- Triggered binary builds CircleCI workflow inside `pytorch/pytorch`: https://github.com/pytorch/pytorch/pull/67310