### PR TITLE
Update MKL to 2022.1

### DIFF
--- a/common/install_mkl.sh
+++ b/common/install_mkl.sh
@@ -3,8 +3,8 @@
 set -ex
 
 # MKL
-MKL_VERSION=2020.0
-MKL_BUILD=166
+MKL_VERSION=2022.2.1
+MKL_BUILD=16993
 mkdir -p /opt/intel/lib
 pushd /tmp
 curl -fsSL https://anaconda.org/intel/mkl-static/${MKL_VERSION}/download/linux-64/mkl-static-${MKL_VERSION}-intel_${MKL_BUILD}.tar.bz2 | tar xjv

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -168,7 +168,7 @@ conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "$tmp_env_name" python="$desired_p
 source activate "$tmp_env_name"
 
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
-retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq mkl-include==2020.1 mkl-static==2020.1 -c intel
+retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq mkl-include==2022.2.1 mkl-static==2022.2.1 -c intel
 retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 
 # For USE_DISTRIBUTED=1 on macOS, need libuv and pkg-config to find libuv.


### PR DESCRIPTION
As previous one occasionally crashes on AMD CPUs

May be addresses https://github.com/pytorch/pytorch/issues/89817

Please note, that in order to get maximum perf on AMD CPUs one needs to compile and LD_PRELOAD following library:
```
int mkl_serv_intel_cpu_true() {
	return 1;
}
```
