### PR TITLE
Remove with_py311 flag as. Python 3.11 was added to nightly matrix

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -36,7 +36,6 @@ jobs:
       package-type: all
       os: linux
       channel: ${{ inputs.channel }}
-      with-py311: enable
 
   linux:
     needs: generate-linux-matrix


### PR DESCRIPTION
Remove with_py311 flag as. Python 3.11 was added to nightly matrix