### PR TITLE
Trivial: fix the typo in the the job name for the release binaries validation workflow

### DIFF
--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -24,7 +24,7 @@ on:
       - .test/smoke_test/*
 
 jobs:
-  validate-nightly-binaries:
+  validate-release-binaries:
     uses: ./.github/workflows/validate-binaries.yml
     with:
       channel: release


### PR DESCRIPTION
Currently in the HUD the jobs from nightly and release channels both have "nightly" in their name.

The issue was introduced in #1144 (it doesn't affect anything functionally, but creates a bit of confusion in the [HUD view](https://hud.pytorch.org/hud/pytorch/builder/main/1?per_page=1)).