### PR TITLE
Add version numbers to the libnvrtc-builtins.so files

### DIFF
--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -230,7 +230,7 @@ elif [[ $CUDA_VERSION == "11.2" ]]; then
 DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.11.0"
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
-    "/usr/local/cuda/lib64/libnvrtc.so.11.2"    # this is not a mistake for 11.3, it links to 11.3.58
+    "/usr/local/cuda/lib64/libnvrtc.so.11.2"
     "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.2"
     "$LIBGOMP_PATH"
 )

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -215,7 +215,7 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.11.0"   # CUDA 11.1 uses libcudart11.0 for backwards compat
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
     "/usr/local/cuda/lib64/libnvrtc.so.11.1"
-    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.1" # CUDA 11.+ searches for versioned builtins library
     "$LIBGOMP_PATH"
 )
 
@@ -223,15 +223,15 @@ DEPS_SONAME=(
     "libcudart.so.11.0"
     "libnvToolsExt.so.1"
     "libnvrtc.so.11.1"
-    "libnvrtc-builtins.so"
+    "libnvrtc-builtins.so.11.1"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.2" ]]; then
 DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.11.0"
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
-    "/usr/local/cuda/lib64/libnvrtc.so.11.2"
-    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "/usr/local/cuda/lib64/libnvrtc.so.11.2"    # this is not a mistake for 11.3, it links to 11.3.58
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.2"
     "$LIBGOMP_PATH"
 )
 
@@ -239,7 +239,7 @@ DEPS_SONAME=(
     "libcudart.so.11.0"
     "libnvToolsExt.so.1"
     "libnvrtc.so.11.2"
-    "libnvrtc-builtins.so"
+    "libnvrtc-builtins.so.11.2"
     "libgomp.so.1"
 )
 else


### PR DESCRIPTION
This PR fixes PyTorch GitHub issue [#69689](https://github.com/pytorch/pytorch/issues/69689) by cherry-picking the pytorch/builder commit [7789627](https://github.com/pytorch/builder/commit/77896279ecb336a8930e5815fbaa68202b44ba44) that fixed the issue on the main branch to the lts/release/1.8 branch. This issue is fixed by adding the version numbers to the `libnvrtc-builtins.so` files, as NVRTC from CUDA-11.X have changed to look for versioned `libnvrtc-builtins.so` files.