### PR TITLE
[ROCm] Rename shared libraries to fix Kineto (roctracer runtime loading) issue

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -316,21 +316,18 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
                 cp $filepath $destpath
             fi
 
-            patchedpath=$(fname_with_sha256 $destpath)
+            # ROCm workaround for roctracer dlopens
+            if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
+                patchedpath=$(fname_without_so_number $destpath)
+            else
+                patchedpath=$(fname_with_sha256 $destpath)
+            fi
             patchedname=$(basename $patchedpath)
             if [[ "$destpath" != "$patchedpath" ]]; then
                 mv $destpath $patchedpath
             fi
             patched+=("$patchedname")
             echo "Copied $filepath to $patchedpath"
-
-            if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
-                linkpath=$(fname_without_so_number $destpath)
-                if [[ "$linkpath" != "$patchedpath" ]]; then
-                    ln -s $patchedname $linkpath
-                fi
-                echo "Linked $patchedpath to $linkpath"
-            fi
         done
 
         echo "patching to fix the so names to the hashed names"

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -237,6 +237,11 @@ fname_with_sha256() {
     fi
 }
 
+fname_without_so_number() {
+    LINKNAME=$(echo $1 | sed 's/\.so.*/.so/g')
+    echo "$LINKNAME"
+}
+
 make_wheel_record() {
     FPATH=$1
     if echo $FPATH | grep RECORD >/dev/null 2>&1; then
@@ -318,6 +323,14 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
             fi
             patched+=("$patchedname")
             echo "Copied $filepath to $patchedpath"
+
+            if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
+                linkpath=$(fname_without_so_number $destpath)
+                if [[ "$linkpath" != "$patchedpath" ]]; then
+                    ln -s $patchedpath $linkpath
+                fi
+                echo "Linked $patchedpath to $linkpath"
+            fi
         done
 
         echo "patching to fix the so names to the hashed names"

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -238,7 +238,7 @@ fname_with_sha256() {
 }
 
 fname_without_so_number() {
-    LINKNAME=$(echo $1 | sed 's/\.so.*/.so/g')
+    LINKNAME=$(echo $1 | sed -e 's/\.so.*/.so/g')
     echo "$LINKNAME"
 }
 
@@ -327,7 +327,7 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
             if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
                 linkpath=$(fname_without_so_number $destpath)
                 if [[ "$linkpath" != "$patchedpath" ]]; then
-                    ln -s $patchedpath $linkpath
+                    ln -s $patchedname $linkpath
                 fi
                 echo "Linked $patchedpath to $linkpath"
             fi


### PR DESCRIPTION
The Kineto feature is currently broken for PyTorch wheels. We get the following error when trying to use Kineto feature:
`roctracer: Loading 'libamdhip64.so' failed, libamdhip64.so: cannot open shared object file: No such file or directory`

Using the Kineto feature loads `libroctracer.so`, which in turn tries to dlopen `libamdhip64.so` and `libroctx64.so`. Those doesn't exist in the wheel install path, since the wheel build flow adds hashes to the library names. This PR disables hashing for ROCm, and *in addition*, renames the numbered .sos to their non-numbered versions eg. `libamdhip64.so.4`->`libamdhip64.so`.

Verified with PyTorch unit tests that use Kineto eg.
```
test_profiler.py: TestProfiler.test_export_stacks
test_linalg.py: TestLinalgCUDA.test_norm_fused_type_promotion_cuda_bfloat16
test_jit_fuser_te.py: TestTEFuser.test_profiler
test_autograd.py: TestAutograd.test_profiler
test_utils.py: TestBottleneck.test_bottleneck_cuda
```