### PR TITLE
conda: add _GLIBCXX_USE_CXX11_ABI=1 support for linux cpu wheel

### DIFF
--- a/conda/Dockerfile_cxx11-abi
+++ b/conda/Dockerfile_cxx11-abi
@@ -1,0 +1,50 @@
+FROM centos:8 as base
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# change to a valid repo
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*.repo
+# enable to install ninja-build
+RUN sed -i 's|enabled=0|enabled=1|g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo
+
+RUN yum -y update
+RUN yum install -y wget curl perl util-linux xz bzip2 git patch which unzip
+RUN yum install -y autoconf automake make cmake gdb gcc gcc-c++
+
+FROM base as patchelf
+# Install patchelf
+ADD ./common/install_patchelf.sh install_patchelf.sh
+RUN bash ./install_patchelf.sh && rm install_patchelf.sh && cp $(which patchelf) /patchelf
+
+FROM base as openssl
+# Install openssl
+ADD ./common/install_openssl.sh install_openssl.sh
+RUN bash ./install_openssl.sh && rm install_openssl.sh
+
+FROM base as conda
+# Install Anaconda
+ADD ./common/install_conda.sh install_conda.sh
+RUN bash ./install_conda.sh && rm install_conda.sh
+
+# Install MNIST test data
+FROM base as mnist
+ADD ./common/install_mnist.sh install_mnist.sh
+RUN bash ./install_mnist.sh
+
+FROM base as final
+# Install LLVM
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm              /opt/llvm
+COPY --from=pytorch/llvm:9.0.1 /opt/llvm_no_cxx11_abi /opt/llvm_no_cxx11_abi
+COPY --from=openssl            /opt/openssl           /opt/openssl
+COPY --from=patchelf           /patchelf              /usr/local/bin/patchelf
+COPY --from=conda              /opt/conda             /opt/conda
+ADD  ./java/jni.h /usr/local/include/jni.h
+ENV  PATH /opt/conda/bin:$PATH
+COPY --from=mnist  /usr/local/mnist /usr/local/mnist
+RUN rm -rf /usr/local/cuda
+RUN chmod o+rw /usr/local
+RUN touch /.condarc && \
+    chmod o+rw /.condarc && \
+    chmod -R o+rw /opt/conda

--- a/conda/build_all_docker.sh
+++ b/conda/build_all_docker.sh
@@ -4,6 +4,6 @@ set -eou pipefail
 
 TOPDIR=$(git rev-parse --show-toplevel)
 
-for CUDA_VERSION in 11.7 11.6 11.5 11.3 10.2 cpu; do
+for CUDA_VERSION in 11.7 11.6 11.5 11.3 10.2 cpu cpu-cxx11-abi; do
   CUDA_VERSION="${CUDA_VERSION}" conda/build_docker.sh
 done

--- a/conda/build_docker.sh
+++ b/conda/build_docker.sh
@@ -10,11 +10,17 @@ DEVTOOLSET_VERSION="9"
 if [[ ${CUDA_VERSION:0:2} == "10" ]]; then
   DEVTOOLSET_VERSION="7"
 fi
+CONDA_LINUX_VERSION=${CONDA_LINUX_VERSION:-}
 
 case ${CUDA_VERSION} in
   cpu)
     BASE_TARGET=base
     DOCKER_TAG=cpu
+    ;;
+  cpu-cxx11-abi)
+    BASE_TARGET=base
+    DOCKER_TAG=cpu-cxx11-abi
+    CONDA_LINUX_VERSION="cxx11-abi"
     ;;
   all)
     BASE_TARGET=all_cuda
@@ -26,6 +32,12 @@ case ${CUDA_VERSION} in
     ;;
 esac
 
+if [[ -n ${CONDA_LINUX_VERSION} ]]; then
+    DOCKERFILE_SUFFIX=_${CONDA_LINUX_VERSION}
+else
+    DOCKERFILE_SUFFIX=''
+fi
+
 (
   set -x
   docker build \
@@ -34,7 +46,7 @@ esac
     --build-arg "CUDA_VERSION=${CUDA_VERSION}" \
     --build-arg "DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}" \
     -t "pytorch/conda-builder:${DOCKER_TAG}" \
-    -f "${TOPDIR}/conda/Dockerfile" \
+    -f "${TOPDIR}/conda/Dockerfile${DOCKERFILE_SUFFIX}" \
     ${TOPDIR}
 )
 

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -49,7 +49,7 @@ else
     build_version="$2"
     build_number="$3"
 fi
-if [[ "$desired_cuda" != cpu ]]; then
+if [[ "$desired_cuda" != cpu ]] && [[ "$desired_cuda" != cpu-cxx11-abi ]]; then
   desired_cuda="$(echo $desired_cuda | tr -d cuda. )"
 fi
 echo "Building cuda version $desired_cuda and pytorch version: $build_version build_number: $build_number"
@@ -108,7 +108,7 @@ fi
 if [[ "$OSTYPE" == "darwin"* ]]; then
     DEVELOPER_DIR=/Applications/Xcode9.app/Contents/Developer
 fi
-if [[ "$desired_cuda" == 'cpu' ]]; then
+if [[ "$desired_cuda" == 'cpu' ]] || [[ "$desired_cuda" == 'cpu-cxx11-abi' ]]; then
     cpu_only=1
 else
     # Switch desired_cuda to be M.m to be consistent with other scripts in

--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -6,8 +6,15 @@ export CMAKE_PREFIX_PATH=$PREFIX
 export TH_BINARY_BUILD=1 # links CPU BLAS libraries thrice in a row (was needed for some MKL static linkage)
 export PYTORCH_BUILD_VERSION=$PKG_VERSION
 export PYTORCH_BUILD_NUMBER=$PKG_BUILDNUM
-export USE_LLVM="/opt/llvm_no_cxx11_abi"
-export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
+if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
+    export _GLIBCXX_USE_CXX11_ABI=1
+    export USE_LLVM="/opt/llvm"
+    export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
+else
+    export _GLIBCXX_USE_CXX11_ABI=0
+    export USE_LLVM="/opt/llvm_no_cxx11_abi"
+    export LLVM_DIR="$USE_LLVM/lib/cmake/llvm"
+fi
 
 # set OPENSSL_ROOT_DIR=/opt/openssl if it exists
 if [[ -e /opt/openssl ]]; then

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -70,6 +70,7 @@ build:
     - DEVELOPER_DIR
     - DEBUG
     - USE_FBGEMM
+    - DESIRED_DEVTOOLSET
     - USE_GLOO_WITH_OPENSSL # [unix]
     - USE_SCCACHE # [win]
     - USE_DISTRIBUTED # [unix]


### PR DESCRIPTION
The target of this commit is to add the support for a new linux
cpu conda wheel file built with _GLIBCXX_USE_CXX11_ABI=1.

we add a Dockerfile (conda/Dockerfile_cxx11-abi) with CentOS8 as base image to
support CXX11_ABI=1.

To build the new docker image with CXX11_ABI support, run:
CUDA_VERSION=cpu-cxx11-abi conda/build_docker.sh
or
conda/build_all_docker.sh

To build a linux cpu conda wheel with CXX11_ABI within this image, run:
// the below settings are special for this image
export DESIRED_CUDA=cpu-cxx11-abi # change from cpu for wheel name
export GPU_ARCH_TYPE=cpu-cxx11-abi # change from cpu for build.sh
export DOCKER_IMAGE=pytorch/conda-builder:cpu-cxx11-abi
export DESIRED_DEVTOOLSET=cxx11-abi

// the below settings are as usual
export BINARY_ENV_FILE=/tmp/env
export BUILDER_ROOT=/builder
export DESIRED_PYTHON=3.7 # or 3.8, 3.9, etc.
export IS_GHA=1
export PACKAGE_TYPE=conda
export PYTORCH_FINAL_PACKAGE_DIR=/artifacts
export PYTORCH_ROOT=/pytorch
export GITHUB_WORKSPACE=/your_path_to_workspace

// the '-e DESIRED_DEVTOOLSET' below is newly added for this container,
// others are as usual
set -x
mkdir -p artifacts/
container_name=$(docker run
-e BINARY_ENV_FILE
-e BUILDER_ROOT
-e DESIRED_CUDA
-e DESIRED_PYTHON
-e GPU_ARCH_TYPE
-e IS_GHA
-e PACKAGE_TYPE
-e PYTORCH_FINAL_PACKAGE_DIR
-e PYTORCH_ROOT
-e DOCKER_IMAGE
-e DESIRED_DEVTOOLSET
--tty
--detach
-v "${GITHUB_WORKSPACE}/pytorch:/pytorch"
-v "${GITHUB_WORKSPACE}/builder:/builder"
-v "${RUNNER_TEMP}/artifacts:/artifacts"
-w /
"${DOCKER_IMAGE}"
)

// build conda wheel as usual,
// and the built wheel file name looks like: pytorch-1.13.0.dev20220616-py3.7_cpu_0.tar.bz2
docker exec -t -w "${PYTORCH_ROOT}" "${container_name}" bash -c "bash .circleci/scripts/binary_populate_env.sh"
docker exec -t "${container_name}" bash -c "source ${BINARY_ENV_FILE} && bash /builder/conda/build.sh"

// to verify the built wheel file, we'll see 'True'
$ conda install pytorch-1.13.0.dev20220616-py3.7_cpu_0.tar.bz2
$ python -c 'import torch; print(torch._C._GLIBCXX_USE_CXX11_ABI)'
True

Co-authored-by: Zhu Hong <hong.zhu@intel.com>
Co-authored-by: Guo Yejun <yejun.guo@intel.com>