### PR TITLE
Git add pytorch as safe directory

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -90,6 +90,8 @@ else
     pushd $pytorch_rootdir
 fi
 pushd $pytorch_rootdir
+
+git config --global --add safe.directory $pytorch_rootdir
 git submodule update --init --recursive --jobs 0
 
 export PATCHELF_BIN=/usr/local/bin/patchelf


### PR DESCRIPTION
This is related to this error observed in libtorch builds: fatal: unsafe repository (REPO is owned by someone else)

Failing workflow:
https://github.com/pytorch/pytorch/runs/6650107715?check_suite_focus=true

Error:
```
fatal: unsafe repository ('/pytorch' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /pytorch
```