### PR TITLE
Add cmake min version and pkg-config to build_aarch64_wheel script

### DIFF
--- a/build_aarch64_wheel.py
+++ b/build_aarch64_wheel.py
@@ -196,7 +196,7 @@ def install_condaforge_python(host: RemoteHost, python_version="3.8") -> None:
     else:
         install_condaforge(host)
         # Pytorch-1.10 or older are not compatible with setuptools=59.6 or newer
-        host.run_cmd(f"conda install -y python={python_version} numpy pyyaml setuptools=59.5.0")
+        host.run_cmd(f"conda install -y python={python_version} numpy cmake>=3.13 pkg-config pyyaml setuptools=59.5.0")
 
 
 def build_OpenBLAS(host: RemoteHost, git_clone_flags: str = "") -> None:


### PR DESCRIPTION
Add cmake min version and pkg-config to build_aarch64_wheel script 

This is to fix following issues:
1: Using the Ninja generator requires CMake version 3.13 or greater
2: Missing pkg-config