### PR TITLE
windows: Ensure we still set CUDA env vars

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -54,7 +54,7 @@ if [[ "$desired_cuda" != cpu ]]; then
 fi
 echo "Building cuda version $desired_cuda and pytorch version: $build_version build_number: $build_number"
 
-if [[ "$OSTYPE" == "msys" && "$CIRCLECI" == 'true' ]]; then
+if [[ "$OSTYPE" == "msys" ]]; then
     export PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:.:$PATH"
 fi
 


### PR DESCRIPTION
With our previous iteration we didn't properly set our env vars for
CUDA, this now does that.

This basically just re-arranges some code to not run when cuda is already installed

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>