### PR TITLE
[DO NOT MERGE] Testing only rocm4.3.1 docker build

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        rocm_version: ["4.1", "4.2", "4.3.1"]
+        rocm_version: ["4.3.1"]
     env:
       GPU_ARCH_TYPE: rocm
       GPU_ARCH_VERSION: ${{ matrix.rocm_version }}


### PR DESCRIPTION
rocm4.3.1 docker build failed in PR #916, but the log file wasn't accessible to triage the issue. Local testing was successful in building a rocm4.3.1 docker. Filing this PR to be able to triage the issue with building 4.3.1 docker.