### PR TITLE
Add cuda profiler api to cuda install 11.8

### DIFF
--- a/windows/internal/cuda_install.bat
+++ b/windows/internal/cuda_install.bat
@@ -87,7 +87,7 @@ if not exist "%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%" (
     curl -k -L "https://ossci-windows.s3.amazonaws.com/%CUDA_INSTALL_EXE%" --output "%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%"
     if errorlevel 1 exit /b 1
     set "CUDA_SETUP_FILE=%SRC_DIR%\temp_build\%CUDA_INSTALL_EXE%"
-    set "ARGS=thrust_11.8 nvcc_11.8 cuobjdump_11.8 nvprune_11.8 nvprof_11.8 cupti_11.8 cublas_11.8 cublas_dev_11.8 cudart_11.8 cufft_11.8 cufft_dev_11.8 curand_11.8 curand_dev_11.8 cusolver_11.8 cusolver_dev_11.8 cusparse_11.8 cusparse_dev_11.8 npp_11.8 npp_dev_11.8 nvrtc_11.8 nvrtc_dev_11.8 nvml_dev_11.8"
+    set "ARGS=cuda_profiler_api_11.8 thrust_11.8 nvcc_11.8 cuobjdump_11.8 nvprune_11.8 nvprof_11.8 cupti_11.8 cublas_11.8 cublas_dev_11.8 cudart_11.8 cufft_11.8 cufft_dev_11.8 curand_11.8 curand_dev_11.8 cusolver_11.8 cusolver_dev_11.8 cusparse_11.8 cusparse_dev_11.8 npp_11.8 npp_dev_11.8 nvrtc_11.8 nvrtc_dev_11.8 nvml_dev_11.8"
 )
 
 set CUDNN_FOLDER=cudnn-windows-x86_64-8.5.0.96_cuda11-archive


### PR DESCRIPTION
In Cuda 11.8 the new installation argument was added.
cuda_profiler_api_11.8	Driver and Runtime APIs for ProfilerStart/Stop.
In previous version it used to be included with nvprof module.

New CUDA 11.8 docs, Instalaltion guide for windows section.:
https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html
CUDA 11.7 docs:
https://docs.nvidia.com/cuda/archive/11.7.0/cuda-installation-guide-microsoft-windows/index.html

