### PR TITLE
Using default workers for manywheel and libtorch jobs

### DIFF
--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -23,10 +23,10 @@ env:
 
 jobs:
   build-docker:
-    runs-on: linux.2xlarge
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
-        cuda_version: ["10.2", "11.1", "11.3", "11.5", "cpu"]
+        cuda_version: ["11.5", "cpu"]
     env:
       CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        cuda_version: ["11.5", "cpu"]
+        cuda_version: ["10.2", "11.1", "11.3", "11.5", "cpu"]
     env:
       CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        cuda_version: ["11.5"]
+        cuda_version: ["11.5", "11.3", "11.1", "10.2"]
     env:
       GPU_ARCH_TYPE: cuda
       GPU_ARCH_VERSION: ${{ matrix.cuda_version }}

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -25,10 +25,10 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.2xlarge
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
-        cuda_version: ["11.5", "11.3", "11.1", "10.2"]
+        cuda_version: ["11.5"]
     env:
       GPU_ARCH_TYPE: cuda
       GPU_ARCH_VERSION: ${{ matrix.cuda_version }}
@@ -44,7 +44,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-rocm:
-    runs-on: linux.2xlarge
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         rocm_version: ["4.1", "4.2", "4.3.1"]
@@ -63,7 +63,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu:
-    runs-on: linux.2xlarge
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2


### PR DESCRIPTION
Changing workers from linux.2xlarge  to ubuntu-18.04 workers. This way we wont need to to use so much resources, specially all the jobs in the builder package.