### PR TITLE
Setup periodic test to run binary verification

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -1,0 +1,60 @@
+name: Validate binaries
+
+# A reusable workflow that triggers a set of jobs that perform a smoke test / validation of pytorch binaries.
+# Optionally restricts validation to the specified OS and channel.
+# For the details about parameter values, see:
+#   pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+# For an example of the `workflow_call` usage see:
+#   https://github.com/pytorch/builder/pull/1144
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: "Operating system to generate for (linux, windows, macos, macos-arm64)"
+        required: true
+        type: string
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Operating system to generate for (linux, windows, macos, macos-arm64)"
+        required: true
+        type: choice
+        default: all
+        options:
+          - windows
+          - linux
+          - macos
+          - all
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        default: all
+        options:
+          - release
+          - nightly
+          - test
+          - all
+
+jobs:
+  validate-windows-binaries:
+    if:  inputs.os == 'windows' || inputs.os == 'all'
+    uses: ./.github/workflows/validate-windows-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}
+
+  validate-linux-binaries:
+    if:  inputs.os == 'linux' || inputs.os == 'all'
+    uses: ./.github/workflows/validate-linux-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}
+
+  validate-mac-binaries:
+    if:  inputs.os == 'macos' || inputs.os == 'all'
+    uses: ./.github/workflows/validate-macos-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -1,42 +1,49 @@
 name: Validate linux binaries
 
 on:
-  push:
-    branches:
-      main
-    paths:
-      - .github/workflows/validate-linux-binaries.yml
-      - .test/smoke_test/*
-  pull_request:
-    paths:
-      - .github/workflows/validate-linux-binaries.yml
-      - .test/smoke_test/*
+  workflow_call:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
+          - all
+
 jobs:
-  generate-conda-matrix:
+  generate-linux-conda-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: conda
       os: linux
-      channel: nightly
-  generate-wheel-matrix:
+      channel: ${{ inputs.channel }}
+  generate-linux-wheel-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: linux
-      channel: nightly
-  generate-libtorch-matrix:
+      channel: ${{ inputs.channel }}
+  generate-linux-libtorch-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: libtorch
       os: linux
-      channel: nightly
-
+      channel: ${{ inputs.channel }}
 
   validate-linux-binaries-conda:
-    needs: generate-conda-matrix
+    needs: generate-linux-conda-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-conda-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-linux-conda-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:
@@ -48,10 +55,10 @@ jobs:
           installation: ${{ matrix.installation }}
           python_version: ${{ matrix.python_version }}
   validate-linux-binaries-wheels:
-    needs: generate-wheel-matrix
+    needs: generate-linux-wheel-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-wheel-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-linux-wheel-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:
@@ -63,10 +70,10 @@ jobs:
           installation: ${{ matrix.installation }}
           python_version: ${{ matrix.python_version }}
   validate-linux-libtorch-binaries:
-    needs: generate-libtorch-matrix
+    needs: generate-linux-libtorch-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-libtorch-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-linux-libtorch-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: "ubuntu-20.04"
     env:

--- a/.github/workflows/validate-macos-binaries.yml
+++ b/.github/workflows/validate-macos-binaries.yml
@@ -1,41 +1,55 @@
 name: Validate MacOS Binaries
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/validate-macos-binaries.yml
-      - .test/smoke_test/*
+  workflow_call:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
+          - all
+
 jobs:
-  generate-arm64-conda-matrix:
+  generate-macos-arm64-conda-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: conda
       os: macos-arm64
-      channel: nightly
-  generate-arm64-wheel-matrix:
+      channel: ${{ inputs.channel }}
+  generate-macos-arm64-wheel-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: macos-arm64
-      channel: nightly
-  generate-x86_64-conda-matrix:
+      channel: ${{ inputs.channel }}
+  generate-macos-x86_64-conda-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: conda
       os: macos
-      channel: nightly
-  generate-x86_64-wheel-matrix:
+      channel: ${{ inputs.channel }}
+  generate-macos-x86_64-wheel-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: macos
-      channel: nightly
+      channel: ${{ inputs.channel }}
 
   validate-macos-arm64-binaries-conda:
-    needs: generate-arm64-conda-matrix
+    needs: generate-macos-arm64-conda-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-arm64-conda-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-macos-arm64-conda-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:
@@ -48,10 +62,10 @@ jobs:
           python_version: ${{ matrix.python_version }}
           target_os: macos
   validate-macos-arm64-binaries-wheel:
-    needs: generate-arm64-wheel-matrix
+    needs: generate-macos-arm64-wheel-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-arm64-wheel-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-macos-arm64-wheel-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:
@@ -64,10 +78,10 @@ jobs:
           python_version: ${{ matrix.python_version }}
           target_os: macos
   validate-macos-x86_64-binaries-conda:
-    needs: generate-x86_64-conda-matrix
+    needs: generate-macos-x86_64-conda-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-x86_64-conda-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-macos-x86_64-conda-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:
@@ -80,10 +94,10 @@ jobs:
           python_version: ${{ matrix.python_version }}
           target_os: macos
   validate-macos-x86_64-binaries-wheel:
-    needs: generate-x86_64-wheel-matrix
+    needs: generate-macos-x86_64-wheel-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-x86_64-wheel-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-macos-x86_64-wheel-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -1,0 +1,31 @@
+name: Validate nightly binaries (all OS)
+
+on:
+  schedule:
+    # At 2:30 pm UTC (7:30 am PDT)
+    - cron: "30 14 * * *"
+  # Have the ability to trigger this job manually through the API
+  workflow_dispatch:
+  push:
+    branches:
+      main
+    paths:
+      - .github/workflows/validate-nightly-binaries.yml
+      - .github/workflows/validate-linux-binaries.yml
+      - .github/workflows/validate-windows-binaries.yml
+      - .github/workflows/validate-macos-binaries.yml
+      - .test/smoke_test/*
+  pull_request:
+    paths:
+      - .github/workflows/validate-nightly-binaries.yml
+      - .github/workflows/validate-linux-binaries.yml
+      - .github/workflows/validate-windows-binaries.yml
+      - .github/workflows/validate-macos-binaries.yml
+      - .test/smoke_test/*
+
+jobs:
+  validate-nightly-binaries:
+    uses: ./.github/workflows/validate-binaries.yml
+    with:
+      channel: nightly
+      os: all

--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -1,0 +1,31 @@
+name: Validate release binaries (all OS)
+
+on:
+  schedule:
+    # At 3 am and 2 pm UTC (7 am and 8 pm PDT)
+    - cron: "0 3,14 * * *"
+  # Have the ability to trigger this job manually through the API
+  workflow_dispatch:
+  push:
+    branches:
+      main
+    paths:
+      - .github/workflows/validate-release-binaries.yml
+      - .github/workflows/validate-linux-binaries.yml
+      - .github/workflows/validate-windows-binaries.yml
+      - .github/workflows/validate-macos-binaries.yml
+      - .test/smoke_test/*
+  pull_request:
+    paths:
+      - .github/workflows/validate-release-binaries.yml
+      - .github/workflows/validate-linux-binaries.yml
+      - .github/workflows/validate-windows-binaries.yml
+      - .github/workflows/validate-macos-binaries.yml
+      - .test/smoke_test/*
+
+jobs:
+  validate-nightly-binaries:
+    uses: ./.github/workflows/validate-binaries.yml
+    with:
+      channel: release
+      os: all

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -1,40 +1,49 @@
-name: Validate binary images
+name: Validate Windows binary images
 
 on:
-  push:
-    branches:
-      main
-    paths:
-      - .github/workflows/validate-windows-binaries.yml
-      - .test/smoke_test/*
-  pull_request:
-    paths:
-      - .github/workflows/validate-windows-binaries.yml
-      - .test/smoke_test/*
+  workflow_call:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Channel to use (nightly, test, release, all)"
+        required: true
+        type: choice
+        options:
+          - release
+          - nightly
+          - test
+          - all
+
 jobs:
-  generate-conda-matrix:
+  generate-windows-conda-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: conda
       os: windows
-      channel: nightly
-  generate-wheel-matrix:
+      channel: ${{ inputs.channel }}
+  generate-windows-wheel-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: wheel
       os: windows
-      channel: nightly
-  generate-libtorch-matrix:
+      channel: ${{ inputs.channel }}
+  generate-windows-libtorch-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: libtorch
       os: windows
-      channel: nightly
+      channel: ${{ inputs.channel }}
+
   validate-windows-binaries-conda:
-    needs: generate-conda-matrix
+    needs: generate-windows-conda-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-conda-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-windows-conda-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:
@@ -47,11 +56,12 @@ jobs:
           gpu_arch_ver: ${{ matrix.gpu_arch_version }}
           installation: ${{ matrix.installation }}
           python_version: ${{ matrix.python_version }}
+
   validate-windows-binaries-wheel:
-    needs: generate-wheel-matrix
+    needs: generate-windows-wheel-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-wheel-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-windows-wheel-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: ${{ matrix.validation_runner }}
     steps:
@@ -64,11 +74,12 @@ jobs:
           gpu_arch_ver: ${{ matrix.gpu_arch_version }}
           installation: ${{ matrix.installation }}
           python_version: ${{ matrix.python_version }}
+
   validate-linux-libtorch-binaries:
-    needs: generate-libtorch-matrix
+    needs: generate-windows-libtorch-matrix
     strategy:
       matrix:
-        ${{ fromJson(needs.generate-libtorch-matrix.outputs.matrix) }}
+        ${{ fromJson(needs.generate-windows-libtorch-matrix.outputs.matrix) }}
       fail-fast: false
     runs-on: "windows-2019"
     env:


### PR DESCRIPTION
fix pytorch/pytorch#84764

Make binary validation workflows reusable, parameterized with the channel and os.

### First implementation:

1. Created reusable workflow, [see  validate-binaries.yml](https://github.com/pytorch/builder/blob/2c25be546e8948975e09ce0833b91d0202d872cf/.github/workflows/validate-binaries.yml)

    The workflow (with its children) takes around **2 hours** to finish (e.g. [1h 42m 12s](https://github.com/pytorch/builder/actions/runs/3102160422))
    
    Can be invoked from pytorch/builder as
    ```jobs:
      validate-nightly-binaries:
        uses: ./.github/workflows/validate-binaries.yml
        with:
          channel: nightly
          os: all
    ```
    Or from any org repo (when merged):
    ```
    jobs:
      validate-nightly-binaries:
        uses: pytorch/builder/.github/workflows/validate-binaries.yml@main
        with:
          channel: nightly
          os: all
    ```
    Supported parameter values:
    ```
          channel:
            description: "Channel to use (nightly, test, release, all)"
            required: true
            type: choice
            options:
              - release
              - nightly
              - test
              - all
          os:
            description: "Operating system to generate for (linux, windows, macos, macos-arm64)"
            required: true
            type: choice
            options:
              - windows
              - linux
              - macos
              - all
    ```

3. Added scheduled workflow for nightly and release builds (see `validate-release-binaries.yml` and `validate-nightly-binaries.yml`) 
    * nightly channel schedule: At 2:30 pm UTC (7:30 am PDT)
    * release schedule: At 3 am and 2 pm UTC (7 am and 8 pm PDT)

----

### Next up:
* Find a way to trigger smoke on specific events (i.e. after `vision` and `audio` builds are finished)
   * Can be done via webhook trigger
   * Or as a reusable action (in this case HUD needs to track several repos)