### PR TITLE
[Conda] Use selectors rather than shell scripts

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -344,13 +344,6 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     rm -rf "$output_folder"
     mkdir "$output_folder"
 
-    export OPENSSL_PACKAGE=""
-    export NUMPY_PACKAGE="    - numpy=1.19"
-    if [[ ${py_ver} = "3.10" ]]; then
-      export NUMPY_PACKAGE="    - numpy>=1.21.2"
-      export OPENSSL_PACKAGE="    - openssl=1.1.1l"
-    fi
-
     # We need to build the compiler activation scripts first on Windows
     if [[ "$OSTYPE" == "msys" ]]; then
         vs_package="vs$VC_YEAR"

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -16,20 +16,20 @@ requirements:
     - python
     - setuptools
     - pyyaml
-    - mkl=2020.2 # [x86_64]
     - mkl-include # [x86_64]
+    - mkl=2020.2 # [x86_64 and (not win or py <= 39)]
+    - mkl=2021.4 # [x86_64 and win and py >= 310]
     - typing_extensions
     - dataclasses # [py36]
     - ninja
     - libuv # [win]
     - libuv # [unix]
     - pkg-config # [unix]
+    - numpy=1.19 # [py <= 39]
+    - numpy>=1.21.2 # [py >= 310]
+    - openssl=1.1.1l # [py >= 310 and linux]
 {{ environ.get('PYTORCH_LLVM_PACKAGE', '    - llvmdev=9') }}
 {{ environ.get('MAGMA_PACKAGE', '') }}
-# Conda has some pretty unpredictable behavior when it comes to channel priority
-# so to be safe on which numpy version we want we default to 1.19
-{{ environ.get('NUMPY_PACKAGE', '    - numpy=1.19') }}
-{{ environ.get('OPENSSL_PACKAGE', '') }}
 
   run:
     - python

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -100,10 +100,6 @@ set CUDA_VER_MINOR=%CUDA_VERSION:~-1,1%
 set CUDA_VERSION_STR=%CUDA_VER_MAJOR%.%CUDA_VER_MINOR%
 
 call conda update -n base -y -c defaults conda
-if "%PACKAGE_TYPE%" == "conda" (if "%DESIRED_PYTHON%" == "3.10"  (
-    call conda install -c=conda-forge -y cudatoolkit=%CUDA_VERSION_STR%
-    if errorlevel 1 exit /b 1
-))
 
 call conda install %CONDA_EXTRA_ARGS% -yq protobuf numpy
 if ERRORLEVEL 1 exit /b 1


### PR DESCRIPTION
According to [conda-build doc](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors) selectors are any valid Python statement

Use it to specify version specific constraints rather than use environment variables

Move openssl and numpy constraints to selectors as well

For Python-3.10, min numpy version is 1.21.2 and on Windows numpy depends on mkl=2021.4

Also openssl constraint should only be applied to Linux builds, as Mac and Windows ones are built without encryption

Testing in https://github.com/pytorch/pytorch/pull/73132
