### PR TITLE
Disable nnpack for macos binaries

### DIFF
--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -174,10 +174,12 @@ retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 export USE_DISTRIBUTED=1
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq libuv pkg-config
 
+# NNPACK Is disabled on macOS because of https://github.com/pytorch/pytorch/issues/76094
+export USE_NNPACK=OFF
+
 if [[ -n "$CROSS_COMPILE_ARM64" ]]; then
     export CMAKE_OSX_ARCHITECTURES=arm64
     export USE_MKLDNN=OFF
-    export USE_NNPACK=OFF
     export USE_QNNPACK=OFF
     export BUILD_TEST=OFF
 else


### PR DESCRIPTION
This will be followed by a PR on the pytorch/pytorch repo migrating the binary builds for x86 to be on macos-12 runners.