### PR TITLE
Add 11.5 workflow for docker image build

### DIFF
--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: linux.2xlarge
     strategy:
       matrix:
-        cuda_version: ["10.2", "11.1", "11.3", "cpu"]
+        cuda_version: ["10.2", "11.1", "11.3", "11.5", "cpu"]
     env:
       CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:


### PR DESCRIPTION
Followup after https://github.com/pytorch/builder/pull/887