### PR TITLE
[LTS] Pin delocate package to before python 3.6 drop

### DIFF
--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -181,7 +181,7 @@ python setup.py bdist_wheel -d "$whl_tmp_dir"
 echo "Finished setup.py bdist_wheel at $(date)"
 
 echo "delocating wheel dependencies"
-retry pip install https://github.com/matthew-brett/delocate/archive/master.zip
+retry pip install https://github.com/matthew-brett/delocate/archive/a5ba7dcc8ccfc9aaa1411c63266bfaf87a4ff393.zip
 echo "found the following wheels:"
 find $whl_tmp_dir -name "*.whl"
 echo "running delocate"

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -181,7 +181,7 @@ python setup.py bdist_wheel -d "$whl_tmp_dir"
 echo "Finished setup.py bdist_wheel at $(date)"
 
 echo "delocating wheel dependencies"
-retry pip install https://github.com/matthew-brett/delocate/archive/a5ba7dcc8ccfc9aaa1411c63266bfaf87a4ff393.zip
+retry pip install https://github.com/matthew-brett/delocate/archive/refs/tags/0.10.2.zip
 echo "found the following wheels:"
 find $whl_tmp_dir -name "*.whl"
 echo "running delocate"


### PR DESCRIPTION
The latest version of delocate package drops support for Python 3.6. So, the package is pinned to an older commit before the drop.