### PR TITLE
Fix windows smoke tests cudatoolkit installation

### DIFF
--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -94,19 +94,19 @@ if errorlevel 1 exit /b 1
 call %CONDA_HOME%\condabin\activate.bat testenv
 if errorlevel 1 exit /b 1
 
+set /a CUDA_VER=%CUDA_VERSION%
+set CUDA_VER_MAJOR=%CUDA_VERSION:~0,-1%
+set CUDA_VER_MINOR=%CUDA_VERSION:~-1,1%
+set CUDA_VERSION_STR=%CUDA_VER_MAJOR%.%CUDA_VER_MINOR%
+
 call conda update -n base -y -c defaults conda
 if "%PACKAGE_TYPE%" == "conda" (if "%DESIRED_PYTHON%" == "3.10"  (
-    call conda install -c=conda-forge -y cudatoolkit
+    call conda install -c=conda-forge -y cudatoolkit=%CUDA_VERSION_STR%
     if errorlevel 1 exit /b 1
 ))
 
 call conda install %CONDA_EXTRA_ARGS% -yq protobuf numpy
 if ERRORLEVEL 1 exit /b 1
-
-set /a CUDA_VER=%CUDA_VERSION%
-set CUDA_VER_MAJOR=%CUDA_VERSION:~0,-1%
-set CUDA_VER_MINOR=%CUDA_VERSION:~-1,1%
-set CUDA_VERSION_STR=%CUDA_VER_MAJOR%.%CUDA_VER_MINOR%
 
 if "%TEST_NIGHTLY_PACKAGE%" == "1" (
     call internal\install_nightly_package.bat


### PR DESCRIPTION
Fix windows smoke tests cudatoolkit installation

Fixes following error:
https://app.circleci.com/pipelines/github/pytorch/pytorch/451891/workflows/c7825ba8-a58e-4764-b4ec-29c9cf1820b1/jobs/16985330

Package cudatoolkit conflicts for:
pytorch -> cudatoolkit[version='>=10.0,<10.1|>=10.1,<10.2|>=10.2,<10.3|>=11.1,<11.2|>=11.3,<11.4|>=11.0,<11.1|>=9.2,<9.3|>=9.0,<9.1|>=8.0,<8.1']
cudatoolkit

Here is the log from testing this fix:

```
(testenv) C:\w\b\windows>for /F "delims=" %i in ('where /R "C:\w\final_pkgs" *.tar.bz2') do call conda install -c=nvidia -y "%i" --offline

(testenv) C:\w\b\windows>call conda install -c=nvidia -y "C:\w\final_pkgs\pytorch-1.12.0.dev20220207-py3.10_cuda11.1_cudnn8_0.tar.bz2" --offline

Downloading and Extracting Packages
########################################################################################################################## | 100%
Preparing transaction: done
Verifying transaction: done
Executing transaction: done

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>if "111" == "cpu" goto install_cpu_torch

(testenv) C:\w\b\windows>call conda update --all -c=nvidia -y -c pytorch -c defaults -c numba/label/dev
Collecting package metadata (current_repodata.json): done
Solving environment: -
The environment is inconsistent, please check the package plan carefully
The following packages are causing the inconsistency:
\
  - <unknown>/win-64::pytorch==1.12.0.dev20220207=py3.10_cuda11.1_cudnn8_0
done

## Package Plan ##

  environment location: C:\w\b\windows\conda\envs\testenv


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    libuv-1.40.0               |       he774522_0         255 KB
    pytorch-mutex-1.0          |             cuda           3 KB  pytorch
    typing_extensions-3.10.0.2 |     pyh06a4308_0          31 KB
    ------------------------------------------------------------
                                           Total:         288 KB

The following NEW packages will be INSTALLED:

  libuv              pkgs/main/win-64::libuv-1.40.0-he774522_0
  pytorch-mutex      pytorch/noarch::pytorch-mutex-1.0-cuda
  typing_extensions  pkgs/main/noarch::typing_extensions-3.10.0.2-pyh06a4308_0



Downloading and Extracting Packages
pytorch-mutex-1.0    | 3 KB      | ####################################################################################### | 100%
typing_extensions-3. | 31 KB     | ####################################################################################### | 100%
libuv-1.40.0         | 255 KB    | ####################################################################################### | 100%
Preparing transaction: done
Verifying transaction: done
Executing transaction: done

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>goto smoke_test

(testenv) C:\w\b\windows>python -c "import torch"
C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\_masked\__init__.py:223: UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe (Triggered internally at  C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:68.)
  example_input = torch.tensor([[-3, -2, -1], [0, 1, 2]])

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>echo Checking that MKL is available
Checking that MKL is available

(testenv) C:\w\b\windows>python -c "import torch; exit(0 if torch.backends.mkl.is_available() else 1)"
C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\_masked\__init__.py:223: UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe (Triggered internally at  C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:68.)
  example_input = torch.tensor([[-3, -2, -1], [0, 1, 2]])

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>if "1" == "0" (
echo "Skip CUDA tests for machines without a Nvidia GPU card"
 goto end
)

(testenv) C:\w\b\windows>echo Checking that CUDA archs are setup correctly
Checking that CUDA archs are setup correctly

(testenv) C:\w\b\windows>python -c "import torch; torch.randn([3,5]).cuda()"
C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\_masked\__init__.py:223: UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe (Triggered internally at  C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:68.)
  example_input = torch.tensor([[-3, -2, -1], [0, 1, 2]])

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>echo Checking that magma is available
Checking that magma is available

(testenv) C:\w\b\windows>python -c "import torch; torch.rand(1).cuda(); exit(0 if torch.cuda.has_magma else 1)"
C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\_masked\__init__.py:223: UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe (Triggered internally at  C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:68.)
  example_input = torch.tensor([[-3, -2, -1], [0, 1, 2]])

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>echo Checking that CuDNN is available
Checking that CuDNN is available

(testenv) C:\w\b\windows>python -c "import torch; exit(0 if torch.backends.cudnn.is_available() else 1)"
C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\_masked\__init__.py:223: UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe (Triggered internally at  C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:68.)
  example_input = torch.tensor([[-3, -2, -1], [0, 1, 2]])

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>echo Checking that basic RNN works
Checking that basic RNN works

(testenv) C:\w\b\windows>python C:/w/b\test_example_code\rnn_smoke.py
C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\_masked\__init__.py:223: UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe (Triggered internally at  C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:68.)
  example_input = torch.tensor([[-3, -2, -1], [0, 1, 2]])

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>echo Checking that basic CNN works
Checking that basic CNN works

(testenv) C:\w\b\windows>python C:/w/b\test_example_code\cnn_smoke.py
C:\w\b\windows\conda\envs\testenv\lib\site-packages\torch\_masked\__init__.py:223: UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe (Triggered internally at  C:\cb\pytorch_1000000000000\work\torch\csrc\utils\tensor_numpy.cpp:68.)
  example_input = torch.tensor([[-3, -2, -1], [0, 1, 2]])
tensor([0.], device='cuda:0', grad_fn=<ViewBackward0>)

(testenv) C:\w\b\windows>if ERRORLEVEL 1 exit /b 1

(testenv) C:\w\b\windows>goto end
```










































































