### PR TITLE
Set torch._C._PYBIND11_BUILD_ABI version check only for GLIBCXX_USE_CXX11_ABI=0

### DIFF
--- a/check_binary.sh
+++ b/check_binary.sh
@@ -435,7 +435,7 @@ fi
 ###############################################################################
 # Check for C++ ABI compatibility between gcc7 and gcc9 compiled binaries
 ###############################################################################
-if [[ "$(uname)" == 'Linux' && ("$PACKAGE_TYPE" == 'conda' || "$PACKAGE_TYPE" == 'manywheel') ]]; then
+if [[ "$(uname)" == 'Linux' && ("$PACKAGE_TYPE" == 'conda' || "$PACKAGE_TYPE" == 'manywheel') && GLIBCXX_USE_CXX11_ABI=0 ]]; then
   pushd /tmp
   python -c "import torch; exit(0 if torch._C._PYBIND11_BUILD_ABI == '_cxxabi1011' else 1)"
   popd


### PR DESCRIPTION
This PR fix issue in https://github.com/pytorch/pytorch/pull/79409. 