### PR TITLE
Get rid of  `libuv`  requirements on Unix

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -12,7 +12,9 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }} # [win]
-
+    - pkg-config # [unix]
+    - libuv # [unix]
+    
   host:
     - python
     - setuptools
@@ -26,8 +28,6 @@ requirements:
     - dataclasses # [py36]
     - ninja
     - libuv # [win]
-    - libuv # [unix]
-    - pkg-config # [unix]
     - numpy=1.19 # [py <= 39]
     - numpy>=1.21.2 # [py >= 310]
     - openssl=1.1.1l # [py >= 310 and linux]


### PR DESCRIPTION
As `libuv` is bundled with tensorpipe and after https://github.com/pytorch/pytorch/pull/77312 can be used by Gloo backend as well

Tested in https://github.com/pytorch/pytorch/pull/74141