### PR TITLE
Adding ref to validate binaries

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -63,9 +63,11 @@ jobs:
     uses: ./.github/workflows/validate-linux-binaries.yml
     with:
       channel: ${{ inputs.channel }}
+      ref: ${{ inputs.ref || github.ref }}
 
   mac:
     if:  inputs.os == 'macos' || inputs.os == 'all'
     uses: ./.github/workflows/validate-macos-binaries.yml
     with:
       channel: ${{ inputs.channel }}
+      ref: ${{ inputs.ref || github.ref }}


### PR DESCRIPTION
Adding ref to validate binaries
This will enable calling the workflow from another repo correctly
Similar to this code: https://github.com/pytorch/test-infra/blob/main/.github/workflows/linux_job.yml#L38