### PR TITLE
Fix py_dot variable initialization

### DIFF
--- a/check_binary.sh
+++ b/check_binary.sh
@@ -27,7 +27,13 @@ if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   # NOTE: Only $PWD works on both CentOS and Ubuntu
   install_root="$PWD"
 else
-  py_dot="${DESIRED_PYTHON:0:3}"
+  # Strip everything but major.minor from DESIRED_PYTHON version
+  if [[ $DESIRED_PYTHON =~ ([0-9].[0-9]+) ]];  then
+    py_dot="${BASH_REMATCH[0]}"
+  else
+    echo "Unexpected ${DESIRED_PYTHON} format"
+    exit 1
+  fi
   install_root="$(dirname $(which python))/../lib/python${py_dot}/site-packages/torch/"
 fi
 


### PR DESCRIPTION
Test plan:
bash -c 'DESIRED_PYTHON=2.17m; [[ $DESIRED_PYTHON =~ ([0-9].[0-9]+) ]]; echo "${BASH_REMATCH[0]}"'