### PR TITLE
Fix M1 conda cross builds

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -68,7 +68,6 @@ fi
 
 # differentiate package name for cross compilation to avoid collision
 if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
-    build_version="$build_version.arm64"
     export PYTORCH_LLVM_PACKAGE=""
 fi
 

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -1,4 +1,5 @@
 {% set build_variant = environ.get('PYTORCH_BUILD_VARIANT', 'cuda') %}
+{% set cmake_osx_architectures = environ.get('CMAKE_OSX_ARCHITECTURES', 'x86_64') %}
 
 package:
   name: pytorch
@@ -16,9 +17,9 @@ requirements:
     - python
     - setuptools
     - pyyaml
-    - mkl-include # [x86_64]
-    - mkl=2020.2 # [x86_64 and (not win or py <= 39)]
-    - mkl=2021.4 # [x86_64 and win and py >= 310]
+    - mkl-include # [x86_64 and cmake_osx_architectures == 'x86_64']
+    - mkl=2020.2 # [x86_64 and (not win or py <= 39) and cmake_osx_architectures == 'x86_64']
+    - mkl=2021.4 # [x86_64 and win and py >= 310 and cmake_osx_architectures == 'x86_64']
     - typing_extensions
     - dataclasses # [py36]
     - ninja


### PR DESCRIPTION
Do not claim that M1 binary depends on mkl
Do not add `arm64` suffix to the version