### PR TITLE
Remove invalid git option

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -41,8 +41,8 @@ echo "export BUILDER_ROOT=${BUILDER_ROOT}" >> ${BASH_ENV}
 retry git clone --depth 1 https://github.com/pytorch/pytorch.git "$PYTORCH_ROOT"
 # Removed checking out pytorch/pytorch using CIRCLE_PR_NUMBER and CIRCLE_SHA1 as
 # those environment variables are tied to the host repo where the build is being
-# triggered. 
-retry git submodule update --init --recursive --jobs 0
+# triggered.
+retry git submodule update --init --recursive
 pushd "$PYTORCH_ROOT"
 echo "Using Pytorch from "
 git --no-pager log --max-count 1

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -190,7 +190,7 @@ if [[ ! -d "$pytorch_rootdir" ]]; then
     popd
 fi
 pushd "$pytorch_rootdir"
-git submodule update --init --recursive --jobs 0
+git submodule update --init --recursive
 echo "Using Pytorch from "
 git --no-pager log --max-count 1
 popd

--- a/cron/nightly_defaults.sh
+++ b/cron/nightly_defaults.sh
@@ -120,7 +120,7 @@ if [[ ! -d "$NIGHTLIES_PYTORCH_ROOT" ]]; then
         export PYTORCH_BRANCH="$last_commit"
     fi
     git checkout "$PYTORCH_BRANCH"
-    git submodule update --jobs 0
+    git submodule update
     popd
 fi
 
@@ -229,7 +229,7 @@ if [[ "$DAYS_TO_KEEP" < '1' ]]; then
 fi
 
 # PYTORCH_NIGHTLIES_TIMEOUT
-#   Timeout in seconds. 
+#   Timeout in seconds.
 #   When full testing is enabled, condas builds often take up to 2 hours 20
 #   minutes, so the default is set to (2 * 60 + 20 + 40 [buffer]) * 60 == 10800
 #   seconds.

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -128,7 +128,7 @@ if [[ ! -d "$pytorch_rootdir" ]]; then
     popd
 fi
 pushd "$pytorch_rootdir"
-git submodule update --init --recursive --jobs 0
+git submodule update --init --recursive
 popd
 
 ##########################


### PR DESCRIPTION
Nightly build starts failing 
```
~/work/pytorch/pytorch/pytorch ~/work/pytorch/pytorch
BUG: run-command.c:1521: you must provide a non-zero number of processes!
/usr/local/Cellar/git/2.39.0/libexec/git-core/git-submodule: line 239: 11975 Abort trap: 6           git ${wt_prefix:+-C "$wt_prefix"} submodule--helper update ${quiet:+--quiet} ${force:+--force} ${progress:+"--progress"} ${remote:+--remote} ${recursive:+--recursive} ${init:+--init} ${nofetch:+--no-fetch} ${rebase:+--rebase} ${merge:+--merge} ${checkout:+--checkout} ${reference:+"$reference"} ${dissociate:+"--dissociate"} ${depth:+"$depth"} ${require_init:+--require-init} ${dissociate:+"--dissociate"} $single_branch $recommend_shallow $jobs $filter -- "$@"
Error: Process completed with exit code 134.
```

Related to latest git change:
https://github.com/git/git/commit/51243f9f0f6a932ea579fd6f8014b348f8c2a523