### PR TITLE
Remove "track_features" from cpuonly conda package + fixes

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -32,9 +32,6 @@ FROM base as conda
 # Install Anaconda
 ADD ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh
-# conda-package-handling fails out for larger tarballs,
-# see: https://github.com/conda/conda-package-handling/issues/71
-RUN /opt/conda/bin/conda install -y conda-package-handling=1.6.0
 
 # Install CUDA
 FROM base as cuda

--- a/conda/README.md
+++ b/conda/README.md
@@ -24,7 +24,6 @@ docker run --rm -it \
     -e DESIRED_PYTHON=3.8 \
     -e PYTORCH_BUILD_VERSION=1.5.0 \
     -e PYTORCH_BUILD_NUMBER=1 \
-    -e OVERRIDE_PACKAGE_VERSION=1.5.0
     -e TORCH_CONDA_BUILD_FOLDER=pytorch-nightly \
     -v /path/to/pytorch:/pytorch \
     -v /path/to/builder:/builder \

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -343,10 +343,7 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     # Build the package
     echo "Build $build_folder for Python version $py_ver"
     conda config --set anaconda_upload no
-    # There was a bug that was introduced in conda-package-handling >= 1.6.1 that makes archives
-    # above a certain size fail out when attempting to extract
-    # see: https://github.com/conda/conda-package-handling/issues/71
-    conda install -y "conda-package-handling=1.6.0"
+    conda install -y conda-package-handling
 
     ADDITIONAL_CHANNELS=""
     echo "Calling conda-build at $(date)"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -247,13 +247,12 @@ if [[ -n "$cpu_only" ]]; then
     if [[ "$OSTYPE" != "darwin"* ]]; then
         build_string_suffix="cpu_${build_string_suffix}"
     fi
-    # on Linux, advertise that the package sets the cpuonly feature
-    export CONDA_CPU_ONLY_FEATURE="    - cpuonly # [not osx]"
+    export PYTORCH_BUILD_VARIANT="cpu"
 else
     # Switch the CUDA version that /usr/local/cuda points to. This script also
     # sets CUDA_VERSION and CUDNN_VERSION
     echo "Switching to CUDA version $desired_cuda"
-    export CONDA_CPU_ONLY_FEATURE=""
+    export PYTORCH_BUILD_VARIANT="cuda"
     . ./switch_cuda_version.sh "$desired_cuda"
     # TODO, simplify after anaconda fixes their cudatoolkit versioning inconsistency.
     # see: https://github.com/conda-forge/conda-forge.github.io/issues/687#issuecomment-460086164

--- a/conda/cpuonly/meta.yaml
+++ b/conda/cpuonly/meta.yaml
@@ -1,8 +1,12 @@
 package:
   name: cpuonly
-  version: 1.0
+  version: 2.0
 
 build:
   track_features:
       - cpuonly
   noarch: generic
+
+requirements:
+  run:
+    - pytorch-mutex 1.0 cpu

--- a/conda/pytorch-mutex/conda_build_config.yaml
+++ b/conda/pytorch-mutex/conda_build_config.yaml
@@ -1,0 +1,3 @@
+build_variant:
+    - cpu
+    - cuda

--- a/conda/pytorch-mutex/meta.yaml
+++ b/conda/pytorch-mutex/meta.yaml
@@ -1,0 +1,29 @@
+{% set version = "1.0" %}
+{% set build = 0 %}
+
+{% if build_variant == 'cuda' %}
+# prefer cuda builds via a build number offset
+{% set build = build + 100 %}
+{% endif %}
+
+package:
+  name: pytorch-mutex
+  version: {{ version }}
+build:
+  number: {{ build }}
+  string: {{ build_variant }}
+  noarch: generic
+  # also lower cpu priority with track_features
+  {% if build_variant == 'cpu' %}
+  track_features:
+      - pytorch-mutex
+  {% endif %}
+  run_exports:
+    - {{ pin_subpackage('pytorch-mutex', exact=True) }}
+requirements: {}
+  # None, pytorch should depend on pytorch-mutex
+test:
+  commands:
+    - echo "pytorch-mutex metapackage is created."
+about:
+  summary: Metapackage to select the PyTorch variant. Use conda's pinning mechanism in your environment to control which variant you want.

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -39,13 +39,13 @@ requirements:
     - ninja
     - typing_extensions
     - blas * mkl
-    - pytorch-mutex 1.0 {{ build_variant }}
+    - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 
   {% if build_variant == 'cpu' %}
   run_constrained:
     - cpuonly
-  {% else %}
+  {% elif not osx %}
   run_constrained:
      - cpuonly <0
   {% endif %}
@@ -72,13 +72,6 @@ build:
     - USE_NNPACK # [unix]
     - USE_QNNPACK # [unix]
     - BUILD_TEST # [unix]
-<<<<<<< HEAD
-  features:
-{{ environ.get('CONDA_CPU_ONLY_FEATURE') }}
-=======
-    - USE_PYTORCH_METAL_EXPORT # [osx]
-    - USE_COREML_DELEGATE # [osx]
->>>>>>> 5fb8b705... Remove "features" from pytorch conda package (#850)
 
 test:
  imports:

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -72,8 +72,13 @@ build:
     - USE_NNPACK # [unix]
     - USE_QNNPACK # [unix]
     - BUILD_TEST # [unix]
+<<<<<<< HEAD
   features:
 {{ environ.get('CONDA_CPU_ONLY_FEATURE') }}
+=======
+    - USE_PYTORCH_METAL_EXPORT # [osx]
+    - USE_COREML_DELEGATE # [osx]
+>>>>>>> 5fb8b705... Remove "features" from pytorch conda package (#850)
 
 test:
  imports:

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -1,3 +1,5 @@
+{% set build_variant = environ.get('PYTORCH_BUILD_VARIANT', 'cuda') %}
+
 package:
   name: pytorch
   version: "{{ environ.get('PYTORCH_BUILD_VERSION') }}"
@@ -37,7 +39,16 @@ requirements:
     - ninja
     - typing_extensions
     - blas * mkl
+    - pytorch-mutex 1.0 {{ build_variant }}
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
+
+  {% if build_variant == 'cpu' %}
+  run_constrained:
+    - cpuonly
+  {% else %}
+  run_constrained:
+     - cpuonly <0
+  {% endif %}
 
 build:
   number: {{ environ.get('PYTORCH_BUILD_NUMBER') }}

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - numpy=1.19
     - setuptools
     - pyyaml
-    - mkl >=2019
+    - mkl=2020.2
     - mkl-include
     - typing_extensions
     - dataclasses # [py36]

--- a/manywheel/build.sh
+++ b/manywheel/build.sh
@@ -215,7 +215,7 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.11.0"   # CUDA 11.1 uses libcudart11.0 for backwards compat
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
     "/usr/local/cuda/lib64/libnvrtc.so.11.1"
-    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.1" # CUDA 11.+ searches for versioned builtins library
     "$LIBGOMP_PATH"
 )
 
@@ -223,7 +223,7 @@ DEPS_SONAME=(
     "libcudart.so.11.0"
     "libnvToolsExt.so.1"
     "libnvrtc.so.11.1"
-    "libnvrtc-builtins.so"
+    "libnvrtc-builtins.so.11.1"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.2" ]]; then
@@ -231,7 +231,7 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.11.0"
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
     "/usr/local/cuda/lib64/libnvrtc.so.11.2"
-    "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.2"
     "$LIBGOMP_PATH"
 )
 
@@ -239,7 +239,7 @@ DEPS_SONAME=(
     "libcudart.so.11.0"
     "libnvToolsExt.so.1"
     "libnvrtc.so.11.2"
-    "libnvrtc-builtins.so"
+    "libnvrtc-builtins.so.11.2"
     "libgomp.so.1"
 )
 else

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -78,9 +78,8 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
     fi
     # Install the testing dependencies
     retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
-    if [[ "$package_type" == wheel ]]; then
-      # Numpy dependency is now dynamic but old caffe2 test assume its always there
-      retry conda install -yq numpy
+    # Numpy dependency is now dynamic but old caffe2 test assume its always there
+    retry conda install -yq numpy
     fi
 else
     retry pip install -qr requirements.txt || true

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -61,7 +61,6 @@ fi
 
 # Environment initialization
 if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
-    EXTRA_CONDA_FLAGS="-c=conda-forge"
     # Why are there two different ways to install dependencies after installing an offline package?
     # The "cpu" conda package for pytorch doesn't actually depend on "cpuonly" which means that
     # when we attempt to update dependencies using "conda update --all" it will attempt to install

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -80,7 +80,6 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
     retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
     # Numpy dependency is now dynamic but old caffe2 test assume its always there
     retry conda install -yq numpy
-    fi
 else
     retry pip install -qr requirements.txt || true
     retry pip install -q hypothesis protobuf pytest setuptools || true

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -71,13 +71,13 @@ if [[ "$package_type" == conda || "$(uname)" == Darwin ]]; then
     # TODO (maybe): Make the "cpu" package of pytorch depend on "cpuonly"
     if [[ "$cuda_ver" = 'cpu' ]]; then
       # Installing cpuonly will also install dependencies as well
-      retry conda install -y -c pytorch ${EXTRA_CONDA_FLAGS} cpuonly
+      retry conda install -y -c pytorch cpuonly
     else
       # Install dependencies from installing the pytorch conda package offline
-      retry conda update -yq --all -c defaults -c pytorch -c numba/label/dev ${EXTRA_CONDA_FLAGS}
+      retry conda update -yq --all -c defaults -c pytorch -c numba/label/dev
     fi
     # Install the testing dependencies
-    retry conda install -yq ${EXTRA_CONDA_FLAGS} future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
+    retry conda install -yq future hypothesis  protobuf=3.14.0 pytest setuptools six typing_extensions pyyaml
     if [[ "$package_type" == wheel ]]; then
       # Numpy dependency is now dynamic but old caffe2 test assume its always there
       retry conda install -yq numpy

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -100,10 +100,6 @@ if [[ "$PACKAGE_TYPE" == 'conda' || "$(uname)" == 'Darwin' ]]; then
     *3.6.*)
       dependencies="${dependencies} future dataclasses"
       ;;
-    # TODO: Remove this once Python 3.9 is workable through the default conda channels
-    *3.9.*)
-      dependencies="-c=conda-forge ${dependencies}"
-      ;;
   esac
   conda install -yq ${dependencies}
 else
@@ -137,9 +133,9 @@ which python
 #  retry curl "https://download.pytorch.org/whl/nightly/$DESIRED_CUDA/torch_nightly.html" -v
 #fi
 
-# CUDA Toolkit 11.1 and 11.2 are both in conda-forge
+# CUDA Toolkit 11.1 and 11.2 are both in nvidia
 if [[ "$DESIRED_CUDA" == cu111 || "$DESIRED_CUDA" == cu112 ]]; then
-  EXTRA_CONDA_FLAGS="-c=conda-forge"
+  EXTRA_CONDA_FLAGS="-c=nvidia"
 elif
   EXTRA_CONDA_FLAGS=""
 fi

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -237,7 +237,11 @@ else
         cp -r "$(pwd)/any_wheel/torch/lib/include" "$(pwd)/libtorch/"
     fi
     cp -r "$(pwd)/any_wheel/torch/share/cmake" "$(pwd)/libtorch/share/"
-    cp -r "$(pwd)/any_wheel/torch/.dylibs/libiomp5.dylib" "$(pwd)/libtorch/lib/"
+    if [[ -d $(pwd)/any_wheel/torch/.dylibs/libiomp5.dylib ]]; then
+        cp -r "$(pwd)/any_wheel/torch/.dylibs/libiomp5.dylib" "$(pwd)/libtorch/lib/"
+    else
+        cp -r "$(pwd)/any_wheel/torch/lib/libiomp5.dylib" "$(pwd)/libtorch/lib/"
+    fi
     rm -rf "$(pwd)/any_wheel"
 
     echo $PYTORCH_BUILD_VERSION > libtorch/build-version

--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -56,11 +56,11 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
-    if "%%v" == "3.6" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing_extensions dataclasses python=%%v
-    if "%%v" == "3.7" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" cffi pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.8" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.9" conda create -n py!PYTHON_VERSION_STR! -y -q "numpy>=1.11" "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl>=2019" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.6" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" cffi pyyaml boto3 cmake ninja typing_extensions dataclasses python=%%v
+    if "%%v" == "3.7" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" cffi pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.8" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.9" conda create -n py!PYTHON_VERSION_STR! -y -q "numpy>=1.11" "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3" conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
 )
 endlocal
 

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -71,14 +71,11 @@ set "CONDA_HOME=%CD%\conda"
 set "tmp_conda=%CONDA_HOME%"
 set "miniconda_exe=%CD%\miniconda.exe"
 set "CONDA_EXTRA_ARGS="
-if "%DESIRED_PYTHON%" == "3.9" (
-    set "CONDA_EXTRA_ARGS=-c=conda-forge"
-)
 if "%CUDA_VERSION%" == "111" (
-    set "CONDA_EXTRA_ARGS=-c=conda-forge"
+    set "CONDA_EXTRA_ARGS=-c=nvidia"
 )
 if "%CUDA_VERSION%" == "112" (
-    set "CONDA_EXTRA_ARGS=-c=conda-forge"
+    set "CONDA_EXTRA_ARGS=-c=nvidia"
 )
 
 rmdir /s /q conda

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -95,7 +95,7 @@ if errorlevel 1 exit /b 1
 call %CONDA_HOME%\condabin\activate.bat testenv
 if errorlevel 1 exit /b 1
 
-call conda install %CONDA_EXTRA_ARGS% -yq future protobuf six
+call conda install %CONDA_EXTRA_ARGS% -yq future protobuf six numpy
 if ERRORLEVEL 1 exit /b 1
 
 set /a CUDA_VER=%CUDA_VERSION%


### PR DESCRIPTION
This PR cherry-picks commits [4d84b21](https://github.com/pytorch/builder/commit/4d84b21d1759acce0480baca3a82d3e61241fe14), [5fb8b70](https://github.com/pytorch/builder/commit/5fb8b705337c7bddb449f0e828f737c8c655a453) and [edd30f5](https://github.com/pytorch/builder/commit/edd30f563708f98eef10b333f28143e151cde7df) from the master branch of pytorch/builder into the lts branch. These commits remove "track_features" that was used to enable/disable cuda / cpu builds but had issues with mamba. `cpuonly` package has now a runtime dependency with pinned `pytorch-mutex`.