### PR TITLE
PyPi binary validation and size check

### DIFF
--- a/.github/workflows/validate-repackaged-binary-sizes.yml
+++ b/.github/workflows/validate-repackaged-binary-sizes.yml
@@ -1,65 +1,77 @@
 name: Validate manywheel binaries
 
+# This workflow validates the size of the manywheel binaries after repackaging for PyPi
+# Specify the direct URLs to the binaries (from https://download.pytorch.org/whl/test/torch/) in the matrix
+# along with the python version.
+#
+# The workflow will:
+#  * download the binaries,
+#  * run release/pypi/prep_binary_for_pypi.sh
+#  * run smoke tests on the repackaged binaries
+#  * display the size before and after repackaging
+
 on:
   pull_request:
 
 jobs:
   validate-binary-size:
-    runs-on: linux.4xlarge.nvidia.gpu
     strategy:
       fail-fast: false
       matrix:
         whl:
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp310-cp310-linux_x86_64.whl
-            python: 3.10
+            python: "3.10"
 #          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp311-cp311-linux_x86_64.whl
-#            python: 3.11
-#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp37-cp37m-linux_x86_64.whl
-#            python: 3.7
-#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp38-cp38-linux_x86_64.whl
-#            python: 3.8
-#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp39-cp39-linux_x86_64.whl
-#            python: 3.9
+#            python: "3.11"
+          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp37-cp37m-linux_x86_64.whl
+            python: "3.7"
+          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp38-cp38-linux_x86_64.whl
+            python: "3.8"
+          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp39-cp39-linux_x86_64.whl
+            python: "3.9"
 
-    env:
-      GPU_ARCH_TYPE: cuda
-      GPU_ARCH_VERSION: "11.7"
-
-    steps:
-      - name: Checkout PyTorch builder
-        uses: actions/checkout@v3
-
-      - name: Install patchelf
-        run: |
-          chmod a+x common/install_patchelf.sh
-          sudo common/install_patchelf.sh
-
-      - name: Download torch whl
-        run: |
-          wget ${{ matrix.whl.url }}
-          FILENAME=$(ls -1 *.whl | head -n 1)
-          echo "::notice::Before repackaging: $(du -h $FILENAME | cut -f1)"
-          echo "FILENAME=$FILENAME" >> $GITHUB_ENV
-
-      - name: Repackage into manywheel
-        continue-on-error: true
-        run: |
-          release/pypi/prep_binary_for_pypi.sh $FILENAME
-          NEW_FILENAME=$(ls -1 *.whl | head -n 1)
-          echo "::notice::After repackaging: $(du -h $NEW_FILENAME | cut -f1)"
-          echo "NEW_FILENAME=$NEW_FILENAME" >> $GITHUB_ENV
-
-      - name: Run smoke test
-        continue-on-error: true
-        run: |
-          set -ex
-          # run smoke test to make sure the binary is not broken
-          conda create -n smoke-test python=${{ matrix.whl.python }} -y
-          conda activate smoke-test
-          pip install $NEW_FILENAME
-          python  ./test/smoke_test/smoke_test.py -- --package=torchonly
-
-      - name: Hold runner for 60 minutes or until ssh sessions have drained
-        timeout-minutes: 60
-        run: |
-          sleep infinity
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      runner: linux.4xlarge.nvidia.gpu
+      repository: "pytorch/builder"
+      ref: ${{ github.ref }}
+      job-name: "Validate binary size"
+      script: |
+        set -ex
+        export ENV_NAME="conda-env-${{ github.run_id }}"
+        export GPU_ARCH_VER="11.7"
+        export GPU_ARCH_TYPE="cuda"
+        export CUDA_VER="11.7"
+        export DESIRED_PYTHON="${{ matrix.whl.python }}"
+        export DESIRED_CUDA="cu117"
+        export PACKAGE_TYPE="wheel"
+        export TARGET_OS="linux"
+        export INSTALLATION=""
+        
+        # install zip
+        sudo yum install zip -y
+        
+        # install patchelf
+        chmod a+x common/install_patchelf.sh
+        sudo common/install_patchelf.sh
+        
+        # download torch whl
+        wget ${{ matrix.whl.url }}
+        FILENAME=$(ls -1 *.whl | head -n 1)
+        SIZE_BEFORE=$(du -h $FILENAME | cut -f1)
+        
+        # repackage into manywheel
+        release/pypi/prep_binary_for_pypi.sh $FILENAME
+        
+        NEW_FILENAME=$(ls -1 *.whl | head -n 1)
+        echo "::notice:: $FILENAME before: $SIZE_BEFORE after: $(du -h $NEW_FILENAME | cut -f1)"
+        
+        # create conda env
+        conda create -y -n $ENV_NAME python=$DESIRED_PYTHON
+        conda activate $ENV_NAME
+        
+        # install torch
+        pip install numpy pillow $NEW_FILENAME
+        
+        # run smoke test
+        python ./test/smoke_test/smoke_test.py --package=torchonly

--- a/.github/workflows/validate-repackaged-binary-sizes.yml
+++ b/.github/workflows/validate-repackaged-binary-sizes.yml
@@ -1,0 +1,65 @@
+name: Validate manywheel binaries
+
+on:
+  pull_request:
+
+jobs:
+  validate-binary-size:
+    runs-on: linux.4xlarge.nvidia.gpu
+    strategy:
+      fail-fast: false
+      matrix:
+        whl:
+          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp310-cp310-linux_x86_64.whl
+            python: 3.10
+#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp311-cp311-linux_x86_64.whl
+#            python: 3.11
+#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp37-cp37m-linux_x86_64.whl
+#            python: 3.7
+#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp38-cp38-linux_x86_64.whl
+#            python: 3.8
+#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp39-cp39-linux_x86_64.whl
+#            python: 3.9
+
+    env:
+      GPU_ARCH_TYPE: cuda
+      GPU_ARCH_VERSION: "11.7"
+
+    steps:
+      - name: Checkout PyTorch builder
+        uses: actions/checkout@v3
+
+      - name: Install patchelf
+        run: |
+          chmod a+x common/install_patchelf.sh
+          sudo common/install_patchelf.sh
+
+      - name: Download torch whl
+        run: |
+          wget ${{ matrix.whl.url }}
+          FILENAME=$(ls -1 *.whl | head -n 1)
+          echo "::notice::Before repackaging: $(du -h $FILENAME | cut -f1)"
+          echo "FILENAME=$FILENAME" >> $GITHUB_ENV
+
+      - name: Repackage into manywheel
+        continue-on-error: true
+        run: |
+          release/pypi/prep_binary_for_pypi.sh $FILENAME
+          NEW_FILENAME=$(ls -1 *.whl | head -n 1)
+          echo "::notice::After repackaging: $(du -h $NEW_FILENAME | cut -f1)"
+          echo "NEW_FILENAME=$NEW_FILENAME" >> $GITHUB_ENV
+
+      - name: Run smoke test
+        continue-on-error: true
+        run: |
+          set -ex
+          # run smoke test to make sure the binary is not broken
+          conda create -n smoke-test python=${{ matrix.whl.python }} -y
+          conda activate smoke-test
+          pip install $NEW_FILENAME
+          python  ./test/smoke_test/smoke_test.py -- --package=torchonly
+
+      - name: Hold runner for 60 minutes or until ssh sessions have drained
+        timeout-minutes: 60
+        run: |
+          sleep infinity

--- a/.github/workflows/validate-repackaged-binary-sizes.yml
+++ b/.github/workflows/validate-repackaged-binary-sizes.yml
@@ -21,21 +21,20 @@ jobs:
         whl:
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp310-cp310-linux_x86_64.whl
             python: "3.10"
-#          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp311-cp311-linux_x86_64.whl
-#            python: "3.11"
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp37-cp37m-linux_x86_64.whl
             python: "3.7"
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp38-cp38-linux_x86_64.whl
             python: "3.8"
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp39-cp39-linux_x86_64.whl
             python: "3.9"
+    #          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp311-cp311-linux_x86_64.whl
+    #            python: "3.11"
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.4xlarge.nvidia.gpu
-      repository: "pytorch/builder"
-      ref: ${{ github.ref }}
       job-name: "Validate binary size"
+      upload-artifact: pipy_wheel
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"
@@ -65,6 +64,9 @@ jobs:
         
         NEW_FILENAME=$(ls -1 *.whl | head -n 1)
         echo "::notice:: $FILENAME before: $SIZE_BEFORE after: $(du -h $NEW_FILENAME | cut -f1)"
+        
+        # cp to ${RUNNER_ARTIFACT_DIR}
+        cp $NEW_FILENAME ${RUNNER_ARTIFACT_DIR}/
         
         # create conda env
         conda create -y -n $ENV_NAME python=$DESIRED_PYTHON

--- a/.github/workflows/validate-repackaged-binary-sizes.yml
+++ b/.github/workflows/validate-repackaged-binary-sizes.yml
@@ -8,10 +8,14 @@ name: Validate manywheel binaries
 #  * download the binaries,
 #  * run release/pypi/prep_binary_for_pypi.sh
 #  * run smoke tests on the repackaged binaries
-#  * display the size before and after repackaging
+#  * display the size before and after repackaging as the workflow annotation
+#  * optionally upload the repackaged binaries as artifacts (for debug or promotion)
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/validate-repackaged-binary-sizes.yml
+      - release/pypi/prep_binary_for_pypi.sh
 
 jobs:
   validate-binary-size:
@@ -20,21 +24,26 @@ jobs:
       matrix:
         whl:
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp310-cp310-linux_x86_64.whl
-            python: "3.10"
+            python: "3.10"  # python version to use for smoke tests
+            upload_artifact: false # upload the repackaged binary as an artifact
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp37-cp37m-linux_x86_64.whl
             python: "3.7"
+            artifact: false
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp38-cp38-linux_x86_64.whl
             python: "3.8"
+            artifact: false
           - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp39-cp39-linux_x86_64.whl
             python: "3.9"
-    #          - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp311-cp311-linux_x86_64.whl
-    #            python: "3.11"
+            artifact: false
+     #    - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp311-cp311-linux_x86_64.whl
+     #      python: "3.11"
+     #      artifact: false
 
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       runner: linux.4xlarge.nvidia.gpu
       job-name: "Validate binary size"
-      upload-artifact: pipy_wheel
+      upload-artifact: ${{ matrix.whl.upload_artifact == 'true' && 'repackaged-binary' || '' }}
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"

--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -77,15 +77,7 @@ for whl_file in "$@"; do
         find "${dist_info_folder}" -type f -exec sed -i "s!${version_with_suffix}!${version_no_suffix}!" {} \;
         # Moves distinfo from one with a version suffix to one without
         # Example: torch-1.8.0+cpu.dist-info => torch-1.8.0.dist-info
-
-        echo "Before moving dist_info_folder"
-        ls -l "${whl_dir}"
-
         mv "${dist_info_folder}" "${dirname_dist_info_folder}/${basename_dist_info_folder/${version_with_suffix}/${version_no_suffix}}"
-
-        echo "After moving dist_info_folder"
-        ls -l "${whl_dir}"
-
         cd "${whl_dir}"
 
         (

--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -77,7 +77,15 @@ for whl_file in "$@"; do
         find "${dist_info_folder}" -type f -exec sed -i "s!${version_with_suffix}!${version_no_suffix}!" {} \;
         # Moves distinfo from one with a version suffix to one without
         # Example: torch-1.8.0+cpu.dist-info => torch-1.8.0.dist-info
+
+        echo "Before moving dist_info_folder"
+        ls -l "${whl_dir}"
+
         mv "${dist_info_folder}" "${dirname_dist_info_folder}/${basename_dist_info_folder/${version_with_suffix}/${version_no_suffix}}"
+
+        echo "After moving dist_info_folder"
+        ls -l "${whl_dir}"
+
         cd "${whl_dir}"
 
         (
@@ -95,6 +103,7 @@ for whl_file in "$@"; do
             fi
         )
 
+        rm -rf "${new_whl_file}"
         zip -qr9 "${new_whl_file}" .
     )
 done


### PR DESCRIPTION
A semi-automated validation workflow for the PyPi binaries.

Allows to specify the list of binaries to repackage and validate as the matrix:
```yml
matrix:
  whl:
    - url: https://download.pytorch.org/whl/test/cu117_pypi_cudnn/torch-1.13.1%2Bcu117.with.pypi.cudnn-cp310-cp310-linux_x86_64.whl
      python: "3.10"  # python version to use for smoke tests
      upload_artifact: false # upload the repackaged binary as an artifact
...
```
The workflow will:
  * download the binaries,
  * run release/pypi/prep_binary_for_pypi.sh
  * run smoke tests on the repackaged binaries
  * display the size before and after repackaging as the workflow annotation
  * optionally upload the repackaged binaries as artifacts (for debug or promotion)

See [this run](https://github.com/pytorch/builder/actions/runs/3698006139).
Annotations:
<img width="943" alt="image" src="https://user-images.githubusercontent.com/108101595/207704386-7d5ffa2c-451b-4318-a434-389e1a85f715.png">


---

Additionally, during evaluation of this workflow I discovered an issue with `prep_binary_for_pypi.sh`:

>   Apparently if the target file exists, `zip -qr9 "${new_whl_file}" .` will add to the file, instead of overwriting the whole file.
> For certain binary names, like `torch-1.13.1+cu117.with.pypi.cudnn-cp310-cp310-linux_x86_64.whl` the original and the repackaged binary names match, meaning the last step will merge them, creating two `dist-info` directories inside.
> See [this run for example](https://github.com/pytorch/builder/actions/runs/3697391375/jobs/6262319139#step:9:1924).

This issue is fixed by adding `rm -rf "${new_whl_file}"` before `zip -qr9 "${new_whl_file}" .` to ensure new file is created from scratch.