### PR TITLE
Adding libcublas to cuda10 wheel

### DIFF
--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -114,6 +114,8 @@ DEPS_LIST=(
     "/usr/local/cuda/lib64/libnvToolsExt.so.1"
     "/usr/local/cuda/lib64/libnvrtc.so.10.2"
     "/usr/local/cuda/lib64/libnvrtc-builtins.so"
+    "/usr/local/cuda/lib64/libcublas.so.10"
+    "/usr/local/cuda/lib64/libcublasLt.so.10"
     "$LIBGOMP_PATH"
 )
 
@@ -122,6 +124,8 @@ DEPS_SONAME=(
     "libnvToolsExt.so.1"
     "libnvrtc.so.10.2"
     "libnvrtc-builtins.so"
+    "libcublas.so.10"
+    "libcublasLt.so.10"
     "libgomp.so.1"
 )
 elif [[ $CUDA_VERSION == "11.3" ]]; then


### PR DESCRIPTION
Since we want to remove static linking for libcublas we should include libcublas in CUDA 10

Test PR: https://github.com/pytorch/pytorch/pull/79231

https://github.com/pytorch/pytorch/runs/6837323424?check_suite_focus=true

```
(base) atalman@atalman-dev-workstation-d4c889c8-2k8hl:~/whl_test/torch/lib$ ldd libtorch_cuda.so
	linux-vdso.so.1 (0x00007fffe8f6a000)
	libc10_cuda.so (0x00007f6539e6a000)
	libcudart-80664282.so.10.2 (0x00007f6539be9000)
	libnvToolsExt-3965bdd0.so.1 (0x00007f65399df000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f65397c0000)
	libc10.so (0x00007f653952f000)
	libtorch_cpu.so (0x00007f6520921000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6520583000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f652037f000)
	libcublas.so.10 (0x00007f651c0c5000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f651bebd000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f651bb34000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f651b91c000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f651b52b000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f656aa13000)
	libgomp-a34b3233.so.1 (0x00007f651b301000)
	libcublasLt.so.10 (0x00007f651946c000)
```
