### PR TITLE
Cuda 11.6 include libraries like cudnn and others

### DIFF
--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -71,6 +71,13 @@ if [[ -n "$build_with_cuda" ]]; then
         export USE_STATIC_CUDNN=0
         #for cuda 11.5 include all dynamic loading libraries
         DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8 /usr/local/cuda-11.5/extras/CUPTI/lib64/libcupti.so.11.5)
+    elif [[ $CUDA_VERSION == 11.6* ]]; then
+        export TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;6.0;6.1;7.0;7.5;8.0;8.6"
+        #for cuda 11.5 we use cudnn 8.3.2.44 https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html
+        #which does not have single static libcudnn_static.a deliverable to link with
+        export USE_STATIC_CUDNN=0
+        #for cuda 11.5 include all dynamic loading libraries
+        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8 /usr/local/cuda-11.6/extras/CUPTI/lib64/libcupti.so.11.6)
     fi
     export NCCL_ROOT_DIR=/usr/local/cuda
     export USE_STATIC_NCCL=1  # links nccl statically (driven by tools/setup_helpers/nccl.py, some of the NCCL cmake files such as FindNCCL.cmake and gloo/FindNCCL.cmake)

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -138,6 +138,8 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudnn_ops_infer.so.8"
     "/usr/local/cuda/lib64/libcudnn_ops_train.so.8"
     "/usr/local/cuda/lib64/libcudnn.so.8"
+    "/usr/local/cuda/lib64/libcublas.so.11"
+    "/usr/local/cuda/lib64/libcublasLt.so.11"
     "$LIBGOMP_PATH"
 )
 
@@ -153,6 +155,8 @@ DEPS_SONAME=(
     "libcudnn_ops_infer.so.8"
     "libcudnn_ops_train.so.8"
     "libcudnn.so.8"
+    "libcublas.so.11"
+    "libcublasLt.so.11"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.5" ]]; then
@@ -189,6 +193,41 @@ DEPS_SONAME=(
     "libcublasLt.so.11"
     "libgomp.so.1"
 )
+elif [[ $CUDA_VERSION == "11.6" ]]; then
+export USE_STATIC_CUDNN=0
+DEPS_LIST=(
+    "/usr/local/cuda/lib64/libcudart.so.11.0"
+    "/usr/local/cuda/lib64/libnvToolsExt.so.1"
+    "/usr/local/cuda/lib64/libnvrtc.so.11.2"    # this is not a mistake for 11.5, it links to 11.5.50
+    "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.6"
+    "/usr/local/cuda/lib64/libcudnn_adv_infer.so.8"
+    "/usr/local/cuda/lib64/libcudnn_adv_train.so.8"
+    "/usr/local/cuda/lib64/libcudnn_cnn_infer.so.8"
+    "/usr/local/cuda/lib64/libcudnn_cnn_train.so.8"
+    "/usr/local/cuda/lib64/libcudnn_ops_infer.so.8"
+    "/usr/local/cuda/lib64/libcudnn_ops_train.so.8"
+    "/usr/local/cuda/lib64/libcudnn.so.8"
+    "/usr/local/cuda/lib64/libcublas.so.11"
+    "/usr/local/cuda/lib64/libcublasLt.so.11"
+    "$LIBGOMP_PATH"
+)
+DEPS_SONAME=(
+    "libcudart.so.11.0"
+    "libnvToolsExt.so.1"
+    "libnvrtc.so.11.2"
+    "libnvrtc-builtins.so.11.5"
+    "libcudnn_adv_infer.so.8"
+    "libcudnn_adv_train.so.8"
+    "libcudnn_cnn_infer.so.8"
+    "libcudnn_cnn_train.so.8"
+    "libcudnn_ops_infer.so.8"
+    "libcudnn_ops_train.so.8"
+    "libcudnn.so.8"
+    "libcublas.so.11"
+    "libcublasLt.so.11"
+    "libgomp.so.1"
+)
+
 
 # Try parallelizing nvcc as well
 export TORCH_NVCC_FLAGS="-Xfatbin -compress-all --threads 2"

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -215,7 +215,7 @@ DEPS_SONAME=(
     "libcudart.so.11.0"
     "libnvToolsExt.so.1"
     "libnvrtc.so.11.2"
-    "libnvrtc-builtins.so.11.5"
+    "libnvrtc-builtins.so.11.6"
     "libcudnn_adv_infer.so.8"
     "libcudnn_adv_train.so.8"
     "libcudnn_cnn_infer.so.8"

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -198,7 +198,7 @@ export USE_STATIC_CUDNN=0
 DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudart.so.11.0"
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
-    "/usr/local/cuda/lib64/libnvrtc.so.11.2"    # this is not a mistake for 11.5, it links to 11.5.50
+    "/usr/local/cuda/lib64/libnvrtc.so.11.2"    # this is not a mistake for 11.6
     "/usr/local/cuda/lib64/libnvrtc-builtins.so.11.6"
     "/usr/local/cuda/lib64/libcudnn_adv_infer.so.8"
     "/usr/local/cuda/lib64/libcudnn_adv_train.so.8"


### PR DESCRIPTION
Cuda 11.6 include libraries.
libcudnn is now dynamically linked since 11.5.