### PR TITLE
Make sure libcudnn are imported with their original name

### DIFF
--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -90,7 +90,7 @@ fname_with_sha256() {
     HASH=$(sha256sum $1 | cut -c1-8)
     DIRNAME=$(dirname $1)
     BASENAME=$(basename $1)
-    if [[ $BASENAME == "libnvrtc-builtins.so" ]]; then
+    if [[ $BASENAME == "libnvrtc-builtins.so" || $BASENAME == "libcudnn"* ]]; then
         echo $1
     else
         INITNAME=$(echo $BASENAME | cut -f1 -d".")

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -223,7 +223,7 @@ fname_with_sha256() {
     HASH=$(sha256sum $1 | cut -c1-8)
     DIRNAME=$(dirname $1)
     BASENAME=$(basename $1)
-    if [[ $BASENAME == "libnvrtc-builtins.so" ]]; then
+    if [[ $BASENAME == "libnvrtc-builtins.so" || $BASENAME == "libcudnn"* ]]; then
         echo $1
     else
         INITNAME=$(echo $BASENAME | cut -f1 -d".")


### PR DESCRIPTION
Issue with libcudnn are included with sha added to they name we want to make sure it included with their original name.

Without this fix the library will be included like so:
libcudnn-c8a8982f.so.8          

However to ensure proper linking it needs to be included like so:
libcudnn.so.8       

This fix is already implemented on manywheel side here: https://github.com/pytorch/builder/blob/main/manywheel/build_common.sh#L231

We want to make sure libcudnn are imported with their original name. 