### PR TITLE
Minor: fix the typo in the job name for windows binaries validation workflow

### DIFF
--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -75,7 +75,7 @@ jobs:
           installation: ${{ matrix.installation }}
           python_version: ${{ matrix.python_version }}
 
-  validate-linux-libtorch-binaries:
+  validate-windows-libtorch-binaries:
     needs: generate-windows-libtorch-matrix
     strategy:
       matrix:


### PR DESCRIPTION
#1144 uncovered a typo in the job name for windows validation workflow, that leads to issues like this:

> There are workflow combinations like this: validate-nightly-binaries / validate-windows-binaries / validate-linux-libtorch-binaries (https://github.com/pytorch/builder/actions/runs/3107089301/jobs/5034808605)
>
> I.e. validate-windows-binaries.yml 
https://github.com/pytorch/builder/blob/b639eb0120210cc1ef7f76fddfdfee33b63c1baf/.github/workflows/validate-binaries.yml#L44
>
> somehow calls validate-linux-libtorch-binaries
https://github.com/pytorch/builder/blob/b639eb0120210cc1ef7f76fddfdfee33b63c1baf/.github/workflows/validate-linux-binaries.yml#L72

