### PR TITLE
Use _GLIBCXX_USE_CXX11_ABI flag in conda builds, Add _PYBIND11_BUILD_…

### DIFF
--- a/check_binary.sh
+++ b/check_binary.sh
@@ -404,3 +404,12 @@ except RuntimeError as e:
     exit 1
   fi
 fi
+
+###############################################################################
+# Check for C++ ABI compatibility between gcc7 and gcc9 compiled binaries
+###############################################################################
+if [[ "$(uname)" == 'Linux' and ("$PACKAGE_TYPE" == 'conda' or "$PACKAGE_TYPE" == 'manywheel') ]]; then
+  pushd /tmp
+  python -c "import torch; exit(0 if torch._C._PYBIND11_BUILD_ABI == '_cxxabi1011' else 1)"
+  popd
+fi

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -301,6 +301,10 @@ fi
 # Build PyTorch with Gloo's TCP_TLS transport
 if [[ "$(uname)" == 'Linux' ]]; then
     export USE_GLOO_WITH_OPENSSL=1
+
+    # Defining and Setting _GLIBCXX_USE_CXX11_ABI flag in order to make sure we are setting
+    # -fabi-version=11 flag in the pytorch CMake lists
+    export _GLIBCXX_USE_CXX11_ABI=0
 fi
 
 # Loop through all Python versions to build a package for each

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - {{ compiler('c') }} # [win]
     - pkg-config # [unix]
     - libuv # [unix]
-    
+
   host:
     - python
     - setuptools
@@ -80,6 +80,7 @@ build:
     - BUILD_TEST # [unix]
     - USE_PYTORCH_METAL_EXPORT # [osx]
     - USE_COREML_DELEGATE # [osx]
+    - _GLIBCXX_USE_CXX11_ABI # [unix]
 
 test:
  imports:


### PR DESCRIPTION
…ABI test for compatibility gcc7 vs gcc9, (#1083)

* Add _PYBIND11_BUILD_ABI test for compatibility gcc7 vs gcc9

* Using _GLIBCXX_USE_CXX11_ABI in Linux conda builds