### PR TITLE
common: Migrate sqlite download to s3

### DIFF
--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -56,7 +56,7 @@ fi
 ## MIOpen minimum requirements
 
 ### Boost; No viable yum package exists. Must use static linking with PIC.
-retry wget https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz
+retry wget --no-check-certificate https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz
 tar xzf boost_1_72_0.tar.gz
 pushd boost_1_72_0
 ./bootstrap.sh

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -56,7 +56,7 @@ fi
 ## MIOpen minimum requirements
 
 ### Boost; No viable yum package exists. Must use static linking with PIC.
-retry wget --no-check-certificate https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz
+retry wget https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz
 tar xzf boost_1_72_0.tar.gz
 pushd boost_1_72_0
 ./bootstrap.sh
@@ -66,7 +66,7 @@ rm -rf boost_1_72_0
 rm -f  boost_1_72_0.tar.gz
 
 ### sqlite; No viable yum package exists. Must be at least version 3.14.
-retry wget https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz
+retry wget --no-check-certificate https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz
 tar xzf sqlite-autoconf-3170000.tar.gz
 pushd sqlite-autoconf-3170000
 ./configure --with-pic

--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -66,7 +66,7 @@ rm -rf boost_1_72_0
 rm -f  boost_1_72_0.tar.gz
 
 ### sqlite; No viable yum package exists. Must be at least version 3.14.
-retry wget --no-check-certificate https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz
+retry wget https://ossci-linux.s3.amazonaws.com/sqlite-autoconf-3170000.tar.gz
 tar xzf sqlite-autoconf-3170000.tar.gz
 pushd sqlite-autoconf-3170000
 ./configure --with-pic


### PR DESCRIPTION
Signed-off-by: Kyle Chen <kylechen@amd.com>

adding --no-check-certificate to wget sqlite for install_miopen.sh.
otherwise, the manywheel build for ROCm would fail with this error:
```
 retry wget https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz
 wget https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz
 --2021-10-22 18:25:19-- https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz
 Resolving sqlite.org (sqlite.org)... 45.33.6.223, 2600:3c00::f03c:91ff:fe96:b959
 Connecting to sqlite.org (sqlite.org)|45.33.6.223|:443... connected.
 ERROR: cannot verify sqlite.org's certificate, issued by ‘/C=US/O=Let's Encrypt/CN=R3’:
 Issued certificate has expired.
 To connect to sqlite.org insecurely, use `--no-check-certificate'.
```

@jeffdaily 