### PR TITLE
[ROCm] Bump magma source to pickup memory leak fix

### DIFF
--- a/common/install_rocm.sh
+++ b/common/install_rocm.sh
@@ -31,7 +31,7 @@ yum install -y \
 # "install" hipMAGMA into /opt/rocm/magma by copying after build
 git clone https://bitbucket.org/icl/magma.git
 pushd magma
-git checkout 092253401778a2cd35a214b0436efacebe2e55cd
+git checkout c62d700d880c7283b33fb1d615d62fc9c7f7ca21
 cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
 echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc
 # overwrite original LIB, because it's wrong; it's missing start/end-group


### PR DESCRIPTION
Magma's magma_queue was double allocating storage when creating
ptrArray for gemm operations. A fix has been upstreamed and the build
needs to pick this up going forward.