### PR TITLE
Use powershell for windows action. GPU runner does not support bash.

### DIFF
--- a/.github/actions/validate-windows-binary/action.yml
+++ b/.github/actions/validate-windows-binary/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Check nvidia smi
       if: ${{ inputs.gpu_arch_type == 'cuda' }}
-      shell: bash
+      shell: powershell
       run: |
         nvidia-smi
     - name: Install conda


### PR DESCRIPTION
Use powershell for windows action. GPU runner does not support bash.