### PR TITLE
Add continue on error to validation jobs

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -49,6 +49,7 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
+      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -71,6 +71,7 @@ jobs:
           curl ${{ matrix.installation }} -o libtorch.zip
           unzip libtorch.zip
         else
+          INSTALLATION=${INSTALLATION/"conda install"/"conda install -y"}
           eval $INSTALLATION
           python  ./test/smoke_test/smoke_test.py
           ${PWD}/check_binary.sh

--- a/.github/workflows/validate-macos-binaries.yml
+++ b/.github/workflows/validate-macos-binaries.yml
@@ -55,6 +55,7 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
+      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"
@@ -94,6 +95,7 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
+      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -49,6 +49,7 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
+      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"


### PR DESCRIPTION
Add continue on error to validation jobs.
Add "-y" flag to conda install. This fixes timeout when installing using conda.