### PR TITLE
Remove pylief dependency

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -207,8 +207,6 @@ if [[ "$(uname)" == 'Darwin' ]]; then
         rm "$miniconda_sh"
     export PATH="$tmp_conda/bin:$PATH"
     retry conda install -yq conda-build
-    # Install py-lief=0.12.0 containing https://github.com/lief-project/LIEF/pull/579 to speed up the builds
-    retry conda install -yq  py-lief==0.12.0 -c malfet
 elif [[ "$OSTYPE" == "msys" ]]; then
     export tmp_conda="${WIN_PACKAGE_WORK_DIR}\\conda"
     export miniconda_exe="${WIN_PACKAGE_WORK_DIR}\\miniconda.exe"


### PR DESCRIPTION
Remove pylief dependency. 

This is to unblock macos conda builds that are failing: https://github.com/pytorch/pytorch/actions/runs/3799171656/jobs/6461449086

Test PR:
https://github.com/pytorch/pytorch/pull/91507
https://github.com/pytorch/pytorch/actions/runs/3801621293/jobs/6466278871

I don't observe any difference in building times vs previously passing build 1hr:07-1hr:15 min:
https://github.com/pytorch/pytorch/actions/runs/3756015842/jobs/6381619694

Looks like the issue caused by long building times is resolved now as per Test PR:
https://github.com/pytorch/pytorch/issues/58534
