### PR TITLE
Setting job name for Windows to HUD friendly name

### DIFF
--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -33,6 +33,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-windows-matrix.outputs.matrix) }}
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    name: ${{ matrix.build_name }}
     with:
       runner: ${{ matrix.validation_runner }}
       repository: "pytorch/builder"


### PR DESCRIPTION
On HUD we currently see following:
```
Validate binaries / win / win (3.7, cuda, 11.6, cu116, pytorch/manylinux-builder:cuda11.6, wheel, wheel-py3_7-cuda11_6, win... / wheel-py3_7-cuda11_6
```
With this change it should be:
```
Validate binaries / win / wheel-py3_7-cuda11_6 (3.7, cuda, 11.6, cu116, pytorch/manylinux-builder:cuda11.6, wheel, wheel-py3_7-cuda11_6, win... / wheel-py3_7-cuda11_6
```

Please refer to:
https://hud.pytorch.org/hud/pytorch/builder/main/1?per_page=50&name_filter=Validate%20binaries%20%2F%20win
