### PR TITLE
Repo dispatch of pytorch/pytorch GHA CI workflows

### DIFF
--- a/.github/workflows/build-pytorch-pytorch.yml
+++ b/.github/workflows/build-pytorch-pytorch.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   call-workflow-build-test:
-    uses: pytorch/pytorch/.github/workflows/build_test.yml@lan/test_builder
+    uses: langong347/pytorch/.github/workflows/build_test.yml@master
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
   dispatch-workflow-build-linux-wheels:
@@ -19,5 +19,5 @@ jobs:
         run: |
           curl -XPOST -u ":${{secrets.GITHUB_TOKEN}}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Content-Type: application/json" https://api.github.com/repos/pytorch/pytorch/dispatches \
-          --data '{"event_type": "build"}'
+          -H "Content-Type: application/json" https://api.github.com/repos/langong347/pytorch/dispatches \
+          --data '{"event_type": "event_type"}'

--- a/.github/workflows/build-pytorch-pytorch.yml
+++ b/.github/workflows/build-pytorch-pytorch.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Send POST request
         run: |
-          curl -XPOST -u ":${{secrets.GITHUB_TOKEN}}" \
+          curl -v -XPOST -u ":${{secrets.GITHUB_TOKEN}}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" https://api.github.com/repos/pytorch/pytorch/dispatches \
           --data '{

--- a/.github/workflows/build-pytorch-pytorch.yml
+++ b/.github/workflows/build-pytorch-pytorch.yml
@@ -1,4 +1,4 @@
-name: Build pytorch/pytorch repository
+name: Trigger CI of pytorch/pytorch repository
 
 on:
   push:
@@ -8,10 +8,6 @@ on:
     types: [opened, synchronize, reopened, unassigned]
 
 jobs:
-  call-workflow-no-concurrency:
-    uses: langong347/pytorch/.github/workflows/workflow_call.yml@master
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
   dispatch-workflow:
     runs-on: linux.2xlarge
     steps:
@@ -20,4 +16,9 @@ jobs:
           curl -XPOST -u ":${{secrets.GITHUB_TOKEN}}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" https://api.github.com/repos/langong347/pytorch/dispatches \
-          --data '{"event_type": "event_type"}'
+          --data '{
+                  "event_type": "trigger", 
+                  "client_payload": {
+                                    "branch": "lan/test_repo_dispatch_gha"
+                                    }
+                  }'

--- a/.github/workflows/build-pytorch-pytorch.yml
+++ b/.github/workflows/build-pytorch-pytorch.yml
@@ -8,11 +8,15 @@ on:
     types: [opened, synchronize, reopened, unassigned]
 
 jobs:
-  call-workflow-build-test:
-    uses: langong347/pytorch/.github/workflows/build_test.yml@master
+  call-workflow-no-concurrency:
+    uses: langong347/pytorch/.github/workflows/workflow_call.yml@master
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
-  dispatch-workflow-build-linux-wheels:
+  call-workflow-concurrency:
+    uses: langong347/pytorch/.github/workflows/build_linux_wheels.yml@master
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+  dispatch-workflow:
     runs-on: linux.2xlarge
     steps:
       - name: Send POST request

--- a/.github/workflows/build-pytorch-pytorch.yml
+++ b/.github/workflows/build-pytorch-pytorch.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           curl -XPOST -u ":${{secrets.GITHUB_TOKEN}}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Content-Type: application/json" https://api.github.com/repos/langong347/pytorch/dispatches \
+          -H "Content-Type: application/json" https://api.github.com/repos/pytorch/pytorch/dispatches \
           --data '{
                   "event_type": "trigger", 
                   "client_payload": {

--- a/.github/workflows/build-pytorch-pytorch.yml
+++ b/.github/workflows/build-pytorch-pytorch.yml
@@ -1,0 +1,23 @@
+name: Build pytorch/pytorch repository
+
+on:
+  push:
+    branches:
+      main
+  pull_request:
+    types: [opened, synchronize, reopened, unassigned]
+
+jobs:
+  call-workflow-build-test:
+    uses: pytorch/pytorch/.github/workflows/build_test.yml@lan/test_builder
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+  dispatch-workflow-build-linux-wheels:
+    runs-on: linux.2xlarge
+    steps:
+      - name: Send POST request
+        run: |
+          curl -XPOST -u ":${{secrets.GITHUB_TOKEN}}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" https://api.github.com/repos/pytorch/pytorch/dispatches \
+          --data '{"event_type": "build"}'

--- a/.github/workflows/build-pytorch-pytorch.yml
+++ b/.github/workflows/build-pytorch-pytorch.yml
@@ -12,10 +12,6 @@ jobs:
     uses: langong347/pytorch/.github/workflows/workflow_call.yml@master
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
-  call-workflow-concurrency:
-    uses: langong347/pytorch/.github/workflows/build_linux_wheels.yml@master
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
   dispatch-workflow:
     runs-on: linux.2xlarge
     steps:


### PR DESCRIPTION
Goal: Trigger CI of `pytorch/pytorch` from `pytorch/builder` thru GitHub's `repository_dispatch` API (with workarounds)
Test plan: Create a test branch with the receiver of the trigger event and verify the workflow file is triggered (https://github.com/pytorch/pytorch/pull/67315)
