### PR TITLE
Package cudnn binaries into cuda-11.3

### DIFF
--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -63,8 +63,7 @@ if [[ -n "$build_with_cuda" ]]; then
         #which does not have single static libcudnn_static.a deliverable to link with
         export USE_STATIC_CUDNN=0
         #for cuda 11.3 include all dynamic loading libraries
-        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8)
-        DEPS_LIST=(/usr/local/cuda-11.3/extras/CUPTI/lib64/libcupti.so.11.3)
+        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8 /usr/local/cuda-11.3/extras/CUPTI/lib64/libcupti.so.11.3)
     elif [[ $CUDA_VERSION == 11.5* ]]; then
         export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0;8.6"
         #for cuda 11.5 we use cudnn 8.3.2.44 https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html

--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -70,7 +70,7 @@ if [[ -n "$build_with_cuda" ]]; then
         #which does not have single static libcudnn_static.a deliverable to link with
         export USE_STATIC_CUDNN=0
         #for cuda 11.5 include all dynamic loading libraries
-        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8)
+        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8 /usr/local/cuda-11.5/extras/CUPTI/lib64/libcupti.so.11.5)
     fi
     export NCCL_ROOT_DIR=/usr/local/cuda
     export USE_STATIC_NCCL=1  # links nccl statically (driven by tools/setup_helpers/nccl.py, some of the NCCL cmake files such as FindNCCL.cmake and gloo/FindNCCL.cmake)


### PR DESCRIPTION
2nd DEPS_LIST definition overrode the first one
Also, bundle cupti for 11.5 conda build

Testing in https://github.com/pytorch/pytorch/pull/74783

Fixes https://github.com/pytorch/pytorch/issues/74779