### PR TITLE
run_tests.sh: fix issue that cpu-cxx11-abi tests on cuda

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -51,6 +51,10 @@ else
   cuda_ver="$3"
 fi
 
+if [[ "$cuda_ver" == 'cpu-cxx11-abi' ]]; then
+    cuda_ver="cpu"
+fi
+
 # cu80, cu90, cu100, cpu
 if [[ ${#cuda_ver} -eq 4 ]]; then
     cuda_ver_majmin="${cuda_ver:2:1}.${cuda_ver:3:1}"


### PR DESCRIPTION
we pass DESIRED_CUDA=cpu-cxx11-abi to the container to build
pytorch wheel with file name like *cpu.cxx11.abi*, and so it is
different with the original cpu wheel file.

this patch corrects the test setting to use same test for cpu
and cpu-cxx11-abi.