### PR TITLE
[github_analyze] also print body for print-reverts

### DIFF
--- a/analytics/github_analyze.py
+++ b/analytics/github_analyze.py
@@ -288,7 +288,7 @@ def print_reverts(commits: List[GitCommit]) -> None:
     for commit in commits:
         if not is_revert(commit):
             continue
-        print(f"{commit.commit_date} {commit.title} {commit.commit_hash}")
+        print(f"{commit.commit_date} {commit.title} {commit.commit_hash} {commit.body}")
 
 
 def analyze_reverts(commits: List[GitCommit]):


### PR DESCRIPTION
The body usually has the revert reason + at least the PR it's reverting, which is more useful to see as an oncall.

It does print more stuff though, see
```
2022-05-06 15:34:41 Revert D29463782: opitimze ConvTransposedND with mkldnn float32 and bfloat16 on CPU b08633917d5bb9da7f919b2c90864bf993de41b5     
    Test Plan: revert-hammer
    
    Differential Revision:
    D29463782 (https://github.com/pytorch/pytorch/commit/479e0d64e607d48fc61a958caf6aeaf165e3d45d)
    
    Original commit changeset: 74b3d6138945
    
    Original Phabricator Diff: D29463782 (https://github.com/pytorch/pytorch/commit/479e0d64e607d48fc61a958caf6aeaf165e3d45d)
    
    fbshipit-source-id: a9765f67f9c8c01faad82450e3c6a8d0c0abbe4b
    (cherry picked from commit 12ce4ef02a13da85aa9bfe6c92ac41d4e0b8d2b0)

2022-05-05 19:13:10 Revert "Contribution- Grammatical Corrections in the documentation" 8ac6b0a0107f2a3bde96a01eaadc49eb7aeec7f8     
    This reverts commit a0ebf1d386b0257fd98bb5f6d28d2b42832817e1.
    
    Reverted https://github.com/pytorch/pytorch/pull/57411 on behalf of https://github.com/malfet

2022-05-05 01:05:51 Revert "Add ZT fastpath for remainder.Tensor JVP" da15d76e8314c854f82847ef9fdf906a100f7741     
    This reverts commit 7471f614ae00e31ff9cd47ac0b2d98702c905c76.
    
    Reverted https://github.com/pytorch/pytorch/pull/76479 on behalf of https://github.com/anjali411
```