### PR TITLE
Simplify mkl build dependencies

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - pyyaml
     {% if cross_compile_arm64 == 0 %}
     - mkl-include # [x86_64]
-    - mkl=2022.1 # [x86_64]
+    - mkl=2020.2 # [x86_64 and not win]
+    - mkl=2021.4 # [x86_64 and win]
     {% endif %}
     - typing_extensions
     - ninja

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -21,8 +21,7 @@ requirements:
     - pyyaml
     {% if cross_compile_arm64 == 0 %}
     - mkl-include # [x86_64]
-    - mkl=2020.2 # [x86_64 and ((not win and py < 311) or py <= 39)]
-    - mkl=2021.4 # [x86_64 and ((win and py >= 310) or py >= 311)]
+    - mkl=2022.1 # [x86_64]
     {% endif %}
     - typing_extensions
     - ninja


### PR DESCRIPTION
On Linux and Mac PyTorch must be built against `mkl=2020.x` in order to be compatible with both `mkl-2021` and `mkl-2022`, that added `.so.1` and `.so.2` files respectively, that would make binary linked against those versions incompatible with the newer/older toolchains.

This is not an issue on Windows, as all mkl binaries there end with simple `.dll`