### PR TITLE
Also reinstall Magma when reinstaling CUDA

### DIFF
--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -90,6 +90,7 @@ if [[ -n "$OVERRIDE_TORCH_CUDA_ARCH_LIST" ]]; then
 
     export OVERRIDE_GENCODE=$override_gencode
     bash "$(dirname "$SCRIPTPATH")"/common/install_cuda.sh "${CUDA_VERSION}"
+    bash "$(dirname "$SCRIPTPATH")"/common/install_magma.sh "${CUDA_VERSION}"
 fi
 
 export TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}


### PR DESCRIPTION
Fix case when `OVERRIDE_TORCH_CUDA_ARCH_LIST` is present. Currently, Magma is getting erased and pytorch is built without Magma support.