### PR TITLE
Manywheel: mark all git directories as safe

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -109,6 +109,11 @@ RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum swap -y git git236-core
+# git236+ would refuse to run git commands in repos owned by other users
+# Which causes version check to fail, as pytorch repo is bind-mounted into the image
+# Override this behaviour by treating every folder as safe
+# For more details see https://github.com/pytorch/pytorch/issues/78659#issuecomment-1144107327
+RUN git config --global --add safe.directory "*"
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 # Install LLVM version

--- a/manywheel/Dockerfile_2014
+++ b/manywheel/Dockerfile_2014
@@ -89,6 +89,11 @@ RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum swap -y git git236-core
+# git236+ would refuse to run git commands in repos owned by other users
+# Which causes version check to fail, as pytorch repo is bind-mounted into the image
+# Override this behaviour by treating every folder as safe
+# For more details see https://github.com/pytorch/pytorch/issues/78659#issuecomment-1144107327
+RUN git config --global --add safe.directory "*"
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 # Install LLVM version


### PR DESCRIPTION
`gitcore-2.36+` refuses to run commands in repos not owned by the user
invoking the command. As `pytorch` and `builder` folders are mounted
into the image, set `safe.directory` global parameter to "*"

Fixes https://github.com/pytorch/pytorch/issues/78659