### PR TITLE
Revert "Pin cmake 3.22.3"

### DIFF
--- a/conda/debugging_pytorch.sh
+++ b/conda/debugging_pytorch.sh
@@ -14,7 +14,7 @@ export USE_CUDA_STATIC_LINK=1
 . ./switch_cuda_version.sh 9.0
 
 
-conda install -y cmake=3.22.3 numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing_extension ninja magma-cuda80 -c pytorch
+conda install -y cmake numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing_extension ninja magma-cuda80 -c pytorch
 
 export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 git clone https://github.com/pytorch/pytorch -b nightly2 --recursive

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -166,7 +166,7 @@ tmp_env_name="wheel_py$python_nodot"
 conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "$tmp_env_name" python="$desired_python"
 source activate "$tmp_env_name"
 
-retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake=3.22.3 "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
+retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq mkl-include==2020.1 mkl-static==2020.1 -c intel
 retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 


### PR DESCRIPTION
Reverts pytorch/builder#1011 as this cmake version is not available on [anaconda](https://anaconda.org/anaconda/cmake) as of today: 
<img width="373" alt="image" src="https://user-images.githubusercontent.com/2453524/162033050-a4598a40-1d20-4548-9c00-cefd5f169f9e.png">
