### PR TITLE
Fix unbound variable error

### DIFF
--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -40,7 +40,7 @@ function do_cpython_build {
     mkdir -p ${prefix}/lib
 
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    if [[ -z  ${WITH_OPENSSL} ]]; then
+    if [[ -z  "${WITH_OPENSSL+x}" ]]; then
         CFLAGS="-Wformat" ./configure --prefix=${prefix} --disable-shared $unicode_flags > /dev/null
     else
         CFLAGS="-Wformat" ./configure --prefix=${prefix} --with-openssl=${WITH_OPENSSL} --with-openssl-rpath=auto --disable-shared $unicode_flags > /dev/null


### PR DESCRIPTION
Regression introduced (and ignored) by https://github.com/pytorch/builder/pull/1262 
Test plan:
```
% bash -c 'set -u; if [[ -z "${FOO}" ]]; then echo "bar"; fi' 
bash: FOO: unbound variable
% bash -c 'set -u; if [[ -z "${FOO+x}" ]]; then echo "bar"; fi'
bar
% FOO=1 bash -c 'set -u; if [[ -z "${FOO+x}" ]]; then echo "bar"; fi'
```