### PR TITLE
Following practice of pinning cmake where conda is used

### DIFF
--- a/conda/debugging_pytorch.sh
+++ b/conda/debugging_pytorch.sh
@@ -14,7 +14,7 @@ export USE_CUDA_STATIC_LINK=1
 . ./switch_cuda_version.sh 9.0
 
 
-conda install -y cmake numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing_extension ninja magma-cuda80 -c pytorch
+conda install -y cmake=3.22.* numpy=1.17 setuptools pyyaml cffi mkl=2018 mkl-include typing_extension ninja magma-cuda80 -c pytorch
 
 export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 git clone https://github.com/pytorch/pytorch -b nightly2 --recursive

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -167,7 +167,7 @@ tmp_env_name="wheel_py$python_nodot"
 conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "$tmp_env_name" python="$desired_python"
 source activate "$tmp_env_name"
 
-retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
+retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake=3.22.* "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" cffi typing_extensions ninja requests
 retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq mkl-include==2022.2.1 mkl-static==2022.2.1 -c intel
 retry pip install -qr "${pytorch_rootdir}/requirements.txt" || true
 


### PR DESCRIPTION

### Description
From this PR https://github.com/pytorch/builder/pull/1011 I saw there are files using conda here that don't have cmake pinned to 3.22.*. Shall we pin them?

### Context (why pin cmake to 3.22.*?)
When conda offered cmake version 3.23.0, certain builds would break https://github.com/pytorch/pytorch/issues/74985#issue-1187048138. This resulted in the pinning of cmake to a stable version like 3.22 where conda is used https://github.com/pytorch/benchmark/pull/845. Since then, conda has yanked 3.23.0 and is currently on version 3.22.1, so it was then safe to unpin cmake https://github.com/pytorch/pytorch/issues/75705.

Now, it has been decided that it would be best practice to pin cmake to a known stable version, then upgrade in a controlled manner instead of leaving cmake unpinned https://github.com/pytorch/pytorch/pull/91739#discussion_r1061974102. Initially set to 3.22, it has since been relaxed to 3.22.* https://github.com/pytorch/pytorch/pull/90307. We've already pinned cmake to 3.22.* in pytorch/pytorch here https://github.com/pytorch/pytorch/pull/91739 and pytorch/test-infra here https://github.com/pytorch/test-infra/pull/1368.

### People with Relevant Context
@huydhn  @janeyx99

### How is this Tested?
I attempted to follow [these instructions](https://github.com/pytorch/pytorch/blob/master/.github/scripts/README.md#testing-pytorchbuilder-changes) to test these changes. The fake PR can be found here.