### PR TITLE
Fix check binary for arm64

### DIFF
--- a/check_binary.sh
+++ b/check_binary.sh
@@ -328,7 +328,7 @@ fi
 if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   echo "Checking that MKL is available"
   build_and_run_example_cpp check-torch-mkl
-else if [[ "$(uname -m)" != "arm64" ]]; then
+elif [[ "$(uname -m)" != "arm64" ]]; then
   if [[ "$(uname)" != 'Darwin' || "$PACKAGE_TYPE" != *wheel ]]; then
     echo "Checking that MKL is available"
     pushd /tmp

--- a/check_binary.sh
+++ b/check_binary.sh
@@ -328,7 +328,7 @@ fi
 if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   echo "Checking that MKL is available"
   build_and_run_example_cpp check-torch-mkl
-else
+else if [[ "$(uname -m)" != "arm64" ]]; then
   if [[ "$(uname)" != 'Darwin' || "$PACKAGE_TYPE" != *wheel ]]; then
     echo "Checking that MKL is available"
     pushd /tmp


### PR DESCRIPTION
Please refer to M1 arm64 build:
https://pipelines.actions.githubusercontent.com/serviceHosts/7d146c05-69c3-4c20-a0e7-818111670117/_apis/pipelines/1/runs/2265405/signedlogcontent/2?urlExpires=2022-10-03T19%3A17%3A44.1738730Z&urlSigningMethod=HMACV1&urlSignature=jeDFwT%2FN1zhgJyOt%2BYgnq68JNcFoMJ6oOm45UISbO9Y%3D

The MKL Usage is off:
```
2022-10-03T07:20:54.5038560Z --   USE_MKL               : OFF
2022-10-03T07:20:54.5039760Z --   USE_MKLDNN            : OFF
```

Hence this code to not include check for M1