### PR TITLE
release: Strip whitespace from version_with_suffix

### DIFF
--- a/release/pypi/prep_binary_for_pypi.sh
+++ b/release/pypi/prep_binary_for_pypi.sh
@@ -40,7 +40,7 @@ for whl_file in "$@"; do
         set -x
         unzip -q "${whl_file}" -d "${whl_dir}"
     )
-    version_with_suffix=$(grep '^Version:' "${whl_dir}"/*/METADATA | cut -d' ' -f2)
+    version_with_suffix=$(grep '^Version:' "${whl_dir}"/*/METADATA | cut -d' ' -f2 | tr -d "[:space:]")
     version_with_suffix_escaped=${version_with_suffix/+/%2B}
 
     # Remove all suffixed +bleh versions


### PR DESCRIPTION
Noticed an errant '\r' when looking through the promotion scripts that cause the substitutions to end up failing later on in the script. This should make it so that this variable won't include any whitespace characters.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>