### PR TITLE
Revert "binary: Add check for git_version"

### DIFF
--- a/check_binary.sh
+++ b/check_binary.sh
@@ -310,16 +310,6 @@ else
   popd
 fi
 
-###############################################################################
-# Check torch.git_version
-###############################################################################
-if [[ "$PACKAGE_TYPE" != 'libtorch' ]]; then
-  pushd /tmp
-  python -c 'import torch; assert torch.git_version != "Unknown"'
-  python -c 'import torch; assert torch.git_version != None'
-  popd
-fi
-
 
 ###############################################################################
 # Check for MKL


### PR DESCRIPTION
Reverts pytorch/builder#1044 as `torch.git_version` argument does not exist and causes failures like that one: https://github.com/pytorch/pytorch/runs/6717304921?check_suite_focus=true