### PR TITLE
Manually invoke bash for miniconda

### DIFF
--- a/common/install_conda.sh
+++ b/common/install_conda.sh
@@ -5,7 +5,8 @@ set -ex
 # Anaconda
 wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod +x  Miniconda3-latest-Linux-x86_64.sh
-./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
+# NB: Manually invoke bash per https://github.com/conda/conda/issues/10431
+bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
 rm Miniconda3-latest-Linux-x86_64.sh
 export PATH=/opt/conda/bin:$PATH
 conda install -y conda-build anaconda-client git ninja

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -40,7 +40,7 @@ function do_cpython_build {
     mkdir -p ${prefix}/lib
 
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    if [[ -z  ${WITH_OPENSSL} ]]; then
+    if [[ -z  ${WITH_OPENSSL+x} ]]; then
         CFLAGS="-Wformat" ./configure --prefix=${prefix} --disable-shared $unicode_flags > /dev/null
     else
         CFLAGS="-Wformat" ./configure --prefix=${prefix} --with-openssl=${WITH_OPENSSL} --with-openssl-rpath=auto --disable-shared $unicode_flags > /dev/null


### PR DESCRIPTION
Fixes build issues failing with:
```
./Miniconda3-latest-Linux-x86_64.sh: 438: ./Miniconda3-latest-Linux-x86_64.sh: [[: not found
```
as seen in e.g.: https://github.com/pytorch/builder/pull/1271

CC @malfet 