### PR TITLE
Integrates CUDA pip wheels

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -357,8 +357,8 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
         done
     fi
 
-    : "${C_SO_RPATH:='$ORIGIN:$ORIGIN/lib'}"
-    : "${LIB_SO_RPATH:='$ORIGIN'}"
+    : "${C_SO_RPATH:='\$ORIGIN:\$ORIGIN/lib'}"
+    : "${LIB_SO_RPATH:='\$ORIGIN'}"
 
     # set RPATH of _C.so and similar to $ORIGIN, $ORIGIN/lib
     find $PREFIX -maxdepth 1 -type f -name "*.so*" | while read sofile; do

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -357,20 +357,17 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
         done
     fi
 
-    : "${C_SO_RPATH:='\$ORIGIN:\$ORIGIN/lib'}"
-    : "${LIB_SO_RPATH:='\$ORIGIN'}"
-
     # set RPATH of _C.so and similar to $ORIGIN, $ORIGIN/lib
     find $PREFIX -maxdepth 1 -type f -name "*.so*" | while read sofile; do
-        echo "Setting rpath of $sofile to $C_SO_RPATH"
-        $PATCHELF_BIN --set-rpath $C_SO_RPATH $sofile
+        echo "Setting rpath of $sofile to ${C_SO_RPATH:-'$ORIGIN:$ORIGIN/lib'}"
+        $PATCHELF_BIN --set-rpath ${C_SO_RPATH:-'$ORIGIN:$ORIGIN/lib'} $sofile
         $PATCHELF_BIN --print-rpath $sofile
     done
 
     # set RPATH of lib/ files to $ORIGIN
     find $PREFIX/lib -maxdepth 1 -type f -name "*.so*" | while read sofile; do
-        echo "Setting rpath of $sofile to $LIB_SO_RPATH"
-        $PATCHELF_BIN --set-rpath $LIB_SO_RPATH $sofile
+        echo "Setting rpath of $sofile to ${LIB_SO_RPATH:-'$ORIGIN'}"
+        $PATCHELF_BIN --set-rpath ${LIB_SO_RPATH:-'$ORIGIN'} $sofile
         $PATCHELF_BIN --print-rpath $sofile
     done
 

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -374,23 +374,6 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
         $PATCHELF_BIN --print-rpath $sofile
     done
 
-    # add dependencies to METADATA
-    # set WHEEL_DEPENDENCIES to be a string in your wrapper script. e.g.: set the
-    # following in build_cuda.sh to get cuda dependencies.
-    #
-    # export WHEEL_DEPENDENCIES="Requires-Dist: nvidia-cublas-cu11\nRequires-Dist: nvidia-cuda-cupti-cu11"
-    #
-    # Notice that each dependency is prefixed 'Requires-Dist: ' and suffixed with a new line char.
-    # The last dependency in the string doesn't have the new line char.
-    # This formatting conforms to the METADATA file in a wheel.
-    if [[ -n "$WHEEL_DEPENDENCIES" ]]; then
-        metadata_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/METADATA/g')
-        if [[ -e $metadata_file ]]; then
-            echo "Adding dependencies to metadata file $metadata_file"
-            sed -i "/^Requires-Dist.*/a$WHEEL_DEPENDENCIES" $metadata_file
-        fi
-    fi
-
     # regenerate the RECORD file with new hashes
     record_file=$(echo $(basename $pkg) | sed -e 's/-cp.*$/.dist-info\/RECORD/g')
     if [[ -e $record_file ]]; then

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -274,6 +274,15 @@ elif [[ $CUDA_VERSION == "11.7" ]]; then
             "libcublas.so.11"
             "libcublasLt.so.11"
         )
+    else
+        echo "Using cudnn and cublas from pypi."
+        CUDA_RPATHS=(
+            '$ORIGIN/../../nvidia/cublas/lib'
+            '$ORIGIN/../../nvidia/cudnn/lib'
+        )
+        CUDA_RPATHS=$(IFS=: ; echo "${CUDA_RPATHS[*]}")
+        export C_SO_RPATH=$CUDA_RPATHS':$ORIGIN:$ORIGIN/lib'
+        export LIB_SO_RPATH=$CUDA_RPATHS':$ORIGIN'
     fi
 else
     echo "Unknown cuda version $CUDA_VERSION"


### PR DESCRIPTION
- This PR refactors addition of RUNPATHs to torch libs and makes it such that it can be set from a wrapper script like `build_cuda.sh`.
- Additionally, it sets the cudnn and cublas RPATHS in `build_cuda.sh`

Test PR: https://github.com/pytorch/pytorch/pull/85489
Test workflow: https://github.com/pytorch/pytorch/actions/runs/3109382225/jobs/5048384359

cc: @ptrblck 