### PR TITLE
Add utility script to switch python versions

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -133,6 +133,10 @@ COPY --from=libpng             /usr/local/include/libpng*            /usr/local/
 COPY --from=libpng             /usr/local/lib/libpng*                /usr/local/lib/
 COPY --from=libpng             /usr/local/lib/pkgconfig              /usr/local/lib/pkgconfig
 
+ADD manywheel/utils/switch_python.sh  /opt/python/switch_python.sh
+ADD manywheel/utils/entrypoint.sh  /bin/entrypoint.sh
+ENTRYPOINT ["bash", "entrypoint.sh"]
+
 FROM common as cpu_final
 ARG BASE_CUDA_VERSION=10.1
 ARG DEVTOOLSET_VERSION=9

--- a/manywheel/utils/entrypoint.sh
+++ b/manywheel/utils/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ ${PYTHON_VERSION:-} != "" ]]; then
+  echo "+ INFO: Switching python version to ${PYTHON_VERSION}"
+  # Switch python version if PYTHON_VERSION env variable set
+  PYTHON_VERSION="${PYTHON_VERSION}" /opt/python/switch_python.sh
+fi

--- a/manywheel/utils/switch_python.sh
+++ b/manywheel/utils/switch_python.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+PYTHON_VERSION=${PYTHON_VERSION:-3.8}
+
+# If given a python version like 3.6m or 2.7mu, convert this to the format we
+# expect. The binary CI jobs pass in python versions like this; they also only
+# ever pass one python version, so we assume that PYTHON_VERSION is not a list
+# in this case
+python_nodot="$(echo "${PYTHON_VERSION}" | tr -d m.u)"
+case ${PYTHON_VERSION} in
+  3.[6-7]*)
+    pydir="cp${python_nodot}-cp${python_nodot}m"
+    ;;
+  # Should catch 3.8+
+  3.*)
+    pydir="cp${python_nodot}-cp${python_nodot}"
+    ;;
+esac
+
+if [[ ! -d "/opt/python/${pydir}" ]]; then
+    cat << EOF
+::error::Requested python version (${PYTHON_VERSION}) not currently supported"
+Please make an issue at https://github.com/pytorch/builder to add support for your requested version"
+EOF
+    exit 1
+fi
+
+echo "INFO: Adding /opt/python/${pydir} to PATH"
+export PATH="/opt/python/${pydir}:${PATH}"


### PR DESCRIPTION
Should enable https://github.com/pytorch/test-infra/pull/783 to run easier and not have to do this work in the script portion but it'll be done automatically

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>