### PR TITLE
Make manywheels workflow depend also on build_rocm.sh

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -15,6 +15,7 @@ on:
       - manywheel/Dockerfile
       - 'common/*'
       - manywheel/build_docker.sh
+  workflow_dispatch:
 
 env:
   DOCKER_REGISTRY: "docker.io"

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/build-manywheel-images.yml
       - manywheel/Dockerfile
       - manywheel/build_docker.sh
+      - manywheel/build_rocm.sh
       - 'common/*'
   pull_request:
     paths:
@@ -15,7 +16,7 @@ on:
       - manywheel/Dockerfile
       - 'common/*'
       - manywheel/build_docker.sh
-  workflow_dispatch:
+      - manywheel/build_rocm.sh
 
 env:
   DOCKER_REGISTRY: "docker.io"


### PR DESCRIPTION
To unblock AMD since they recently needed to change https://github.com/pytorch/builder/pull/1091