### PR TITLE
Nit syntax error fix

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -80,7 +80,6 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
     retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
     # Numpy dependency is now dynamic but old caffe2 test assume its always there
     retry conda install -yq numpy
-    fi
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true


### PR DESCRIPTION
This PR fixes a nit syntax error bug made by my earlier PR #891, where a stranded `fi` bash line was left. This change removes the lone `fi`.