### PR TITLE
[ROCm] fix libtorch docker images, missing drm

### DIFF
--- a/common/install_rocm_drm.sh
+++ b/common/install_rocm_drm.sh
@@ -7,7 +7,9 @@
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   ubuntu)
-    apt install -y libpciaccess-dev pkg-config
+    apt-get update -y
+    apt-get install -y libpciaccess-dev pkg-config
+    apt-get clean
     ;;
   centos)
     yum install -y libpciaccess-devel pkgconfig
@@ -36,7 +38,7 @@ index a5007ffc..a3627529 100644
 @@ -22,6 +22,13 @@
   *
   */
- 
+
 +#define _XOPEN_SOURCE 700
 +#define _LARGEFILE64_SOURCE
 +#define _FILE_OFFSET_BITS 64
@@ -50,7 +52,7 @@ index a5007ffc..a3627529 100644
 @@ -34,6 +41,21 @@
  #include "amdgpu_drm.h"
  #include "amdgpu_internal.h"
- 
+
 +static char *amdgpuids_path = NULL;
 +
 +static int check_for_location_of_amdgpuids(const char *filepath, const struct stat *info, const int typeflag, struct FTW *pathinfo)
@@ -72,7 +74,7 @@ index a5007ffc..a3627529 100644
 @@ -113,13 +135,48 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
  	int line_num = 1;
  	int r = 0;
- 
+
 -	fp = fopen(AMDGPU_ASIC_ID_TABLE, "r");
 +	char self_path[ PATH_MAX ];
 +	ssize_t count;
@@ -113,7 +115,7 @@ index a5007ffc..a3627529 100644
  			strerror(errno));
  		return;
  	}
- 
+
 +	}
 +
  	/* 1st valid line is file version */

--- a/common/install_rocm_drm.sh
+++ b/common/install_rocm_drm.sh
@@ -7,9 +7,7 @@
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   ubuntu)
-    apt-get update -y
-    apt-get install -y libpciaccess-dev pkg-config
-    apt-get clean
+    apt install -y libpciaccess-dev pkg-config
     ;;
   centos)
     yum install -y libpciaccess-devel pkgconfig
@@ -38,7 +36,7 @@ index a5007ffc..a3627529 100644
 @@ -22,6 +22,13 @@
   *
   */
-
+ 
 +#define _XOPEN_SOURCE 700
 +#define _LARGEFILE64_SOURCE
 +#define _FILE_OFFSET_BITS 64
@@ -52,7 +50,7 @@ index a5007ffc..a3627529 100644
 @@ -34,6 +41,21 @@
  #include "amdgpu_drm.h"
  #include "amdgpu_internal.h"
-
+ 
 +static char *amdgpuids_path = NULL;
 +
 +static int check_for_location_of_amdgpuids(const char *filepath, const struct stat *info, const int typeflag, struct FTW *pathinfo)
@@ -74,7 +72,7 @@ index a5007ffc..a3627529 100644
 @@ -113,13 +135,48 @@ void amdgpu_parse_asic_ids(struct amdgpu_device *dev)
  	int line_num = 1;
  	int r = 0;
-
+ 
 -	fp = fopen(AMDGPU_ASIC_ID_TABLE, "r");
 +	char self_path[ PATH_MAX ];
 +	ssize_t count;
@@ -115,7 +113,7 @@ index a5007ffc..a3627529 100644
  			strerror(errno));
  		return;
  	}
-
+ 
 +	}
 +
  	/* 1st valid line is file version */

--- a/common/install_rocm_drm.sh
+++ b/common/install_rocm_drm.sh
@@ -7,7 +7,9 @@
 ID=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
 case "$ID" in
   ubuntu)
-    apt install -y libpciaccess-dev pkg-config
+    apt-get update -y
+    apt-get install -y libpciaccess-dev pkg-config
+    apt-get clean
     ;;
   centos)
     yum install -y libpciaccess-devel pkgconfig

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -65,6 +65,7 @@ ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ENV MKLROOT /opt/intel
 ADD ./common/install_rocm.sh install_rocm.sh
+ADD ./common/install_rocm_drm.sh install_rocm_drm.sh
 ADD ./common/install_rocm_magma.sh install_rocm_magma.sh
 # gfortran needed for building magma from source for ROCm
 RUN apt-get update -y && \
@@ -73,10 +74,12 @@ RUN apt-get update -y && \
 
 FROM rocm as rocm5.0
 RUN ROCM_VERSION=5.0 bash ./install_rocm.sh && rm install_rocm.sh
+RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
 RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
 
 FROM rocm as rocm5.1.1
 RUN ROCM_VERSION=5.1.1 bash ./install_rocm.sh && rm install_rocm.sh
+RUN bash ./install_rocm_drm.sh && rm install_rocm_drm.sh
 RUN bash ./install_rocm_magma.sh && rm install_rocm_magma.sh
 
 FROM ${BASE_TARGET} as final


### PR DESCRIPTION
libtorch nightly builds were failing due to missing custom drm package.