### PR TITLE
Fixup wheel published to PyPI

### DIFF
--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -85,6 +85,6 @@ for whl_file in "$@"; do
             fi
         )
 
-        zip -qr "${new_whl_file}" .
+        zip -qr9 "${new_whl_file}" .
     )
 done

--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -56,7 +56,7 @@ for whl_file in "$@"; do
         if [[ $whl_file == *"with.pypi.cudnn"* ]]; then
             rm -rf "${whl_dir}/caffe2"
             rm -rf "${whl_dir}"/torch/lib/libnvrtc*
-            find "${whl_dir}/torch/include/caffe2" -maxdepth 1 -type d|grep -v serialize|xargs rm -rf
+            find "${whl_dir}/torch/include/caffe2" -maxdepth 1 -mindepth 1 -type d|grep -v serialize|xargs rm -rf
             sed -i -e "/^Requires-Dist: nvidia-cublas-cu11 (==11.10.3.66).*/a Requires-Dist: nvidia-cuda-nvrtc-cu11 (==11.7.99)" "${whl_dir}"/*/METADATA
 
             sed -i -e "s/-with-pypi-cudnn//g" "${whl_dir}/torch/version.py"

--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -54,7 +54,14 @@ for whl_file in "$@"; do
 
         # Special build with pypi cudnn remove it from version
         if [[ $whl_file == *"with.pypi.cudnn"* ]]; then
+            rm -rf "${whl_dir}/caffe2"
+            rm -rf "${whl_dir}"/torch/lib/libnvrtc*
+            find "${whl_dir}/torch/include/caffe2" -maxdepth 1 -type d|grep -v serialize|xargs rm -rf
+            sed -i -e "/^Requires-Dist: nvidia-cublas-cu11 (==11.10.3.66).*/a Requires-Dist: nvidia-cuda-nvrtc-cu11 (==11.7.99)" "${whl_dir}"/*/METADATA
+
             sed -i -e "s/-with-pypi-cudnn//g" "${whl_dir}/torch/version.py"
+            patchelf --set-rpath '$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN' \
+                $(find "${whl_dir}/torch/lib" -name "*.so")
         fi
 
         find "${dist_info_folder}" -type f -exec sed -i "s!${version_with_suffix}!${version_no_suffix}!" {} \;


### PR DESCRIPTION
Remove caffe2 python package
Remove caffe2 headers except for serialize
Remove bundled nvrtc and add it as wheel dependency


Test plan:
```
pip install wheel
```
```
python -c "import torch; a = torch.tensor([2, 2, 3], device='cuda'); print(a.prod())"
python -c "import torch.utils.cpp_extension as cppe; cppe.load_inline(name='foo', cpp_sources='#include <torch/library.h>\n#include <torch/csrc/jit/serialization/import.h>', is_python_module=False)"
```