### PR TITLE
Explicitly turn off USE_CUPTI_SO

### DIFF
--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -12,6 +12,7 @@ export USE_STATIC_NCCL=1
 export ATEN_STATIC_CUDA=1
 export USE_CUDA_STATIC_LINK=1
 export INSTALL_TEST=0 # dont install test binaries into site-packages
+export USE_CUPTI_SO=0
 
 # Keep an array of cmake variables to add to
 if [[ -z "$CMAKE_ARGS" ]]; then


### PR DESCRIPTION
This is currently the default but I'm changing the default
in https://github.com/pytorch/pytorch/pull/66539 ; so this
change is necessary to preserve builder behavior.