### PR TITLE
Removing .github/scale-config.yml, now this repo is using the config in test-infra

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -1,6 +1,0 @@
-runner_types:
-  linux.2xlarge:
-    instance_type: c5.2xlarge
-    os: linux
-    max_available: 20
-    disk_size: 150


### PR DESCRIPTION
[As communicated internally](https://fb.workplace.com/groups/pytorch.dev/permalink/1189033455008466/), all repositories now rely on a single scale-config.yml that is on pytorch/test-infra. As such this file is no longer used and to avoid confusion it is better to remove it.

Here is a short summary of the announcement:

> [As previously announced](https://fb.workplace.com/groups/pytorch.dev/permalink/1173939633184515/), the scale-config.yml file in each repository for the pytorch/ organization is now not being used to control GHA runners. On its place, [the file with same path on test-infra](https://github.com/pytorch/test-infra/blob/main/.github/scale-config.yml) repository is controlling and enabling runners. If you feel the need for new runners, or change settings for current ones, feel free to submit a PR with required changes on the former file.
