### PR TITLE
Regenerates RECORD file to reflect version changes in release pypi binary

### DIFF
--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -12,6 +12,19 @@
 set -eou pipefail
 shopt -s globstar
 
+# Function copied from manywheel/build_common.sh
+make_wheel_record() {
+    FPATH=$1
+    if echo $FPATH | grep RECORD >/dev/null 2>&1; then
+        # if the RECORD file, then
+        echo "$FPATH,,"
+    else
+        HASH=$(openssl dgst -sha256 -binary $FPATH | openssl base64 | sed -e 's/+/-/g' | sed -e 's/\//_/g' | sed -e 's/=//g')
+        FSIZE=$(ls -nl $FPATH | awk '{print $5}')
+        echo "$FPATH,sha256=$HASH,$FSIZE"
+    fi
+}
+
 OUTPUT_DIR=${OUTPUT_DIR:-$(pwd)}
 
 tmp_dir="$(mktemp -d)"
@@ -42,6 +55,19 @@ for whl_file in "$@"; do
         # Example: torch-1.8.0+cpu.dist-info => torch-1.8.0.dist-info
         mv "${dist_info_folder}" "${dirname_dist_info_folder}/${basename_dist_info_folder/${version_with_suffix}/${version_no_suffix}}"
         cd "${whl_dir}"
+
+        # copied from manywheel/build_common.sh
+        # regenerate the RECORD file with new hashes
+        record_file="${dirname_dist_info_folder}/${basename_dist_info_folder/${version_with_suffix}/${version_no_suffix}}/RECORD"
+        if [[ -e $record_file ]]; then
+            echo "Generating new record file $record_file"
+            rm -f $record_file
+            # generate records for folders in wheel
+            find * -type f | while read fname; do
+                echo $(make_wheel_record $fname) >>$record_file
+            done
+        fi
+
         zip -qr "${new_whl_file}" .
     )
 done


### PR DESCRIPTION
When the version in METADATA is changed (e.g. from 1.13.0+cu117.with.pypi.cudnn to 1.13.0), the hash for METADATA in the RECORD file should be changed as well. However, the binary produced before and after the script has the same hash for METADATA (e.g. `sha256=NEV-OiKmMQO5aC89LwYMAFsAedKLsWLxfZ3XdnUmRcM,23902` for the METADATA file in 1.13.0+cu117.with.pypi.cudnn binary). 

This PR copies the RECORD file regeneration logic from manywheel/build_common.sh. With this change, in the above example, the hash for METADATA is correctly regenerated in the RECORD file:
`torch-1.13.0.dist-info/METADATA,sha256=2A235SVt_S_U8gSRuhwR7fJlM5j64pMddcoYP_WmrNs,23880`

It looks like pip install doesn't care about this but the pypi spec does want installer to look at this RECORD and fail installation if things don't match: https://github.com/pypa/pip/issues/2752

cc: @malfet @atalman @ptrblck @seemethere 