### PR TITLE
Fix for cudatoolkit dependency for 11.7

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -267,7 +267,7 @@ else
     # TODO, simplify after anaconda fixes their cudatoolkit versioning inconsistency.
     # see: https://github.com/conda-forge/conda-forge.github.io/issues/687#issuecomment-460086164
     if [[ "$desired_cuda" == "11.7" ]]; then
-	    export CONDA_CUDATOOLKIT_CONSTRAINT="    - cudatoolkit >=11.7,<11.8 # [not osx]"
+	    export CONDA_CUDATOOLKIT_CONSTRAINT="    - cuda >=11.7,<11.8 # [not osx]"
 	    export MAGMA_PACKAGE="    - magma-cuda117 # [not osx and not win]"
     elif [[ "$desired_cuda" == "11.6" ]]; then
         export CONDA_CUDATOOLKIT_CONSTRAINT="    - cuda >=11.6,<11.7 # [not osx]"


### PR DESCRIPTION
Fix for cudatoolkit dependency for 11.7 
We want to depend on cuda and then on pytorch-cuda package rather then cudatoolkit