### PR TITLE
Put back smoke test label

### DIFF
--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -102,6 +102,7 @@ set CUDA_VERSION_STR=%CUDA_VER_MAJOR%.%CUDA_VER_MINOR%
 for /F "delims=" %%i in ('where /R "%PYTORCH_FINAL_PACKAGE_DIR:/=\%" *.tar.bz2') do call conda install -yq "%%i" --offline
 if ERRORLEVEL 1 exit /b 1
 
+:smoke_test
 python -c "import torch"
 if ERRORLEVEL 1 exit /b 1
 


### PR DESCRIPTION
Previous commit:
https://github.com/pytorch/builder/commit/cb2019bf0ee0d54163afa761d1679c764d40607d
Accidentally removed smoke_test label.
As a result nightly builds failing:
https://github.com/pytorch/pytorch/actions/runs/4161328222/jobs/7200608352
```
C:\actions-runner\_work\pytorch\pytorch\builder\windows>goto smoke_test 
The system cannot find the batch label specified - smoke_test
Error: Process completed with exit code 1.
```