### PR TITLE
Build with `--enabled-shared` if `patchelf` is found

### DIFF
--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -29,7 +29,7 @@ function do_cpython_build {
     fi
 
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" ./configure --prefix=${prefix} ${openssl_flags} --disable-shared > /dev/null
+    CFLAGS="-Wformat" ./configure --prefix=${prefix} ${openssl_flags} --enable-shared > /dev/null
 
     make -j40 > /dev/null
     make install > /dev/null

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -22,17 +22,26 @@ function do_cpython_build {
 
     local prefix="/opt/_internal/cpython-${py_ver}"
     mkdir -p ${prefix}/lib
+    if [[ -n $(which patchelf) ]]; then
+        local shared_flags="--enable-shared"
+    else
+        local shared_flags="--disable-shared"
+    fi
     if [[ -z  "${WITH_OPENSSL+x}" ]]; then
-       local openssl_flags=""
+        local openssl_flags=""
     else
         local openssl_flags="--with-openssl=${WITH_OPENSSL} --with-openssl-rpath=auto"
     fi
 
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" ./configure --prefix=${prefix} ${openssl_flags} --enable-shared > /dev/null
+    CFLAGS="-Wformat" ./configure --prefix=${prefix} ${openssl_flags} ${shared_flags} > /dev/null
 
     make -j40 > /dev/null
     make install > /dev/null
+
+    if [[ "${shared_flags}" == "--enable-shared" ]]; then
+        patchelf --set-rpath '$ORIGIN/../lib' ${prefix}/bin/python3
+    fi
 
     popd
     rm -rf Python-$py_ver

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -36,7 +36,14 @@ FROM base as openssl
 ADD ./common/install_openssl.sh install_openssl.sh
 RUN bash ./install_openssl.sh && rm install_openssl.sh
 
-FROM base as python
+# EPEL for cmake
+FROM base as patchelf
+# Install patchelf
+ADD ./common/install_patchelf.sh install_patchelf.sh
+RUN bash ./install_patchelf.sh && rm install_patchelf.sh
+RUN cp $(which patchelf) /patchelf
+
+FROM patchelf as python
 # build python
 COPY manywheel/build_scripts /build_scripts
 ADD ./common/install_cpython.sh /build_scripts/install_cpython.sh
@@ -58,13 +65,6 @@ FROM base as intel
 # MKL
 ADD ./common/install_mkl.sh install_mkl.sh
 RUN bash ./install_mkl.sh && rm install_mkl.sh
-
-# EPEL for cmake
-FROM base as patchelf
-# Install patchelf
-ADD ./common/install_patchelf.sh install_patchelf.sh
-RUN bash ./install_patchelf.sh && rm install_patchelf.sh
-RUN cp $(which patchelf) /patchelf
 
 FROM base as magma
 ARG BASE_CUDA_VERSION=10.2


### PR DESCRIPTION
This is needed to make `manylinux-wheel` images usable for building new Triton binaries.

Test plan: Build docker and verify that following `CMakeLists.txt` finishes successfully:
```
cmake_minimum_required(VERSION 3.6)
find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
message(WARNING Executable ${Python3_EXECUTABLE})
message(WARNING IncludeDirs ${Python3_INCLUDE_DIRS})
message(WARNING Libraries ${Python3_LIBRARIES})
```