### PR TITLE
Fix libtorch static builds that regressed

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -122,8 +122,14 @@ fi
 
 echo "Calling setup.py install at $(date)"
 
+BUILD_SHARED_VAR="ON"
+USE_TENSORPIPE_VAR="ON"
 if [[ $LIBTORCH_VARIANT = *"static"* ]]; then
     STATIC_CMAKE_FLAG="-DTORCH_STATIC=1"
+    BUILD_SHARED_VAR="OFF"
+    # Tensorpipe breaks with static builds.
+    # Remove this after https://github.com/pytorch/tensorpipe/issues/449 is fixed
+    USE_TENSORPIPE_VAR="OFF"
 fi
 
 (
@@ -135,7 +141,9 @@ fi
         EXTRA_CAFFE2_CMAKE_FLAGS="${EXTRA_CAFFE2_CMAKE_FLAGS[@]} $STATIC_CMAKE_FLAG" \
         # TODO: Remove this flag once https://github.com/pytorch/pytorch/issues/55952 is closed
         CFLAGS='-Wno-deprecated-declarations' \
-        BUILD_LIBTORCH_CPU_WITH_DEBUG=1 \
+	BUILD_SHARED_LIBS=${BUILD_SHARED_VAR} \
+	USE_TENSORPIPE=${USE_TENSORPIPE_VAR} \
+	BUILD_LIBTORCH_CPU_WITH_DEBUG=1 \
         python setup.py install
 
     mkdir -p libtorch/{lib,bin,include,share}


### PR DESCRIPTION
libtorch-static used to ship libtorch.a until 1.0.1 and has
regressed since forcing people to build from source.

This fixes the build commands and add BUILD_SHARED_LIBS=OFF
It also removes build it as a debug build, and turns off
USE_TENSORPIPE until https://github.com/pytorch/tensorpipe/issues/449
is fixed.

Tested on my system to verify a libtorch.a is produced but can't
test the CI

Fixes: https://github.com/pytorch/pytorch/issues/70898