### PR TITLE
Pin cmake to 3.22.1 for conda

### DIFF
--- a/conda/debugging_pytorch.sh
+++ b/conda/debugging_pytorch.sh
@@ -14,7 +14,7 @@ export USE_CUDA_STATIC_LINK=1
 . ./switch_cuda_version.sh 9.0
 
 
-conda install -y cmake numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing_extension ninja magma-cuda80 -c pytorch
+conda install -y cmake=3.22.1 numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing_extension ninja magma-cuda80 -c pytorch
 
 export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 git clone https://github.com/pytorch/pytorch -b nightly2 --recursive

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -160,13 +160,14 @@ case ${desired_python} in
         NUMPY_PINNED_VERSION="=1.11.3"
         ;;
 esac
+CMAKE_PINNED_VERSION="=3.22.1"
 
 # Install into a fresh env
 tmp_env_name="wheel_py$python_nodot"
 conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "$tmp_env_name" python="$desired_python"
 source activate "$tmp_env_name"
 
-retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake=3.22.1 "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
+retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq "cmake${CMAKE_PINNED_VERSION}" "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq mkl-include==2020.1 mkl-static==2020.1 -c intel
 retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -166,7 +166,7 @@ tmp_env_name="wheel_py$python_nodot"
 conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "$tmp_env_name" python="$desired_python"
 source activate "$tmp_env_name"
 
-retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
+retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake=3.22.1 "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq mkl-include==2020.1 mkl-static==2020.1 -c intel
 retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 


### PR DESCRIPTION
Summary: See title


Test Plan:
I tried running conda/build_all.sh but I got this error about not being able to find a submodule. I tried running it on master as well but still couldn't find it. It doesn't seem like that's a git repo anymore?

```
fatal: repository 'https://github.com/NervanaSystems/nervanagpu.git/' not found
fatal: clone of 'https://github.com/NervanaSystems/nervanagpu.git' into submodule path '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/nervanagpu' failed
Failed to clone 'third_party/nervanagpu' a second time, aborting
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/sleef'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/python-six'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/pybind11'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/googletest'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/onnx'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/catch'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/cereal'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/cub'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/zstd'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/eigen'...
Cloning into '/Users/kerryz/Workspace/builder/wheel/tmp_wheel_conda__193503/pytorch/third_party/protobuf'...
(base) kerryz@kerryz-mbp wheel % ls
```

