### PR TITLE
Add MAGMA patches fixing LU factorization

### DIFF
--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -6,11 +6,13 @@ on:
       main
     paths:
       - magma/*
+      - magma/package_files/*
       - common/install_conda.sh
       - .github/workflows/build-magma-linux.yml
   pull_request:
     paths:
       - magma/*
+      - magma/package_files/*
       - common/install_conda.sh
       - .github/workflows/build-magma-linux.yml
 

--- a/magma/build_magma.sh
+++ b/magma/build_magma.sh
@@ -10,6 +10,8 @@ cp ${PACKAGE_FILES}/build.sh ${PACKAGE_DIR}/build.sh
 cp ${PACKAGE_FILES}/meta.yaml ${PACKAGE_DIR}/meta.yaml
 cp ${PACKAGE_FILES}/thread_queue.patch ${PACKAGE_DIR}/thread_queue.patch
 cp ${PACKAGE_FILES}/cmakelists.patch ${PACKAGE_DIR}/cmakelists.patch
+cp ${PACKAGE_FILES}/getrf_shfl.patch ${PACKAGE_DIR}/getrf_shfl.patch
+cp ${PACKAGE_FILES}/getrf_nbparam.patch ${PACKAGE_DIR}/getrf_nbparam.patch
 
 conda install -yq conda-build conda-verify
 . ./conda/switch_cuda_version.sh "${DESIRED_CUDA}"

--- a/magma/package_files/getrf_nbparam.patch
+++ b/magma/package_files/getrf_nbparam.patch
@@ -1,0 +1,40 @@
+diff --git a/control/get_batched_crossover.cpp b/control/get_batched_crossover.cpp
+index 4ec57306..912f8608 100644
+--- a/control/get_batched_crossover.cpp
++++ b/control/get_batched_crossover.cpp
+@@ -119,7 +119,7 @@ void magma_get_spotrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_
+ void magma_get_zgetrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_t *recnb)
+ {
+     *nb    = 64;
+-    *recnb = 32;
++    *recnb = 16;
+     return;
+ }
+ 
+@@ -127,7 +127,7 @@ void magma_get_zgetrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_
+ void magma_get_cgetrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_t *recnb)
+ {
+     *nb    = 128;
+-    *recnb =  32;
++    *recnb =  16;
+     return;
+ }
+ 
+@@ -135,7 +135,7 @@ void magma_get_cgetrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_
+ void magma_get_dgetrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_t *recnb)
+ {
+     *nb    = 128;
+-    *recnb =  32;
++    *recnb =  16;
+     return;
+ }
+ 
+@@ -143,7 +143,7 @@ void magma_get_dgetrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_
+ void magma_get_sgetrf_batched_nbparam(magma_int_t n, magma_int_t *nb, magma_int_t *recnb)
+ {
+     *nb    = 128;
+-    *recnb =  32;
++    *recnb =  16;
+     return;
+ }
+ 

--- a/magma/package_files/getrf_shfl.patch
+++ b/magma/package_files/getrf_shfl.patch
@@ -1,0 +1,15 @@
+diff --git a/src/zgetrf_batched.cpp b/src/zgetrf_batched.cpp
+index 24a65a90..884d9352 100644
+--- a/src/zgetrf_batched.cpp
++++ b/src/zgetrf_batched.cpp
+@@ -116,7 +116,9 @@ magma_zgetrf_batched(
+             return magma_zgetrf_batched_smallsq_noshfl( m, dA_array, ldda, ipiv_array, info_array, batchCount, queue );
+         }
+         else{
+-            return magma_zgetrf_batched_smallsq_shfl( m, dA_array, ldda, ipiv_array, info_array, batchCount, queue );
++            // magma_cgetrf_batched_smallsq_shfl is broken, therefore let's call noshfl version for arch < 700
++            // return magma_zgetrf_batched_smallsq_shfl( m, dA_array, ldda, ipiv_array, info_array, batchCount, queue );
++            return magma_zgetrf_batched_smallsq_noshfl( m, dA_array, ldda, ipiv_array, info_array, batchCount, queue );
+         }
+         #else
+         return magma_zgetrf_batched_smallsq_noshfl( m, dA_array, ldda, ipiv_array, info_array, batchCount, queue );

--- a/magma/package_files/meta.yaml
+++ b/magma/package_files/meta.yaml
@@ -11,7 +11,7 @@ source:
      - getrf_nbparam.patch  # fixes "too many resources requested for launch" error
 
 build:
-  number: 0
+  number: 1
   script_env:
     - DESIRED_CUDA
     - CUDA_ARCH_LIST

--- a/magma/package_files/meta.yaml
+++ b/magma/package_files/meta.yaml
@@ -7,6 +7,8 @@ source:
    patches:
      - cmakelists.patch
      - thread_queue.patch
+     - getrf_shfl.patch  # incorrect results for <7.0 arch
+     - getrf_nbparam.patch  # fixes "too many resources requested for launch" error
 
 build:
   number: 0


### PR DESCRIPTION
These patches should `fix` https://github.com/pytorch/pytorch/issues/70111 and https://github.com/pytorch/pytorch/issues/57482. However, the failure in these issues is observed only on Windows CI (I think it's GPU dependent, not OS) and this package is only for Linux. I saw these failures on Linux on P100 (`getrf_shfl.patch`) and V100 (`getrf_nbparam.patch`) GPUs.

What would be the procedure for updating the MAGMA lib that's used in Windows CI?