### PR TITLE
Refactor python_nodot in mac builds

### DIFF
--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -40,7 +40,7 @@ fi
 
 echo "Building for Python: $desired_python Version: $build_version Build: $build_number"
 echo "This is for OSX. There is no CUDA/CUDNN"
-python_nodot="${desired_python:0:1}${desired_python:2:2}"
+python_nodot="$(echo $desired_python | tr -d m.u)"
 
 # Version: setup.py uses $PYTORCH_BUILD_VERSION.post$PYTORCH_BUILD_NUMBER if
 # PYTORCH_BUILD_NUMBER > 1


### PR DESCRIPTION
Make logic in mac build_wheel.sh and manywheel/build_common.sh be the same
 bash -c 'desired_python=3.10; echo $desired_python | tr -d m.u'
310
 bash -c 'desired_python=3.9; echo $desired_python | tr -d m.u'
39