### PR TITLE
Fixes cuda pypi rpaths and libnvrtc name

### DIFF
--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -61,8 +61,18 @@ for whl_file in "$@"; do
             sed -i -e "/^Requires-Dist: nvidia-cublas-cu11 (==11.10.3.66).*/a Requires-Dist: nvidia-cuda-nvrtc-cu11 (==11.7.99)" "${whl_dir}"/*/METADATA
 
             sed -i -e "s/-with-pypi-cudnn//g" "${whl_dir}/torch/version.py"
-            patchelf --set-rpath '$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN' \
-                $(find "${whl_dir}/torch/lib" -name "*.so")
+            find "${whl_dir}/torch/" -maxdepth 1 -type f -name "*.so*" | while read sofile; do
+                patchelf --set-rpath '$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN:$ORIGIN/lib' \
+                    --force-rpath $sofile
+                patchelf --print-rpath $sofile
+            done
+
+            find "${whl_dir}/torch/lib" -maxdepth 1 -type f -name "*.so*" | while read sofile; do
+                patchelf --set-rpath '$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN' \
+                    --force-rpath $sofile
+                patchelf --print-rpath $sofile
+            done
+            patchelf --replace-needed libnvrtc-d833c4f3.so.11.2 libnvrtc.so.11.2 "${whl_dir}/torch/lib/libcaffe2_nvrtc.so"
         fi
 
         find "${dist_info_folder}" -type f -exec sed -i "s!${version_with_suffix}!${version_no_suffix}!" {} \;


### PR DESCRIPTION
https://github.com/pytorch/builder/pull/1181 doesn't force rpaths. Also it didn't add nvrtc rpath to the .so's in the torch/ folder.

Additionally, the libnvrtc name is changed, otherwise libcaffe2_nvrtc.so will not find it.