### PR TITLE
Remove extra git clone from libtorch

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -77,23 +77,6 @@ fi
 pydir="/opt/python/$DESIRED_PYTHON"
 export PATH="$pydir/bin:$PATH"
 
-# Clone pytorch source code
-pytorch_rootdir="/pytorch"
-if [[ ! -d "$pytorch_rootdir" ]]; then
-    # TODO probably safe to completely remove this
-    git clone https://github.com/pytorch/pytorch $pytorch_rootdir
-    pushd $pytorch_rootdir
-    if ! git checkout v${PYTORCH_BUILD_VERSION}; then
-          git checkout tags/v${PYTORCH_BUILD_VERSION}
-    fi
-else
-    pushd $pytorch_rootdir
-fi
-pushd $pytorch_rootdir
-
-git config --global --add safe.directory $pytorch_rootdir
-git submodule update --init --recursive --jobs 0
-
 export PATCHELF_BIN=/usr/local/bin/patchelf
 patchelf_version=`$PATCHELF_BIN --version`
 echo "patchelf version: " $patchelf_version
@@ -189,7 +172,7 @@ fi
     mv libtorch/lib/libtorch_cpu.so.dbg debug/libtorch_cpu.so.dbg
 
     echo "${PYTORCH_BUILD_VERSION}" > libtorch/build-version
-    echo "$(pushd $pytorch_rootdir && git rev-parse HEAD)" > libtorch/build-hash
+    echo "$(pushd $PYTORCH_ROOT && git rev-parse HEAD)" > libtorch/build-hash
 
 )
 

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -88,6 +88,11 @@ fi
 ########################################################
 # Compile wheels as well as libtorch
 #######################################################
+if [[ -z "$PYTORCH_ROOT" ]]; then
+    echo "Need to set PYTORCH_ROOT env variable"
+    exit 1
+fi
+pushd "$PYTORCH_ROOT"
 python setup.py clean
 retry pip install -qr requirements.txt
 if [[ "$DESIRED_PYTHON"  == "cp37-cp37m" ]]; then

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -90,6 +90,8 @@ else
     pushd $pytorch_rootdir
 fi
 pushd $pytorch_rootdir
+
+git config --global --add safe.directory $pytorch_rootdir
 git submodule update --init --recursive --jobs 0
 
 export PATCHELF_BIN=/usr/local/bin/patchelf


### PR DESCRIPTION
This is related to this error observed in libtorch builds: fatal: unsafe repository (REPO is owned by someone else)

Failing workflow:
https://github.com/pytorch/pytorch/runs/6650107715?check_suite_focus=true

Error:
```
fatal: unsafe repository ('/pytorch' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /pytorch
```

This error is related to: https://github.com/actions/checkout/issues/760
And this : https://github.blog/2022-04-12-git-security-vulnerability-announced/

Test PR:
https://github.com/pytorch/pytorch/pull/78495

Test workflow:
https://github.com/pytorch/pytorch/runs/6660497517?check_suite_focus=true

To followup on this issue, looks like we don't need this git step altogether:
This was added here:
https://github.com/pytorch/builder/pull/690
It was removed from common here:
https://github.com/pytorch/builder/pull/861

But not from libtorch, hence will be removing it from libtorch as well

