### PR TITLE
Adding py311 validations for wheel builds

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -11,14 +11,28 @@ if [[ ${PACKAGE_TYPE} == "libtorch" ]]; then
     curl ${INSTALLATION} -o libtorch.zip
     unzip libtorch.zip
 else
-    conda create -y -n ${ENV_NAME} python=${DESIRED_PYTHON} numpy pillow
-    conda activate ${ENV_NAME}
-    export CONDA_LIBRARY_PATH="$(dirname $(which python))/../lib"
-    export LD_LIBRARY_PATH=$CONDA_LIBRARY_PATH:$LD_LIBRARY_PATH
-    INSTALLATION=${INSTALLATION/"conda install"/"conda install -y"}
-    eval $INSTALLATION
-    python  ./test/smoke_test/smoke_test.py
-    if [[ ${TARGET_OS} != 'macos' && ${TARGET_OS} != 'windows' ]]; then
-        ${PWD}/check_binary.sh
+    if [ $DESIRED_PYTHON == '3.11' ]; then
+        export CPYTHON_VERSIONS=3.11.0
+        sudo yum -y install openssl-devel libssl-dev bzip2-devel libffi-devel
+        sudo yum -y groupinstall "Development Tools"
+        export PYTHON_PATH="/opt/_internal/cpython-3.11.0/bin"
+        export PIP_PATH="${PYTHON_PATH}/pip"
+        export PIP_INSTALLATION="${INSTALLATION/pip3/"$PIP_PATH"}"
+        export WITH_OPENSSL="/opt/openssl"
+        ./common/install_cpython.sh
+        eval ${PYTHON_PATH}/python --version
+        eval ${PIP_INSTALLATION}
+        eval ${PYTHON_PATH}/python ./test/smoke_test/smoke_test.py --package torchonly
+    else
+        conda create -y -n ${ENV_NAME} python=${DESIRED_PYTHON} numpy pillow
+        conda activate ${ENV_NAME}
+        export CONDA_LIBRARY_PATH="$(dirname $(which python))/../lib"
+        export LD_LIBRARY_PATH=$CONDA_LIBRARY_PATH:$LD_LIBRARY_PATH
+        INSTALLATION=${INSTALLATION/"conda install"/"conda install -y"}
+        eval $INSTALLATION
+        python  ./test/smoke_test/smoke_test.py
+        if [[ ${TARGET_OS} != 'macos' && ${TARGET_OS} != 'windows' ]]; then
+            ${PWD}/check_binary.sh
+        fi
     fi
 fi

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -36,6 +36,7 @@ jobs:
       package-type: all
       os: linux
       channel: ${{ inputs.channel }}
+      with-py311: enable
 
   linux:
     needs: generate-linux-matrix

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -40,7 +40,11 @@ function do_cpython_build {
     mkdir -p ${prefix}/lib
 
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" ./configure --prefix=${prefix} --disable-shared $unicode_flags > /dev/null
+    if [[ -z  ${WITH_OPENSSL} ]]; then
+        CFLAGS="-Wformat" ./configure --prefix=${prefix} --disable-shared $unicode_flags > /dev/null
+    else
+        CFLAGS="-Wformat" ./configure --prefix=${prefix} --with-openssl=${WITH_OPENSSL} --with-openssl-rpath=auto --disable-shared $unicode_flags > /dev/null
+    fi
 
     make -j40 > /dev/null
     make install > /dev/null
@@ -61,7 +65,6 @@ function do_cpython_build {
     ln -s ${prefix} /opt/python/${abi_tag}
 }
 
-
 function build_cpython {
     local py_ver=$1
     check_var $py_ver
@@ -77,7 +80,6 @@ function build_cpython {
     rm -f Python-$py_ver.tgz
 }
 
-
 function build_cpythons {
     check_var $GET_PIP_URL
     curl -sLO $GET_PIP_URL
@@ -86,7 +88,6 @@ function build_cpythons {
     done
     rm -f get-pip.py
 }
-
 
 mkdir -p /opt/python
 mkdir -p /opt/_internal


### PR DESCRIPTION
Adding python 3.11 validations for nightly testing.

Please note: Compiling python```--with-openssl``` is needed in CentOS, this is what we are running in Docker.