### PR TITLE
Uses RPATH instead of RUNPATH so that user strictly uses pypi libs

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -360,14 +360,14 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
     # set RPATH of _C.so and similar to $ORIGIN, $ORIGIN/lib
     find $PREFIX -maxdepth 1 -type f -name "*.so*" | while read sofile; do
         echo "Setting rpath of $sofile to ${C_SO_RPATH:-'$ORIGIN:$ORIGIN/lib'}"
-        $PATCHELF_BIN --set-rpath ${C_SO_RPATH:-'$ORIGIN:$ORIGIN/lib'} $sofile
+        $PATCHELF_BIN --set-rpath ${C_SO_RPATH:-'$ORIGIN:$ORIGIN/lib'} ${FORCE_RPATH:-} $sofile
         $PATCHELF_BIN --print-rpath $sofile
     done
 
     # set RPATH of lib/ files to $ORIGIN
     find $PREFIX/lib -maxdepth 1 -type f -name "*.so*" | while read sofile; do
         echo "Setting rpath of $sofile to ${LIB_SO_RPATH:-'$ORIGIN'}"
-        $PATCHELF_BIN --set-rpath ${LIB_SO_RPATH:-'$ORIGIN'} $sofile
+        $PATCHELF_BIN --set-rpath ${LIB_SO_RPATH:-'$ORIGIN'} ${FORCE_RPATH:-} $sofile
         $PATCHELF_BIN --print-rpath $sofile
     done
 

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -283,6 +283,7 @@ elif [[ $CUDA_VERSION == "11.7" ]]; then
         CUDA_RPATHS=$(IFS=: ; echo "${CUDA_RPATHS[*]}")
         export C_SO_RPATH=$CUDA_RPATHS':$ORIGIN:$ORIGIN/lib'
         export LIB_SO_RPATH=$CUDA_RPATHS':$ORIGIN'
+        export FORCE_RPATH="--force-rpath"
     fi
 else
     echo "Unknown cuda version $CUDA_VERSION"


### PR DESCRIPTION
Torch libs currently uses the default RUNPATH behavior for dynamically loading libraries. While RUNPATH is the recommended approach and RPATH usage is deprecated, we want predictable behavior for a wheel we publish. For instance, if we publish a wheel with RUNPATH set to the cuda pypi wheels, and if the user has LD_LIBRARY_PATH set to /usr/local/cuda/lib64, torch libs will use the cudnn installed in /usr/loca/cuda/lib64, instead of the pypi supplied cudnn. We can get around that by setting RPATH instead of RUNPATH.

Test run: https://github.com/pytorch/pytorch/actions/runs/3109382225

Readelf test:
```
readelf -d libtorch.so 

Dynamic section at offset 0x2e00 contains 26 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libtorch_cuda.so]
 0x0000000000000001 (NEEDED)             Shared library: [libtorch_cuda_cpp.so]
 0x0000000000000001 (NEEDED)             Shared library: [libtorch_cpu.so]
 0x0000000000000001 (NEEDED)             Shared library: [libtorch_cuda_cu.so]
 0x000000000000000e (SONAME)             Library soname: [libtorch.so]
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN]
```

ldd test:
```
ldd -r libtorch.so 
	linux-vdso.so.1 (0x00007ffd007fb000)
	libtorch_cuda.so => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libtorch_cuda.so (0x00007f08459e0000)
	libtorch_cuda_cpp.so => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libtorch_cuda_cpp.so (0x00007f083619c000)
	libtorch_cpu.so => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libtorch_cpu.so (0x00007f081ad29000)
	libtorch_cuda_cu.so => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libtorch_cuda_cu.so (0x00007f07f1172000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f07f0f5a000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f07f0b69000)
	libc10_cuda.so => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libc10_cuda.so (0x00007f0845899000)
	libcudart-e409450e.so.11.0 => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libcudart-e409450e.so.11.0 (0x00007f07f08c0000)
	libnvToolsExt-847d78f2.so.1 => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libnvToolsExt-847d78f2.so.1 (0x00007f07f06b5000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f07f0496000)
	libc10.so => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libc10.so (0x00007f07f03de000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f07f0040000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f07efe3c000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f07efc34000)
	libcudnn.so.8 => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./../../nvidia/cudnn/lib/libcudnn.so.8 (0x00007f07efa0e000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f07ef685000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f08457e5000)
	libgomp-a34b3233.so.1 => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./libgomp-a34b3233.so.1 (0x00007f07ef45b000)
	libcublas.so.11 => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./../../nvidia/cublas/lib/libcublas.so.11 (0x00007f07e61fd000)
	libcublasLt.so.11 => /data/home/atalman/conda/envs/newpypi39/lib/python3.9/site-packages/torch/lib/./../../nvidia/cublas/lib/libcublasLt.so.11 (0x00007f07d225c000)
```

cc: @malfet @atalman @ptrblck 