### PR TITLE
Shorten binary validation workflow names, to improve readability of the HUD and GH views

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -41,19 +41,19 @@ on:
           - all
 
 jobs:
-  validate-windows-binaries:
+  win:
     if:  inputs.os == 'windows' || inputs.os == 'all'
     uses: ./.github/workflows/validate-windows-binaries.yml
     with:
       channel: ${{ inputs.channel }}
 
-  validate-linux-binaries:
+  linux:
     if:  inputs.os == 'linux' || inputs.os == 'all'
     uses: ./.github/workflows/validate-linux-binaries.yml
     with:
       channel: ${{ inputs.channel }}
 
-  validate-mac-binaries:
+  mac:
     if:  inputs.os == 'macos' || inputs.os == 'all'
     uses: ./.github/workflows/validate-macos-binaries.yml
     with:

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -39,7 +39,7 @@ jobs:
       os: linux
       channel: ${{ inputs.channel }}
 
-  validate-linux-binaries-conda:
+  linux-conda:
     needs: generate-linux-conda-matrix
     strategy:
       matrix:
@@ -58,7 +58,8 @@ jobs:
           dev_toolset: ''
           package_type: conda
           target_os: linux
-  validate-linux-binaries-wheels:
+
+  linux-wheel:
     needs: generate-linux-wheel-matrix
     strategy:
       matrix:
@@ -78,7 +79,7 @@ jobs:
           package_type: wheel
           target_os: linux
 
-  validate-linux-libtorch-binaries:
+  linux-libt:
     needs: generate-linux-libtorch-matrix
     strategy:
       matrix:

--- a/.github/workflows/validate-macos-binaries.yml
+++ b/.github/workflows/validate-macos-binaries.yml
@@ -45,7 +45,7 @@ jobs:
       os: macos
       channel: ${{ inputs.channel }}
 
-  validate-macos-arm64-binaries-conda:
+  mac-arm64-conda:
     needs: generate-macos-arm64-conda-matrix
     strategy:
       matrix:
@@ -63,7 +63,8 @@ jobs:
           desired_cuda: ${{ matrix.desired_cuda }}
           package_type: conda
           target_os: macos
-  validate-macos-arm64-binaries-wheel:
+
+  mac-arm64-wheel:
     needs: generate-macos-arm64-wheel-matrix
     strategy:
       matrix:
@@ -81,7 +82,8 @@ jobs:
           desired_cuda: ${{ matrix.desired_cuda }}
           package_type: wheel
           target_os: macos
-  validate-macos-x86_64-binaries-conda:
+
+  mac-x64-conda:
     needs: generate-macos-x86_64-conda-matrix
     strategy:
       matrix:
@@ -99,7 +101,8 @@ jobs:
           desired_cuda: ${{ matrix.desired_cuda }}
           package_type: conda
           target_os: macos
-  validate-macos-x86_64-binaries-wheel:
+
+  mac-x64-wheel:
     needs: generate-macos-x86_64-wheel-matrix
     strategy:
       matrix:

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -1,4 +1,5 @@
-name: Validate nightly binaries (all OS)
+# Scheduled validation of the nightly binaries
+name: cron
 
 on:
   schedule:
@@ -8,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      main
+      - main
     paths:
       - .github/workflows/validate-nightly-binaries.yml
       - .github/workflows/validate-linux-binaries.yml
@@ -24,7 +25,7 @@ on:
       - .test/smoke_test/*
 
 jobs:
-  validate-nightly-binaries:
+  nightly:
     uses: ./.github/workflows/validate-binaries.yml
     with:
       channel: nightly

--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -1,4 +1,5 @@
-name: Validate release binaries (all OS)
+# Scheduled validation of the release binaries
+name: cron
 
 on:
   schedule:
@@ -8,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      main
+      - main
     paths:
       - .github/workflows/validate-release-binaries.yml
       - .github/workflows/validate-linux-binaries.yml
@@ -24,7 +25,7 @@ on:
       - .test/smoke_test/*
 
 jobs:
-  validate-release-binaries:
+  release:
     uses: ./.github/workflows/validate-binaries.yml
     with:
       channel: release

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -39,7 +39,7 @@ jobs:
       os: windows
       channel: ${{ inputs.channel }}
 
-  validate-windows-binaries-conda:
+  win-conda:
     needs: generate-windows-conda-matrix
     strategy:
       matrix:
@@ -57,7 +57,7 @@ jobs:
           installation: ${{ matrix.installation }}
           python_version: ${{ matrix.python_version }}
 
-  validate-windows-binaries-wheel:
+  win-wheel:
     needs: generate-windows-wheel-matrix
     strategy:
       matrix:
@@ -75,7 +75,7 @@ jobs:
           installation: ${{ matrix.installation }}
           python_version: ${{ matrix.python_version }}
 
-  validate-windows-libtorch-binaries:
+  win-libt:
     needs: generate-windows-libtorch-matrix
     strategy:
       matrix:


### PR DESCRIPTION
### HUD

new look:
https://hud.pytorch.org/hud/pytorch/builder/shorten-validation-workflow-names/1?per_page=1
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/108101595/194435285-a338021c-59a8-4389-bb8d-89b026095ec0.png">

vs old look:
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/108101595/194435331-48970b6e-1637-48ea-92fd-d3a8ebb06814.png">

Grouping by OS works correctly, more information fits into the view.


----

### GH view

old/new:
<img width="364" alt="194435466-0bbbf051-ce9b-40a4-86ec-7a10455a3dad" src="https://user-images.githubusercontent.com/108101595/194435745-c8157db1-f4f0-4c0f-b250-558bcd5ca261.png"><img width="336" alt="image" src="https://user-images.githubusercontent.com/108101595/194435496-db5f7d79-dabf-4ffa-998a-262cb4dac36d.png">


