### PR TITLE
git224-core no longer available, use git236-core

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -108,7 +108,7 @@ RUN yum install -y \
 RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum swap -y git git224-core
+RUN yum swap -y git git236-core
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 # Install LLVM version

--- a/manywheel/Dockerfile_2014
+++ b/manywheel/Dockerfile_2014
@@ -88,7 +88,7 @@ RUN yum install -y \
 RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum swap -y git git224-core
+RUN yum swap -y git git236-core
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 # Install LLVM version


### PR DESCRIPTION
Fixes the error:

```
#10 [common  4/19] RUN yum swap -y git git224-core
#10 sha256:e9a6243e3c9c6d05a358419c93665b335b2d6e7e131c00060e8cdd6af792182f
#10 6.122 No package git224-core available.
#10 6.278 Error: swap install git224-core
#10 ERROR: executor failed running [/bin/sh -c yum swap -y git git224-core]: exit code: 1
```