### PR TITLE
Fix naming for macos jobs

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -71,3 +71,10 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       ref: ${{ inputs.ref || github.ref }}
+
+  mac-arm64:
+    if:  inputs.os == 'macos' || inputs.os == 'all'
+    uses: ./.github/workflows/validate-macos-arm64-binaries.yml
+    with:
+      channel: ${{ inputs.channel }}
+      ref: ${{ inputs.ref || github.ref }}

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -1,4 +1,4 @@
-name: Validate MacOS Binaries
+name: Validate MacOS ARM64 Binaries
 
 on:
   workflow_call:
@@ -30,16 +30,16 @@ on:
         type: string
 
 jobs:
-  generate-macos-matrix:
+  generate-macos-arm64-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: all
-      os: macos
+      os: macos-arm64
       channel: ${{ inputs.channel }}
-  macos:
-    needs: generate-macos-matrix
+  macos-arm64:
+    needs: generate-macos-arm64-matrix
     strategy:
-      matrix: ${{ fromJson(needs.generate-macos-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.generate-macos-arm64-matrix.outputs.matrix) }}
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     name: ${{ matrix.build_name }}
@@ -57,7 +57,6 @@ jobs:
         export CUDA_VER="${{ matrix.desired_cuda }}"
         export DESIRED_PYTHON="${{ matrix.python_version }}"
         export DESIRED_CUDA="${{ matrix.desired_cuda }}"
-        export DESIRED_DEVTOOLSET="${{ matrix.devtoolset }}"
         export PACKAGE_TYPE="${{ matrix.package_type }}"
-        export TARGET_OS="macos"
+        export TARGET_OS="macos-arm64"
         ./.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -15,6 +15,7 @@ on:
       - .github/workflows/validate-linux-binaries.yml
       - .github/workflows/validate-windows-binaries.yml
       - .github/workflows/validate-macos-binaries.yml
+      - .github/workflows/validate-macos-arm64-binaries.yml
       - test/smoke_test/*
   pull_request:
     paths:
@@ -22,6 +23,7 @@ on:
       - .github/workflows/validate-linux-binaries.yml
       - .github/workflows/validate-windows-binaries.yml
       - .github/workflows/validate-macos-binaries.yml
+      - .github/workflows/validate-macos-arm64-binaries.yml
       - test/smoke_test/*
 
 jobs:

--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -15,6 +15,7 @@ on:
       - .github/workflows/validate-linux-binaries.yml
       - .github/workflows/validate-windows-binaries.yml
       - .github/workflows/validate-macos-binaries.yml
+      - .github/workflows/validate-macos-arm64-binaries.yml
       - test/smoke_test/*
   pull_request:
     paths:
@@ -22,6 +23,7 @@ on:
       - .github/workflows/validate-linux-binaries.yml
       - .github/workflows/validate-windows-binaries.yml
       - .github/workflows/validate-macos-binaries.yml
+      - .github/workflows/validate-macos-arm64-binaries.yml
       - test/smoke_test/*
 
 jobs:


### PR DESCRIPTION
Move macos-arm64 into separate group, this way it makes easier to distinguish macos from macos-arm64 failures:
Please refer to following:
https://github.com/pytorch/builder/actions/runs/3676261591/jobs/6216706935