### PR TITLE
update conda-build during the install

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -344,6 +344,8 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     echo "Build $build_folder for Python version $py_ver"
     conda config --set anaconda_upload no
     conda install -y conda-package-handling
+    # NS: To be removed after conda docker images are updated
+    conda update -y conda-build
 
     ADDITIONAL_CHANNELS=""
     echo "Calling conda-build at $(date)"


### PR DESCRIPTION
This PR fixes PyTorch GitHub issue [#69683](https://github.com/pytorch/pytorch/issues/69683) by cherry-picking the pytorch/builder commit [da79c4c](https://github.com/pytorch/builder/commit/da79c4c6aa17c61cf166314194940731218df51c) that fixed the issue on the main branch to the lts/release/1.8 branch. This issue is fixed by updating conda-build during install.