### PR TITLE
Install NumPy 1.19 for smoke testing

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -81,13 +81,9 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true
-    numpy_ver=1.15
-    case "$(python --version 2>&1)" in
-      *2* | *3.5* | *3.6*)
-        numpy_ver=1.11
-        ;;
-    esac
-    retry pip install -q "numpy==${numpy_ver}" || true
+    # NumPy v1.19 is used during the building of PyTorch, so install
+    # same version for smoke testing.
+    retry pip install -q "numpy==1.19" || true
 fi
 
 echo "Testing with:"


### PR DESCRIPTION
This PR attempts to fix the failing binary builds for the lts/release/1.8 branch for installing NumPy 1.19 for the smoke-testing stage in the builds. As all builds use NumPy 1.19 for building PyTorch, using the same version of NumPy may unblock these failing LTS builds.