### PR TITLE
conda: skip tests on windows

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -369,6 +369,10 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     # NS: To be removed after conda docker images are updated
     conda update -y conda-build
 
+    if [[ "$OSTYPE" == "msys" ]]; then
+      # Don't run tests on windows (they were ignored mostly anyways)
+      NO_TEST="--no-test"
+    fi
 
     echo "Calling conda-build at $(date)"
     time CMAKE_ARGS=${CMAKE_ARGS[@]} \
@@ -377,6 +381,7 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
          PYTORCH_BUILD_STRING="$build_string" \
          PYTORCH_MAGMA_CUDA_VERSION="$cuda_nodot" \
          conda build -c "$ANACONDA_USER" ${ADDITIONAL_CHANNELS} \
+                     ${NO_TEST:-} \
                      --no-anaconda-upload \
                      --python "$py_ver" \
                      --output-folder "$output_folder" \


### PR DESCRIPTION
Windows Conda builds for GHA were failing during our migration with: ([logs](https://github.com/pytorch/pytorch/runs/4927457717?check_suite_focus=true#step:8:27391))
```
CondaVerificationError: The package for pytorch located at C:\actions-runner\_work\pytorch\pytorch\builder\tmp_conda_3.7_200613\conda\pkgs\pytorch-1.11.0.dev20220124-py3.7_cpu_0
appears to be corrupted. The path 'Lib/site-packages/caffe2/python/serialized_test/data/operator_test/piecewise_linear_transform_test.test_multi_predictions_params_from_arg.zip'
specified in the package manifest cannot be found.
```

So this makes it so that we don't run tests for windows on conda.

This aligns it with linux which has a `|| true` in its testing phases

conda-build reference: https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-build.html

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>