### PR TITLE
Add cuda and date check to smoke test

### DIFF
--- a/.github/actions/validate-windows-binary/action.yml
+++ b/.github/actions/validate-windows-binary/action.yml
@@ -38,6 +38,7 @@ runs:
       env:
         GPU_ARCH_VER: ${{ inputs.gpu_arch_ver }}
         GPU_ARCH_TYPE: ${{ inputs.gpu_arch_type }}
+        INSTALLATION: ${{ inputs.installation }}
         CUDA_VER: ${{ inputs.desired_cuda }}
       run: |
         conda install numpy pillow python=${{ inputs.python_version }}

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -73,7 +73,7 @@ def smoke_test_cuda() -> None:
         # https://github.com/pytorch/audio/pull/2707
         # so relying on anaconda output for pytorch-test and pytorch channel
         torchaudio_allstr = get_anaconda_output_for_package(torchaudio.__name__)
-        if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio_allstr:
+        if is_cuda_system and 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio_allstr:
             raise RuntimeError(f"CUDA version issue. Loaded: {torchaudio_allstr} Expected: {gpu_arch_ver}")
  
  

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -74,7 +74,7 @@ def smoke_test_cuda() -> None:
         # so relying on anaconda output for pytorch-test and pytorch channel
         torchaudio_allstr = get_anaconda_output_for_package(torchaudio.__name__)
         if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio_allstr:
-            raise RuntimeError(f"CUDA version mismatch. Loaded: {torchaudio_allstr.replace(" ", "")} Expected: {gpu_arch_ver}")
+            raise RuntimeError(f"CUDA version issue. Loaded: {torchaudio_allstr} Expected: {gpu_arch_ver}")
  
  
 

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -62,19 +62,10 @@ def smoke_test_cuda() -> None:
         print(f"torch cuda: {torch.version.cuda}")
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
-    # leverage torchvision's existing cuda check: raise runtime error if mismatch
 
-
-    # check torchaudio's cuda version against system cuda version
-    # torchaudio runtime does not retain cuda version
-    # relying solely on anaconda output
-    torchaudio_allstr = get_anaconda_output_for_package(torchaudio.__name__)
-    print('cu' + str(gpu_arch_ver).replace(".", ""))
-    if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio_allstr:
-        loaded_cuda_str = re.findall('cu\d+', torchaudio_allstr)[0]
-        raise RuntimeError(f"Wrong CUDA version. Loaded: {loaded_cuda_str} Expected: {gpu_arch_ver}")
-
-
+    # just print out cuda version, as version check were perform during import
+    print(f"torchvision cuda: {torch.ops.torchvision._cuda_version()}")
+    print(f"torchaudio cuda: {torch.ops.torchaudio.cuda_version()}")
 
 def smoke_test_conv2d() -> None:
     import torch.nn as nn

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -63,6 +63,8 @@ def smoke_test_cuda() -> None:
         print(f"torch cuda: {torch.version.cuda}")
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
+        print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
+
 
     
     if installation_str.find('nightly') != -1:  

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -65,7 +65,7 @@ def smoke_test_cuda() -> None:
 
     
     if installation_str.find('nightly') != -1:  
-        # just print out cuda version, as version check were perform during import
+        # just print out cuda version, as version check were already performed during import
         print(f"torchvision cuda: {torch.ops.torchvision._cuda_version()}")
         print(f"torchaudio cuda: {torch.ops.torchaudio.cuda_version()}")
     else:
@@ -152,9 +152,9 @@ def main() -> None:
     print(f"torch: {torch.__version__}")
     print(f"torchvision: {torchvision.__version__}")
     print(f"torchaudio: {torchaudio.__version__}")
+    smoke_test_cuda()
     if installation_str.find('nightly') != -1:  
       check_nightly_binaries_date()
-    smoke_test_cuda()
     #smoke_test_conv2d()
     #smoke_test_torchaudio()
     #smoke_test_torchvision()

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -11,9 +11,8 @@ from pathlib import Path
 
 gpu_arch_ver = os.getenv("GPU_ARCH_VER")
 gpu_arch_type = os.getenv("GPU_ARCH_TYPE")
-# need installation env variable to tell nightly
+# use installation env variable to tell if it is nightly channel
 installation_str = os.getenv("INSTALLATION")
-print(installation_str)
 is_cuda_system = gpu_arch_type == "cuda"
 SCRIPT_DIR = Path(__file__).parent
 
@@ -29,7 +28,6 @@ def get_anaconda_output_for_package(pkg_name_str):
     # Get the last line only
     return output.strip().split('\n')[-1]
 
-# only makes sense to check nightly package where dates are known
 def check_nightly_binaries_date() -> None: 
     torch_str = torch.__version__
     ta_str = torchaudio.__version__
@@ -64,8 +62,6 @@ def smoke_test_cuda() -> None:
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
-
-
     
     if installation_str.find('nightly') != -1:  
         # just print out cuda version, as version check were already performed during import
@@ -78,8 +74,6 @@ def smoke_test_cuda() -> None:
         torchaudio_allstr = get_anaconda_output_for_package(torchaudio.__name__)
         if is_cuda_system and 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio_allstr:
             raise RuntimeError(f"CUDA version issue. Loaded: {torchaudio_allstr} Expected: {gpu_arch_ver}")
- 
- 
 
 def smoke_test_conv2d() -> None:
     import torch.nn as nn
@@ -156,8 +150,11 @@ def main() -> None:
     print(f"torchvision: {torchvision.__version__}")
     print(f"torchaudio: {torchaudio.__version__}")
     smoke_test_cuda()
+
+    # only makes sense to check nightly package where dates are known
     if installation_str.find('nightly') != -1:  
       check_nightly_binaries_date()
+
     smoke_test_conv2d()
     smoke_test_torchaudio()
     smoke_test_torchvision()

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -19,9 +19,9 @@ def smoke_test_cuda() -> None:
         print(f"torch cuda: {torch.version.cuda}")
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
-    # check torchvision's cuda version against system cuda version
-    if(torch.ops.torchvision.__cuda__version() != gpu_arch_ver):
-        raise RuntimeError(f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}")
+    # leverage torchvision's existing cuda check: raise runtime error if mismatch
+    torchvision.extension._check_cuda_version()
+
     # check torchaudio's cuda version against system cuda version
     if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio.__version__.split("+"):
         raise RuntimeError(f"Wrong CUDA version. Loaded: {torchaudio.__version__} Expected: {gpu_arch_ver}")

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -63,9 +63,20 @@ def smoke_test_cuda() -> None:
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
 
-    # just print out cuda version, as version check were perform during import
-    print(f"torchvision cuda: {torch.ops.torchvision._cuda_version()}")
-    print(f"torchaudio cuda: {torch.ops.torchaudio.cuda_version()}")
+    
+    if installation_str.find('nightly') != -1:  
+        # just print out cuda version, as version check were perform during import
+        print(f"torchvision cuda: {torch.ops.torchvision._cuda_version()}")
+        print(f"torchaudio cuda: {torch.ops.torchaudio.cuda_version()}")
+    else:
+        # torchaudio runtime added the cuda verison check on 09/23/2022 via
+        # https://github.com/pytorch/audio/pull/2707
+        # so relying on anaconda output for pytorch-test and pytorch channel
+        torchaudio_allstr = get_anaconda_output_for_package(torchaudio.__name__)
+        if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio_allstr:
+            raise RuntimeError(f"CUDA version mismatch. Loaded: {torchaudio_allstr.replace(" ", "")} Expected: {gpu_arch_ver}")
+ 
+ 
 
 def smoke_test_conv2d() -> None:
     import torch.nn as nn

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -156,11 +156,11 @@ def main() -> None:
     smoke_test_cuda()
     if installation_str.find('nightly') != -1:  
       check_nightly_binaries_date()
-    #smoke_test_conv2d()
-    #smoke_test_torchaudio()
-    #smoke_test_torchvision()
-    #smoke_test_torchvision_read_decode()
-    #smoke_test_torchvision_resnet50_classify()
+    smoke_test_conv2d()
+    smoke_test_torchaudio()
+    smoke_test_torchvision()
+    smoke_test_torchvision_read_decode()
+    smoke_test_torchvision_resnet50_classify()
 
 if __name__ == "__main__":
     main()

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -19,6 +19,14 @@ def smoke_test_cuda() -> None:
         print(f"torch cuda: {torch.version.cuda}")
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
+    # check torchvision's cuda version against system cuda version
+    if(torch.ops.torchvision.__cuda__version() != gpu_arch_ver):
+        raise RuntimeError(f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}")
+    # check torchaudio's cuda version against system cuda version
+    if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio.__version__.split("+")
+        raise RuntimeError(f"Wrong CUDA version. Loaded: {torchaudio.__version__} Expected: {gpu_arch_ver}
+
+
 
 def smoke_test_conv2d() -> None:
     import torch.nn as nn

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -23,8 +23,8 @@ def smoke_test_cuda() -> None:
     if(torch.ops.torchvision.__cuda__version() != gpu_arch_ver):
         raise RuntimeError(f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}")
     # check torchaudio's cuda version against system cuda version
-    if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio.__version__.split("+")
-        raise RuntimeError(f"Wrong CUDA version. Loaded: {torchaudio.__version__} Expected: {gpu_arch_ver}
+    if 'cu'+str(gpu_arch_ver).replace(".", "") not in torchaudio.__version__.split("+"):
+        raise RuntimeError(f"Wrong CUDA version. Loaded: {torchaudio.__version__} Expected: {gpu_arch_ver}")
 
 
 

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -24,9 +24,10 @@ def get_anaconda_output_for_package(pkg_name_str):
 
     # ignore the header row: 
     # Name                    Version                   Build  Channel
-    cmd = 'conda list -f ' + pkg_name_str + ' |tail -n 1 '
+    cmd = 'conda list -f ' + pkg_name_str 
     output = sp.getoutput(cmd)
-    return output
+    # Get the last line only
+    return output.strip().split('\n')[-1]
 
 # only makes sense to check nightly package where dates are known
 def check_nightly_binaries_date() -> None: 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/85085 partially. 
Addressing No.1 and No.2 in https://github.com/pytorch/pytorch/issues/85085#issuecomment-1254011982 

Essentially, this PR helps enhance the cudnn check, e.g. during development it prompted torchaudio's addition of https://github.com/pytorch/audio/pull/2707 since it was found that initially "import torchvision" would trigger cudnn check but torchaudio would not. 

Also for nightly tests, added date check to detect if (py)torch, torchvision, torchaudio are not from the same date, or if they are, whether they are obsolete (more than 2 days old). 