### PR TITLE
Adding libcufft constraint

### DIFF
--- a/conda/pytorch-cuda/meta.yaml
+++ b/conda/pytorch-cuda/meta.yaml
@@ -1,7 +1,9 @@
 {% set build = 0 %}
 {% set cuda_constraints=">=11.6,<11.7" %}
+{% set libcufft_constraints=">=10.6.0.107,<10.7.2.91" %}
 {% if version == '11.7' %}
 {% set cuda_constraints=">=11.7,<11.8" %}
+{% set libcufft_constraints=">=10.7.2.91,<10.9.0.58" %}
 {% endif %}
 
 package:
@@ -35,6 +37,8 @@ requirements:
     - cuda-runtime {{ cuda_constraints }}
     - cuda-toolkit {{ cuda_constraints }}
     - cuda-tools {{ cuda_constraints }}
+    - libcufft {{ libcufft_constraints }}
+    - libcufft-dev {{ libcufft_constraints }}
   # None, pytorch should depend on pytorch-cuda
 test:
   commands:


### PR DESCRIPTION
Adding libcufft constraint

Resolves following failure:
```
+ python ./test/smoke_test/smoke_test.py
Traceback (most recent call last):
  File "./test/smoke_test/smoke_test.py", line 6, in <module>
    import torch
  File "/opt/conda/envs/conda-env-3677553166/lib/python3.7/site-packages/torch/__init__.py", line 217, in <module>
    _load_global_deps()
  File "/opt/conda/envs/conda-env-3677553166/lib/python3.7/site-packages/torch/__init__.py", line 177, in _load_global_deps
    raise err
  File "/opt/conda/envs/conda-env-3677553166/lib/python3.7/site-packages/torch/__init__.py", line 172, in _load_global_deps
    ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
  File "/opt/conda/envs/conda-env-3677553166/lib/python3.7/ctypes/__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libcufft.so.10: cannot open shared object file: No such file or directory
Error: Process completed with exit code 1.
```