### PR TITLE
release: Make macos platform a variable / glob

### DIFF
--- a/release/pypi/promote_pypi_to_staging.sh
+++ b/release/pypi/promote_pypi_to_staging.sh
@@ -23,22 +23,25 @@ upload_pypi_to_staging() {
 # Uncomment these to promote to pypi
 LINUX_VERSION_SUFFIX="%2Bcu102"
 WIN_VERSION_SUFFIX="%2Bcpu"
+MACOS_X86_64="macosx_.*_x86_64"
+MACOS_ARM64="macosx_.*_arm64"
+
 PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torch "${PYTORCH_VERSION}"
 PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                        upload_pypi_to_staging torch "${PYTORCH_VERSION}"
 PLATFORM="win_amd64"             VERSION_SUFFIX="${WIN_VERSION_SUFFIX}"   upload_pypi_to_staging torch "${PYTORCH_VERSION}"
-PLATFORM="macosx_10_9"           VERSION_SUFFIX=""                        upload_pypi_to_staging torch "${PYTORCH_VERSION}" # intel mac
-PLATFORM="macosx_11_0"           VERSION_SUFFIX=""                        upload_pypi_to_staging torch "${PYTORCH_VERSION}" # m1 mac
+PLATFORM="${MACOS_X86_64}"       VERSION_SUFFIX=""                        upload_pypi_to_staging torch "${PYTORCH_VERSION}" # intel mac
+PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                        upload_pypi_to_staging torch "${PYTORCH_VERSION}" # m1 mac
 
 PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 PLATFORM="win_amd64"             VERSION_SUFFIX="${WIN_VERSION_SUFFIX}"   upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
-PLATFORM="macosx_10_9"           VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
-PLATFORM="macosx_11_0"           VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
+PLATFORM="${MACOS_X86_64}"       VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
+PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 
 PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
 PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
 PLATFORM="win_amd64"             VERSION_SUFFIX="${WIN_VERSION_SUFFIX}"   upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
-PLATFORM="macosx_10_15"          VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
-PLATFORM="macosx_11_0"           VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
+PLATFORM="${MACOS_X86_64}"       VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
+PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
 
 upload_pypi_to_staging torchtext "${TORCHTEXT_VERSION}"


### PR DESCRIPTION
macos binaries changed between the last promotion to have a different
version string, change these to be a variable with a glob so we can just
search for macos + ARCH to make this more resilient

Relates to https://github.com/pytorch/audio/issues/2620

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>