### PR TITLE
Always set $python_nodot for python 3.10 or later in build_common.sh

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -85,6 +85,8 @@ if [[ -n "$DESIRED_PYTHON" && "$DESIRED_PYTHON" != cp* ]]; then
         DESIRED_PYTHON="cp${python_nodot}-cp${python_nodot}"
         ;;
     esac
+else
+    python_nodot="${echo $DESIRED_PYTHON | sed -e 's/^cp\([0-9]*\)-.*/\1/'}"
 fi
 
 if [[ ${python_nodot} -ge 310 ]]; then


### PR DESCRIPTION
If `DESIRED_PYTHON` is already `cpXX-cpXX` format it wouldn't be set