### PR TITLE
Nightly: do test deps install better and skip CUDA tests on cpu only box

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Folders:
 - **windows** : scripts to build Windows wheels
 - **cron** : scripts to drive all of the above scripts across multiple configurations together
 - **analytics** : scripts to pull wheel download count from our AWS s3 logs
+
+## Testing
+
+In order to test build triggered by PyTorch repo's GitHub actions see [these instructions](https://github.com/pytorch/pytorch/blob/master/.github/scripts/README.md#testing-pytorchbuilder-changes)


### PR DESCRIPTION
I somehow ran into issues where `conda update` in `run_tests.sh` was resetting the pytorch version back to some old one for the smoke test. Accourding to https://github.com/conda/conda/issues/1884 installing single tar.gz is not installing the deps. Instead one has to use local channel and then the deps are installed properly.

I also added a skip of the cuda smoke test on boxes without cuda drivers.

Test PyTorch PR: https://github.com/pytorch/pytorch/pull/91921