### PR TITLE
libtinfo.so version update and logic fix for ROCm libtorch

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -281,7 +281,7 @@ replace_needed_sofiles() {
         patchedname=$3
         if [[ "$origname" != "$patchedname" ]] || [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
             set +e
-            origname=$($PATCHELF_BIN --print-needed $sofile | grep "$origname*") 
+            origname=$($PATCHELF_BIN --print-needed $sofile | grep "$origname.*") 
             ERRCODE=$?
             set -e
             if [ "$ERRCODE" -eq "0" ]; then

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -303,7 +303,7 @@ for pkg in /$LIBTORCH_HOUSE_DIR/libtorch*.zip; do
                 patchedname=${patched[i]}
                 if [[ "$origname" != "$patchedname" ]] || [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
                     set +e
-                    origname=$($PATCHELF_BIN --print-needed $sofile | grep "$origname*") 
+                    origname=$($PATCHELF_BIN --print-needed $sofile | grep "$origname.*") 
                     ERRCODE=$?
                     set -e
                     if [ "$ERRCODE" -eq "0" ]; then

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -114,7 +114,7 @@ elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
     LIBGOMP_PATH="/usr/lib/x86_64-linux-gnu/libgomp.so.1"
     LIBNUMA_PATH="/usr/lib/x86_64-linux-gnu/libnuma.so.1"
     LIBELF_PATH="/usr/lib/x86_64-linux-gnu/libelf.so.1"
-    LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.5"
+    LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.6"
     LIBDRM_PATH="/usr/lib/x86_64-linux-gnu/libdrm.so.2"
     LIBDRM_AMDGPU_PATH="/usr/lib/x86_64-linux-gnu/libdrm_amdgpu.so.1"
     MAYBE_LIB64=lib

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -114,7 +114,11 @@ elif [[ "$OS_NAME" == *"Ubuntu"* ]]; then
     LIBGOMP_PATH="/usr/lib/x86_64-linux-gnu/libgomp.so.1"
     LIBNUMA_PATH="/usr/lib/x86_64-linux-gnu/libnuma.so.1"
     LIBELF_PATH="/usr/lib/x86_64-linux-gnu/libelf.so.1"
-    LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.6"
+    if [[ $ROCM_INT -ge 50300 ]]; then
+        LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.6"
+    else
+        LIBTINFO_PATH="/lib/x86_64-linux-gnu/libtinfo.so.5"
+    fi	
     LIBDRM_PATH="/usr/lib/x86_64-linux-gnu/libdrm.so.2"
     LIBDRM_AMDGPU_PATH="/usr/lib/x86_64-linux-gnu/libdrm_amdgpu.so.1"
     MAYBE_LIB64=lib


### PR DESCRIPTION
This PR updates build_rocm.sh to use libtinfo.so.6 on ROCm5.3 and beyond and includes a bug fix for the grep in build_common.sh and build_libtorch.sh

Tested on upstream CI:
https://github.com/pytorch/pytorch/actions/runs/3957589731/jobs/6779808516
https://github.com/pytorch/pytorch/pull/92538

This fixes the error seen for libtorch wheels in ROCm5.3 eg. in https://ossci-raw-job-status.s3.amazonaws.com/log/10656518264:
```
2023-01-15T10:02:53.3817808Z + g++ /builder/test_example_code/simple-torch-test.cpp -I/tmp/libtorch/include -I/tmp/libtorch/include/torch/csrc/api/include -D_GLIBCXX_USE_CXX11_ABI=1 -std=gnu++14 -L/tmp/libtorch/lib -Wl,-R/tmp/libtorch/lib -Wl,--no-as-needed -ltorch -ltorch_cpu -lc10 -o simple-torch-test
2023-01-15T10:03:08.1787744Z /usr/bin/ld: /tmp/libtorch/lib/libamd_comgr.so: undefined reference to `del_curterm@NCURSES6_TINFO_5.0.19991023'
2023-01-15T10:03:08.1789529Z /usr/bin/ld: /tmp/libtorch/lib/libamd_comgr.so: undefined reference to `setupterm@NCURSES6_TINFO_5.0.19991023'
2023-01-15T10:03:08.1790919Z /usr/bin/ld: /tmp/libtorch/lib/libamd_comgr.so: undefined reference to `tigetnum@NCURSES6_TINFO_5.0.19991023'
2023-01-15T10:03:08.1792336Z /usr/bin/ld: /tmp/libtorch/lib/libamd_comgr.so: undefined reference to `set_curterm@NCURSES6_TINFO_5.0.19991023'
2023-01-15T10:03:08.1793470Z collect2: error: ld returned 1 exit status
2023-01-15T10:03:08.1928694Z ##[error]Process completed with exit code 1.
```

CC: @jithunnair-amd 