### PR TITLE
Adding zlib dll (new req for cudnn)

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -121,6 +121,11 @@ if NOT "%build_with_cuda%" == "" (
     :: cupti library file name changes aggressively, bundle it to avoid
     :: potential file name mismatch.
     copy "%CUDA_PATH%\extras\CUPTI\lib64\cupti64_*.dll*" %SP_DIR%\torch\lib
+
+    ::copy zlib if it exist in windows/system32
+    if exist "C:\Windows\System32\zlibwapi.dll" (
+        copy "C:\Windows\System32\zlibwapi.dll"  %SP_DIR%\torch\lib
+    )
 )
 
 exit /b 0

--- a/windows/internal/copy.bat
+++ b/windows/internal/copy.bat
@@ -16,5 +16,5 @@ copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib
 
 ::copy zlib if it exist in windows/system32
 if exist "C:\Windows\System32\zlibwapi.dll" (
-    copy "C:\Windows\System32\zlibwapi.dll"  %SP_DIR%\torch\lib
+    copy "C:\Windows\System32\zlibwapi.dll"  pytorch\torch\lib
 )

--- a/windows/internal/copy.bat
+++ b/windows/internal/copy.bat
@@ -13,3 +13,8 @@ copy "C:\Program Files\NVIDIA Corporation\NvToolsExt\bin\x64\nvToolsExt64_1.dll*
 copy "%CONDA_LIB_PATH%\libiomp*5md.dll" pytorch\torch\lib
 :: Should be set in build_pytorch.bat
 copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib
+
+::copy zlib if it exist in windows/system32
+if exist "C:\Windows\System32\zlibwapi.dll" (
+    copy "C:\Windows\System32\zlibwapi.dll"  %SP_DIR%\torch\lib
+)


### PR DESCRIPTION
Adding zlib dll (new req for cudnn)

Fixes:
https://app.circleci.com/pipelines/github/pytorch/pytorch/450105/workflows/9b17d16f-4c23-4d2d-9689-8d5e5a47f39a/jobs/16976675
```(testenv) C:\w\b\windows>python -c "import torch" 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\__init__.py", line 137, in <module>
    raise err
OSError: [WinError 126] The specified module could not be found. Error loading "C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\lib\cudnn_cnn_infer64_8.dll" or one of its dependencies.

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1
```

Tested in CircleCI:

New Workflow:
https://circleci.com/api/v1.1/project/github/pytorch/pytorch/16980670/output/105/0?file=true&allocation-id=61fd470fcd4a1c70882c1183-0-build%2F174DBC47

From the logs:
Notice zlibwapi.dll in /torch/lib/zlibwapi.dll
```
INFO:conda_build.build:Packaging pytorch
INFO conda_build.build:build(2289): Packaging pytorch
Packaging pytorch-1.11.0.dev20220204-py3.9_cuda11.5_cudnn8_0
INFO:conda_build.build:Packaging pytorch-1.11.0.dev20220204-py3.9_cuda11.5_cudnn8_0
INFO conda_build.build:bundle_conda(1529): Packaging pytorch-1.11.0.dev20220204-py3.9_cuda11.5_cudnn8_0
compiling .pyc files...
number of files: 10504
   INFO: sysroot: 'C:/Windows/' files: '['winhlp32.exe', 'win.ini', 'twain_32/wiatwain.ds', 'twain_32.dll']'
WARNING (pytorch,Lib/site-packages/torch/lib/cudnn_cnn_train64_8.dll): $RPATH/cudnn_ops_infer64_8.dll not found in packages, sysroot(s) nor the missing_dso_whitelist.
.. is this binary repackaging?
WARNING (pytorch,Lib/site-packages/torch/lib/cudnn_cnn_train64_8.dll): $RPATH/cudnn_ops_train64_8.dll not found in packages, sysroot(s) nor the missing_dso_whitelist.
.. is this binary repackaging?
WARNING (pytorch,Lib/site-packages/torch/lib/cudnn_cnn_train64_8.dll): $RPATH/cudnn_cnn_infer64_8.dll not found in packages, sysroot(s) nor the missing_dso_whitelist.
.. is this binary repackaging?
   INFO (pytorch,Lib/site-packages/torch/lib/cudnn_cnn_train64_8.dll): Needed DSO C:/Windows/System32/KERNEL32.dll found in $SYSROOT
   INFO (pytorch,Scripts/convert-caffe2-to-onnx.exe): Needed DSO C:/Windows/System32/KERNEL32.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/asmjit.dll): Needed DSO C:/Windows/System32/KERNEL32.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/asmjit.dll): Needed DSO C:/Windows/System32/VCRUNTIME140.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/asmjit.dll): Needed DSO C:/Windows/System32/VCRUNTIME140_1.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/asmjit.dll): Needed DSO C:/Windows/System32/downlevel/api-ms-win-crt-heap-l1-1-0.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/asmjit.dll): Needed DSO C:/Windows/System32/downlevel/api-ms-win-crt-stdio-l1-1-0.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/asmjit.dll): Needed DSO C:/Windows/System32/downlevel/api-ms-win-crt-runtime-l1-1-0.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/zlibwapi.dll): Needed DSO C:/Windows/System32/KERNEL32.dll found in $SYSROOT
   INFO (pytorch,Lib/site-packages/torch/lib/zlibwapi.dll): Needed DSO C:/Windows/System32/msvcrt.dll found in $SYSROOT
```
VS
Original workflow:
https://circleci.com/api/v1.1/project/github/pytorch/pytorch/16975399/output/104/0?file=true&allocation-id=61fb1eb196b3de7754b9dfff-0-build%2F50BD755D
