### PR TITLE
use PYTORCH_ROOT for pytorch_rootdir

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -159,10 +159,10 @@ fi
 ###########################################################
 if [[ "$(uname)" == 'Darwin' ]]; then
     mkdir -p "$MAC_PACKAGE_WORK_DIR" || true
-    pytorch_rootdir="${MAC_PACKAGE_WORK_DIR}/pytorch"
+    pytorch_rootdir="${PYTORCH_ROOT:-${MAC_PACKAGE_WORK_DIR}/pytorch}"
 elif [[ "$OSTYPE" == "msys" ]]; then
     mkdir -p "$WIN_PACKAGE_WORK_DIR" || true
-    pytorch_rootdir="$(realpath ${WIN_PACKAGE_WORK_DIR})/pytorch"
+    pytorch_rootdir="${PYTORCH_ROOT:-(realpath ${WIN_PACKAGE_WORK_DIR})/pytorch}"
     git config --system core.longpaths true
     # The jobs are seperated on Windows, so we don't need to clone again.
     if [[ -d "$NIGHTLIES_PYTORCH_ROOT" ]]; then

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -88,7 +88,7 @@ if [[ -z "$MAC_PACKAGE_WORK_DIR" ]]; then
     MAC_PACKAGE_WORK_DIR="$(pwd)/tmp_wheel_conda_${DESIRED_PYTHON}_$(date +%H%M%S)"
 fi
 mkdir -p "$MAC_PACKAGE_WORK_DIR" || true
-pytorch_rootdir="${MAC_PACKAGE_WORK_DIR}/pytorch"
+pytorch_rootdir="${PYTORCH_ROOT:-${MAC_PACKAGE_WORK_DIR}/pytorch}"
 whl_tmp_dir="${MAC_PACKAGE_WORK_DIR}/dist"
 mkdir -p "$whl_tmp_dir"
 


### PR DESCRIPTION
These values shouldn't be hardcoded to anything and should be set by
upstream workflows. This doesn't remove the original behavior though and
makes it backwards compat safe. So if no PYTORCH_ROOT is specified then
it should function exactly the same.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>