### PR TITLE
Fix py3.10 check binary tests

### DIFF
--- a/check_binary.sh
+++ b/check_binary.sh
@@ -27,7 +27,7 @@ if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   # NOTE: Only $PWD works on both CentOS and Ubuntu
   install_root="$PWD"
 else
-  py_dot="${DESIRED_PYTHON:0:3}"
+  py_dot="${DESIRED_PYTHON:0:4}"
   install_root="$(dirname $(which python))/../lib/python${py_dot}/site-packages/torch/"
 fi
 


### PR DESCRIPTION
Fix py3.10 check binary tests
Test plan:
bash -c 'desired_python=3.9; echo ${desired_python:0:4}'
3.9
bash -c 'desired_python=3.10; echo ${desired_python:0:4}'
3.10