### PR TITLE
Packaging libcusolver.so as part of manywheel package

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -234,7 +234,7 @@ fname_with_sha256() {
     # Do not rename nvrtc-builtins.so as they are dynamically loaded
     # by libnvrtc.so
     # Similarly don't mangle libcudnn and libcublas library names
-    if [[ $BASENAME == "libnvrtc-builtins.s"* || $BASENAME == "libcudnn"* || $BASENAME == "libcublas"*  ]]; then
+    if [[ $BASENAME == "libnvrtc-builtins.s"* || $BASENAME == "libcudnn"* || $BASENAME == "libcublas"* || $BASENAME == "libcusolver"*  ]]; then
         echo $1
     else
         INITNAME=$(echo $BASENAME | cut -f1 -d".")

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -114,6 +114,7 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
     "/usr/local/cuda/lib64/libnvrtc.so.10.2"
     "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "/usr/local/cuda/lib64/libcusolver.so.10"
     "$LIBGOMP_PATH"
 )
 
@@ -122,6 +123,7 @@ DEPS_SONAME=(
     "libnvToolsExt.so.1"
     "libnvrtc.so.10.2"
     "libnvrtc-builtins.so"
+    "libcusolver.so.10"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.3" ]]; then
@@ -140,6 +142,7 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudnn.so.8"
     "/usr/local/cuda/lib64/libcublas.so.11"
     "/usr/local/cuda/lib64/libcublasLt.so.11"
+    "/usr/local/cuda/lib64/libcusolver.so.11"
     "$LIBGOMP_PATH"
 )
 
@@ -157,6 +160,7 @@ DEPS_SONAME=(
     "libcudnn.so.8"
     "libcublas.so.11"
     "libcublasLt.so.11"
+    "libcusolver.so.11"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.5" ]]; then
@@ -175,6 +179,7 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudnn.so.8"
     "/usr/local/cuda/lib64/libcublas.so.11"
     "/usr/local/cuda/lib64/libcublasLt.so.11"
+    "/usr/local/cuda/lib64/libcusolver.so.11"
     "$LIBGOMP_PATH"
 )
 DEPS_SONAME=(
@@ -191,6 +196,7 @@ DEPS_SONAME=(
     "libcudnn.so.8"
     "libcublas.so.11"
     "libcublasLt.so.11"
+    "libcusolver.so.11"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.6" ]]; then
@@ -209,6 +215,7 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libcudnn.so.8"
     "/usr/local/cuda/lib64/libcublas.so.11"
     "/usr/local/cuda/lib64/libcublasLt.so.11"
+    "/usr/local/cuda/lib64/libcusolver.so.11"
     "$LIBGOMP_PATH"
 )
 DEPS_SONAME=(
@@ -225,6 +232,7 @@ DEPS_SONAME=(
     "libcudnn.so.8"
     "libcublas.so.11"
     "libcublasLt.so.11"
+    "libcusolver.so.11"
     "libgomp.so.1"
 )
 


### PR DESCRIPTION
Packaging libcusolver as part of manywheel package

Fixes: https://github.com/pytorch/functorch/issues/855

This is a required package for libtorch_cuda_linalg.so
```
(base) atalman@atalman-dev-workstation-d4c889c8-2k8hl:~/torch/lib$ ldd libtorch_cuda_linalg.so
	linux-vdso.so.1 (0x00007ffe0958f000)
	libtorch_cpu.so (0x00007f4fd5cdb000)
	libtorch_cuda.so (0x00007f4ffc21a000)
	libcusolver.so.11 => /usr/local/cuda-11.1/targets/x86_64-linux/lib/libcusolver.so.11 (0x00007f4fab985000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f4fab781000)
	libtorch_cuda_cpp.so (0x00007f4f9c7ab000)
	libc10_cuda.so (0x00007f4ffc0f5000)
	libc10.so (0x00007f4ffc05b000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4f9c58c000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4f9c1ee000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f4f9bfe6000)
	libtorch_cuda_cu.so (0x00007f4f5c3cd000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f4f5c044000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4f5be2c000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4f5ba3b000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4ffc012000)
	libgomp-a34b3233.so.1 (0x00007f4f5b811000)
	libcudart-a7b20f20.so.11.0 (0x00007f4f5b574000)
	libnvToolsExt-24de1d56.so.1 (0x00007f4f5b36a000)
	libcudnn.so.8 (0x00007f4f5b142000)
```