### PR TITLE
Set ubuntu distribution correctly for ROCm5.3 and above

### DIFF
--- a/common/install_rocm.sh
+++ b/common/install_rocm.sh
@@ -47,6 +47,10 @@ install_ubuntu() {
         ROCM_REPO="xenial"
     fi
 
+    if [[ $(ver $ROCM_VERSION) -ge $(ver 5.3) ]]; then
+        ROCM_REPO="${UBUNTU_VERSION_NAME}"
+    fi
+
     # Add rocm repository
     wget -qO - http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
     local rocm_baseurl="http://repo.radeon.com/rocm/apt/${ROCM_VERSION}"


### PR DESCRIPTION
Missed this in the ROCm5.3 updates. This PR addresses the warning seen when installing ROCm5.3 or above:
```
#32 3.070 W: Conflicting distribution: https://repo.radeon.com/rocm/apt/5.4 ubuntu InRelease (expected ubuntu but got focal)
```