### PR TITLE
Removed caffe2 testing in LTS binary builds

### DIFF
--- a/check_binary.sh
+++ b/check_binary.sh
@@ -300,7 +300,6 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
 else
   pushd /tmp
   python -c 'import torch'
-  python -c 'from caffe2.python import core'
   popd
 fi
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -78,9 +78,6 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
     fi
     # Install the testing dependencies
     retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
-    if [[ "$package_type" == wheel ]]; then
-      # Numpy dependency is now dynamic but old caffe2 test assume its always there
-      retry conda install -yq numpy
     fi
 else
     retry pip install -qr requirements.txt || true
@@ -105,7 +102,6 @@ conda list || true
 pushd /
 echo "Smoke testing imports"
 python -c 'import torch'
-python -c 'from caffe2.python import core'
 
 # Test that MKL is there
 if [[ "$(uname)" == 'Darwin' && "$package_type" == *wheel ]]; then

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -125,9 +125,6 @@ if ERRORLEVEL 1 exit /b 1
 python -c "import torch"
 if ERRORLEVEL 1 exit /b 1
 
-python -c "from caffe2.python import core"
-if ERRORLEVEL 1 exit /b 1
-
 echo Checking that MKL is available
 python -c "import torch; exit(0 if torch.backends.mkl.is_available() else 1)"
 if ERRORLEVEL 1 exit /b 1


### PR DESCRIPTION
This PR carries over the changes done in PR #864, which removes the caffe2 import tests. This is causing the LTS binary builds to fail, due to it perceiving a missing NumPy package. [Sample failure link](https://app.circleci.com/pipelines/github/pytorch/pytorch/409789/workflows/9f84dfcc-1ad9-4108-9e1a-985be6f3ee0d/jobs/16726528?invite=true#step-105-2878).