### PR TITLE
Revert "Fix to not use sccache if it's not setup properly (#1171)"

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -4,60 +4,6 @@
 set -ex
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# Courtesy of pytorch/.jenkins/pytorch/common_utils.sh
-#
-# - 1st arg:  code to add
-# - remaining args:  names of traps to modify
-#
-trap_add() {
-    trap_add_cmd=$1; shift || fatal "${FUNCNAME[0]} usage error"
-    for trap_add_name in "$@"; do
-        trap -- "$(
-            # helper fn to get existing trap command from output
-            # of trap -p
-            extract_trap_cmd() { printf '%s\n' "$3"; }
-            # print existing trap command with newline
-            eval "extract_trap_cmd $(trap -p "${trap_add_name}")"
-            # print the new trap command
-            printf '%s\n' "${trap_add_cmd}"
-        )" "${trap_add_name}" \
-            || fatal "unable to add to trap ${trap_add_name}"
-    done
-}
-# set the trace attribute for the above function.  this is
-# required to modify DEBUG or RETURN traps because functions don't
-# inherit them unless the trace attribute is set
-declare -f -t trap_add
-
-# Initialize sccache
-if [[ -n "$SCCACHE_BUCKET" ]] && which sccache > /dev/null; then
-    # Save sccache logs to file
-    sccache --stop-server > /dev/null  2>&1 || true
-    rm -f ~/sccache_error.log || true
-
-    export SCCACHE_IDLE_TIMEOUT=1200
-    export SCCACHE_ERROR_LOG=~/sccache_error.log
-    export RUST_LOG=sccache::server=error
-
-    # Report sccache stats for easier debugging
-    sccache --zero-stats
-    function sccache_epilogue() {
-        sccache --show-stats
-        sccache --stop-server || true
-    }
-
-    trap_add sccache_epilogue EXIT
-else
-    # Not using sscache if it's not setup properly
-    rm -f /opt/cache/bin/cc
-    rm -f /opt/cache/bin/c++
-    rm -f /opt/cache/bin/clang
-    rm -f /opt/cache/bin/clang++
-    rm -f /opt/cache/bin/gcc
-    rm -f /opt/cache/bin/g++
-
-    unset CMAKE_CUDA_COMPILER_LAUNCHER
-fi
 
 # Require only one python installation
 if [[ -z "$DESIRED_PYTHON" ]]; then


### PR DESCRIPTION
This reverts commit 377efea5040e585708401e671f767972f183aa2e.

Breaks audio builds
```
CMake Error at /opt/_internal/cpython-3.10.1/lib/python3.10/site-packages/cmake/data/share/cmake-3.24/Modules/CMakeTestCUDACompiler.cmake:102 (message):
  The CUDA compiler

    "/usr/local/cuda-11.7//bin/nvcc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /root/project/build/temp.linux-x86_64-3.10/CMakeFiles/CMakeTmp
    
    Run Build Command(s):/opt/python/cp310-cp310/bin/ninja cmTC_2f1ce && [1/2] Building CUDA object CMakeFiles/cmTC_2f1ce.dir/main.cu.o
    FAILED: CMakeFiles/cmTC_2f1ce.dir/main.cu.o 
    /opt/cache/bin/sccache /usr/local/cuda-11.7//bin/nvcc -forward-unknown-to-host-compiler   --generate-code=arch=compute_35,code=[sm_35] --generate-code=arch=compute_50,code=[compute_50,sm_50] --generate-code=arch=compute_60,code=[sm_60] --generate-code=arch=compute_70,code=[sm_70] --generate-code=arch=compute_75,code=[sm_75] --generate-code=arch=compute_80,code=[sm_80] --generate-code=arch=compute_86,code=[sm_86] -Xcompiler=-fPIE -MD -MT CMakeFiles/cmTC_2f1ce.dir/main.cu.o -MF CMakeFiles/cmTC_2f1ce.dir/main.cu.o.d -x cu -c /root/project/build/temp.linux-x86_64-3.10/CMakeFiles/CMakeTmp/main.cu -o CMakeFiles/cmTC_2f1ce.dir/main.cu.o
    sccache: error: failed to execute compile
    sccache: caused by: Compiler not supported: "nvcc fatal   : Failed to preprocess host compiler properties.\n"
    ninja: build stopped: subcommand failed.
```