### PR TITLE
bump cudnn to 8.3.2.44 for CUDA11.3

### DIFF
--- a/common/install_cuda.sh
+++ b/common/install_cuda.sh
@@ -35,7 +35,7 @@ function install_102 {
 }
 
 function install_113 {
-    echo "Installing CUDA 11.3 and CuDNN 8.2"
+    echo "Installing CUDA 11.3 and CuDNN 8.3"
     rm -rf /usr/local/cuda-11.3 /usr/local/cuda
     # install CUDA 11.3.1 in the same container
     wget -q https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run
@@ -46,10 +46,10 @@ function install_113 {
 
     # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
     mkdir tmp_cudnn && cd tmp_cudnn
-    wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.2.0/cudnn-11.3-linux-x64-v8.2.0.53.tgz -O cudnn-8.2.tgz
-    tar xf cudnn-8.2.tgz
-    cp -a cuda/include/* /usr/local/cuda/include/
-    cp -a cuda/lib64/* /usr/local/cuda/lib64/
+    wget -q https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.2/local_installers/11.5/cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz -O cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz
+    tar xf cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive.tar.xz
+    cp -a cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive/include/* /usr/local/cuda/include/
+    cp -a cudnn-linux-x86_64-8.3.2.44_cuda11.5-archive/lib/* /usr/local/cuda/lib64/
     cd ..
     rm -rf tmp_cudnn
     ldconfig
@@ -151,7 +151,6 @@ function prune_113 {
 		"echo {} && $NVPRUNE $GENCODE $CUDA_LIB_DIR/{} -o $CUDA_LIB_DIR/{}"
 
     # prune CuDNN and CuBLAS
-    $NVPRUNE $GENCODE_CUDNN $CUDA_LIB_DIR/libcudnn_static.a -o $CUDA_LIB_DIR/libcudnn_static.a
     $NVPRUNE $GENCODE_CUDNN $CUDA_LIB_DIR/libcublas_static.a -o $CUDA_LIB_DIR/libcublas_static.a
     $NVPRUNE $GENCODE_CUDNN $CUDA_LIB_DIR/libcublasLt_static.a -o $CUDA_LIB_DIR/libcublasLt_static.a
 

--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -58,6 +58,11 @@ if [[ -n "$build_with_cuda" ]]; then
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5"
     elif [[ $CUDA_VERSION == 11.3* ]]; then
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0;8.6"
+	#for cuda 11.3 we use cudnn 8.3.2.44 https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html
+        #which does not have single static libcudnn_static.a deliverable to link with
+        export USE_STATIC_CUDNN=0
+        #for cuda 11.3 include all dynamic loading libraries
+        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8)
     elif [[ $CUDA_VERSION == 11.5* ]]; then
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0;8.6"
         #for cuda 11.5 we use cudnn 8.3.2.44 https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -125,11 +125,19 @@ DEPS_SONAME=(
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.3" ]]; then
+export USE_STATIC_CUDNN=0
 DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.11.0"
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
     "/usr/local/cuda/lib64/libnvrtc.so.11.2"    # this is not a mistake for 11.3, it links to 11.3.58
     "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.3"
+    "/usr/local/cuda/lib64/libcudnn_adv_infer.so.8"
+    "/usr/local/cuda/lib64/libcudnn_adv_train.so.8"
+    "/usr/local/cuda/lib64/libcudnn_cnn_infer.so.8"
+    "/usr/local/cuda/lib64/libcudnn_cnn_train.so.8"
+    "/usr/local/cuda/lib64/libcudnn_ops_infer.so.8"
+    "/usr/local/cuda/lib64/libcudnn_ops_train.so.8"
+    "/usr/local/cuda/lib64/libcudnn.so.8"
     "$LIBGOMP_PATH"
 )
 
@@ -138,6 +146,13 @@ DEPS_SONAME=(
     "libnvToolsExt.so.1"
     "libnvrtc.so.11.2"
     "libnvrtc-builtins.so.11.3"
+    "libcudnn_adv_infer.so.8"
+    "libcudnn_adv_train.so.8"
+    "libcudnn_cnn_infer.so.8"
+    "libcudnn_cnn_train.so.8"
+    "libcudnn_ops_infer.so.8"
+    "libcudnn_ops_train.so.8"
+    "libcudnn.so.8"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.5" ]]; then

--- a/windows/internal/cuda_install.bat
+++ b/windows/internal/cuda_install.bat
@@ -53,12 +53,20 @@ if not exist "%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%" (
     set "ARGS=thrust_11.3 nvcc_11.3 cuobjdump_11.3 nvprune_11.3 nvprof_11.3 cupti_11.3 cublas_11.3 cublas_dev_11.3 cudart_11.3 cufft_11.3 cufft_dev_11.3 curand_11.3 curand_dev_11.3 cusolver_11.3 cusolver_dev_11.3 cusparse_11.3 cusparse_dev_11.3 npp_11.3 npp_dev_11.3 nvrtc_11.3 nvrtc_dev_11.3 nvml_dev_11.3"
 )
 
-set CUDNN_INSTALL_ZIP=cudnn-11.3-windows-x64-v8.2.0.53.zip
+set CUDNN_FOLDER=cudnn-windows-x86_64-8.3.2.44_cuda11.5-archive
+set CUDNN_LIB_FOLDER="lib"
+set CUDNN_INSTALL_ZIP=%CUDNN_FOLDER%.zip"
 if not exist "%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%" (
     curl -k -L "http://s3.amazonaws.com/ossci-windows/%CUDNN_INSTALL_ZIP%" --output "%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%"
     if errorlevel 1 exit /b 1
     set "CUDNN_SETUP_FILE=%SRC_DIR%\temp_build\%CUDNN_INSTALL_ZIP%"
 )
+
+@REM Cuda 8.3+ required zlib to be installed on the path
+echo Installing ZLIB dlls
+curl -k -L "http://s3.amazonaws.com/ossci-windows/zlib123dllx64.zip" --output "%SRC_DIR%\temp_build\zlib123dllx64.zip"
+7z x "%SRC_DIR%\temp_build\zlib123dllx64.zip" -o"%SRC_DIR%\temp_build\zlib"
+xcopy /Y "%SRC_DIR%\temp_build\zlib\dll_x64\*.dll" "C:\Windows\System32"
 
 goto cuda_common
 


### PR DESCRIPTION
Updates cuDNN to 8.3.2.44 for the CUDA11.3 builds and uses dynamic linking (same as done for CUDA11.5).

CC @atalman 