### PR TITLE
Pin numpy to 1.21.5

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - libuv # [unix]
     - pkg-config # [unix]
     - numpy=1.19 # [py <= 39]
-    - numpy>=1.21.2 # [py >= 310]
+    - numpy=1.21.5 # [py >= 310]
     - openssl=1.1.1l # [py >= 310 and linux]
 {{ environ.get('PYTORCH_LLVM_PACKAGE', '    - llvmdev=9') }}
 {{ environ.get('MAGMA_PACKAGE', '') }}


### PR DESCRIPTION
This pins numpy to 1.21.5 to fix torchvision downstream module following failure:
Since 18 May the numpy version of the core module have advanced to:
- numpy 1.22.3 py310h4f1e569_0
- numpy-base 1.22.3 py310hf2716ce_0

This create following issue in torchvision    
https://app.circleci.com/pipelines/github/pytorch/vision/17720/workflows/4d40b9b7-99f5-43d9-a076-d9d1e55b7fff/jobs/1435021


Tested on circleci:
```
Collecting environment information...
PyTorch version: 1.12.0.dev20220517
Is debug build: False
CUDA used to build PyTorch: Could not collect
ROCM used to build PyTorch: N/A

OS: CentOS Linux 7 (Core) (x86_64)
GCC version: (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)
Clang version: Could not collect
CMake version: Could not collect
Libc version: glibc-2.17

Python version: 3.10.4 (main, Mar 31 2022, 08:41:55) [GCC 7.5.0] (64-bit runtime)
Python platform: Linux-5.13.0-1021-aws-x86_64-with-glibc2.17
Is CUDA available: False
CUDA runtime version: 10.2.89
GPU models and configuration: Could not collect
Nvidia driver version: Could not collect
cuDNN version: Could not collect
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

Versions of relevant libraries:
[pip3] numpy==1.21.5
[pip3] torch==1.12.0.dev20220517
[pip3] torchvision==0.13.0a0+32a7c7b
[conda] blas                      1.0                         mkl
[conda] cpuonly                   2.0                           0    pytorch-nightly
[conda] ffmpeg                    4.2                  hf484d3e_0    pytorch
[conda] mkl                       2021.4.0           h06a4308_640
[conda] mkl-service               2.4.0           py310h7f8727e_0
[conda] mkl_fft                   1.3.1           py310hd6ae3a3_0
[conda] mkl_random                1.2.2           py310h00e6091_0
[conda] numpy                     1.21.5          py310hfa59a62_2
[conda] numpy-base                1.21.5          py310h9585f30_2
[conda] pytorch                   1.12.0.dev20220517    py3.10_cpu_0    <unknown>
[conda] pytorch-mutex             1.0                         cpu    pytorch-nightly
[conda] torchvision               0.13.0a0+32a7c7b           dev_0    <develop>
============================= test session starts ==============================
platform linux -- Python 3.10.4, pytest-7.1.1, pluggy-1.0.0 -- /root/project/env/bin/python
cachedir: .pytest_cache
rootdir: /root/project, configfile: pytest.ini, testpaths: test
plugins: cov-3.0.0, mock-3.6.1
collecting ... collected 29590 items / 1 skipped

test/test_backbone_utils.py::test_resnet_fpn_backbone[resnet18] PASSED   [  0%]
test/test_backbone_utils.py::test_resnet_fpn_backbone[resnet50] PASSED   [  0%]
test/test_backbone_utils.py::test_mobilenet_backbone[mobilenet_v2] PASSED [  0%]
test/test_backbone_utils.py::test_mobilenet_backbone[mobilenet_v3_large] PASSED [  0%]
test/test_backbone_utils.py::test_mobilenet_backbone[mobilenet_v3_small] PASSED [  0%]
```