### PR TITLE
Disable continue on error for validation workflows

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -49,7 +49,6 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
-      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"

--- a/.github/workflows/validate-macos-binaries.yml
+++ b/.github/workflows/validate-macos-binaries.yml
@@ -55,7 +55,6 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
-      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"
@@ -95,7 +94,6 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
-      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -49,7 +49,6 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
-      continue-on-error: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"


### PR DESCRIPTION
Disable continue on error for validation workflows. As per documentation, feature:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
```
Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.
```

Normally we need to continue testing all jobs if 1 step fails or 1 job fails. However this feature seems to have side effect that the failing step is shown as successful on the UI, which is wrong. Hence reverting.
