### PR TITLE
Remove "track_features" from cpuonly conda package + fixes

### DIFF
--- a/conda/README.md
+++ b/conda/README.md
@@ -24,7 +24,6 @@ docker run --rm -it \
     -e DESIRED_PYTHON=3.8 \
     -e PYTORCH_BUILD_VERSION=1.5.0 \
     -e PYTORCH_BUILD_NUMBER=1 \
-    -e OVERRIDE_PACKAGE_VERSION=1.5.0
     -e TORCH_CONDA_BUILD_FOLDER=pytorch-nightly \
     -v /path/to/pytorch:/pytorch \
     -v /path/to/builder:/builder \

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -247,13 +247,12 @@ if [[ -n "$cpu_only" ]]; then
     if [[ "$OSTYPE" != "darwin"* ]]; then
         build_string_suffix="cpu_${build_string_suffix}"
     fi
-    # on Linux, advertise that the package sets the cpuonly feature
-    export CONDA_CPU_ONLY_FEATURE="    - cpuonly # [not osx]"
+    export PYTORCH_BUILD_VARIANT="cpu"
 else
     # Switch the CUDA version that /usr/local/cuda points to. This script also
     # sets CUDA_VERSION and CUDNN_VERSION
     echo "Switching to CUDA version $desired_cuda"
-    export CONDA_CPU_ONLY_FEATURE=""
+    export PYTORCH_BUILD_VARIANT="cuda"
     . ./switch_cuda_version.sh "$desired_cuda"
     # TODO, simplify after anaconda fixes their cudatoolkit versioning inconsistency.
     # see: https://github.com/conda-forge/conda-forge.github.io/issues/687#issuecomment-460086164

--- a/conda/cpuonly/meta.yaml
+++ b/conda/cpuonly/meta.yaml
@@ -1,8 +1,12 @@
 package:
   name: cpuonly
-  version: 1.0
+  version: 2.0
 
 build:
   track_features:
       - cpuonly
   noarch: generic
+
+requirements:
+  run:
+    - pytorch-mutex 1.0 cpu

--- a/conda/pytorch-mutex/conda_build_config.yaml
+++ b/conda/pytorch-mutex/conda_build_config.yaml
@@ -1,0 +1,3 @@
+build_variant:
+    - cpu
+    - cuda

--- a/conda/pytorch-mutex/meta.yaml
+++ b/conda/pytorch-mutex/meta.yaml
@@ -1,0 +1,29 @@
+{% set version = "1.0" %}
+{% set build = 0 %}
+
+{% if build_variant == 'cuda' %}
+# prefer cuda builds via a build number offset
+{% set build = build + 100 %}
+{% endif %}
+
+package:
+  name: pytorch-mutex
+  version: {{ version }}
+build:
+  number: {{ build }}
+  string: {{ build_variant }}
+  noarch: generic
+  # also lower cpu priority with track_features
+  {% if build_variant == 'cpu' %}
+  track_features:
+      - pytorch-mutex
+  {% endif %}
+  run_exports:
+    - {{ pin_subpackage('pytorch-mutex', exact=True) }}
+requirements: {}
+  # None, pytorch should depend on pytorch-mutex
+test:
+  commands:
+    - echo "pytorch-mutex metapackage is created."
+about:
+  summary: Metapackage to select the PyTorch variant. Use conda's pinning mechanism in your environment to control which variant you want.

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -39,13 +39,13 @@ requirements:
     - ninja
     - typing_extensions
     - blas * mkl
-    - pytorch-mutex 1.0 {{ build_variant }}
+    - pytorch-mutex 1.0 {{ build_variant }}  # [not osx ]
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
 
   {% if build_variant == 'cpu' %}
   run_constrained:
     - cpuonly
-  {% else %}
+  {% elif not osx %}
   run_constrained:
      - cpuonly <0
   {% endif %}
@@ -72,13 +72,6 @@ build:
     - USE_NNPACK # [unix]
     - USE_QNNPACK # [unix]
     - BUILD_TEST # [unix]
-<<<<<<< HEAD
-  features:
-{{ environ.get('CONDA_CPU_ONLY_FEATURE') }}
-=======
-    - USE_PYTORCH_METAL_EXPORT # [osx]
-    - USE_COREML_DELEGATE # [osx]
->>>>>>> 5fb8b705... Remove "features" from pytorch conda package (#850)
 
 test:
  imports:

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -72,8 +72,13 @@ build:
     - USE_NNPACK # [unix]
     - USE_QNNPACK # [unix]
     - BUILD_TEST # [unix]
+<<<<<<< HEAD
   features:
 {{ environ.get('CONDA_CPU_ONLY_FEATURE') }}
+=======
+    - USE_PYTORCH_METAL_EXPORT # [osx]
+    - USE_COREML_DELEGATE # [osx]
+>>>>>>> 5fb8b705... Remove "features" from pytorch conda package (#850)
 
 test:
  imports:

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -1,3 +1,5 @@
+{% set build_variant = environ.get('PYTORCH_BUILD_VARIANT', 'cuda') %}
+
 package:
   name: pytorch
   version: "{{ environ.get('PYTORCH_BUILD_VERSION') }}"
@@ -37,7 +39,16 @@ requirements:
     - ninja
     - typing_extensions
     - blas * mkl
+    - pytorch-mutex 1.0 {{ build_variant }}
 {{ environ.get('CONDA_CUDATOOLKIT_CONSTRAINT') }}
+
+  {% if build_variant == 'cpu' %}
+  run_constrained:
+    - cpuonly
+  {% else %}
+  run_constrained:
+     - cpuonly <0
+  {% endif %}
 
 build:
   number: {{ environ.get('PYTORCH_BUILD_NUMBER') }}


### PR DESCRIPTION
This PR cherry-picks commits [4d84b21](https://github.com/pytorch/builder/commit/4d84b21d1759acce0480baca3a82d3e61241fe14), [5fb8b70](https://github.com/pytorch/builder/commit/5fb8b705337c7bddb449f0e828f737c8c655a453) and [edd30f5](https://github.com/pytorch/builder/commit/edd30f563708f98eef10b333f28143e151cde7df) from the master branch of pytorch/builder into the lts branch. These commits remove "track_features" that was used to enable/disable cuda / cpu builds but had issues with mamba. `cpuonly` package has now a runtime dependency with pinned `pytorch-mutex`.