### PR TITLE
Smoke test for cuda runtime errors

### DIFF
--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -72,7 +72,7 @@ def cuda_runtime_error():
 def smoke_test_cuda(package: str) -> None:
     if not torch.cuda.is_available() and is_cuda_system:
         raise RuntimeError(f"Expected CUDA {gpu_arch_ver}. However CUDA is not loaded.")
-
+    if torch.cuda.is_available():
         if torch.version.cuda != gpu_arch_ver:
             raise RuntimeError(
                 f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}"

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -55,7 +55,7 @@ def check_nightly_binaries_date(package: str) -> None:
                     f"Expected {module['name']} to be less then {NIGHTLY_ALLOWED_DELTA} days. But its {date_m_delta}"
                 )
 
-def cuda_runtime_error():
+def test_cuda_runtime_errors_captured():
     cuda_exception_missed=True
     try:
         torch._assert_async(torch.tensor(0, device="cuda"))
@@ -65,22 +65,13 @@ def cuda_runtime_error():
             print(f"Caught CUDA exception with success: {e}")
             cuda_exception_missed = False
         else:
-            raise(e)
+            raise e
     if(cuda_exception_missed):
         raise RuntimeError( f"Expected CUDA RuntimeError but have not received!")
 
 def smoke_test_cuda(package: str) -> None:
     if not torch.cuda.is_available() and is_cuda_system:
         raise RuntimeError(f"Expected CUDA {gpu_arch_ver}. However CUDA is not loaded.")
-    if torch.cuda.is_available():
-        if torch.version.cuda != gpu_arch_ver:
-            raise RuntimeError(
-                f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}"
-            )
-        print(f"torch cuda: {torch.version.cuda}")
-        # todo add cudnn version validation
-        print(f"torch cudnn: {torch.backends.cudnn.version()}")
-        print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
 
     if(package == 'all' and is_cuda_system):
         for module in MODULES:
@@ -93,6 +84,19 @@ def smoke_test_cuda(package: str) -> None:
             else:
                 version = imported_module._extension._check_cuda_version()
             print(f"{module['name']} CUDA: {version}")
+
+    if torch.cuda.is_available():
+        if torch.version.cuda != gpu_arch_ver:
+            raise RuntimeError(
+                f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}"
+            )
+        print(f"torch cuda: {torch.version.cuda}")
+        # todo add cudnn version validation
+        print(f"torch cudnn: {torch.backends.cudnn.version()}")
+        print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
+
+        # This check has to be run last, since its messing up CUDA runtime
+        test_cuda_runtime_errors_captured()
 
 
 def smoke_test_conv2d() -> None:
@@ -113,6 +117,7 @@ def smoke_test_conv2d() -> None:
         x = torch.randn(1, 3, 24, 24).cuda()
         with torch.cuda.amp.autocast():
             out = conv(x)
+
 
 def smoke_test_modules():
     for module in MODULES:
@@ -141,7 +146,6 @@ def main() -> None:
     )
     options = parser.parse_args()
     print(f"torch: {torch.__version__}")
-    smoke_test_cuda(options.package)
     smoke_test_conv2d()
 
     if options.package == "all":
@@ -151,9 +155,7 @@ def main() -> None:
     if installation_str.find("nightly") != -1:
         check_nightly_binaries_date(options.package)
 
-    # This check has to be run last, since its messing up CUDA runtime
-    if torch.cuda.is_available():
-        cuda_runtime_error()
+    smoke_test_cuda(options.package)
 
 
 if __name__ == "__main__":

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -55,7 +55,7 @@ def check_nightly_binaries_date(package: str) -> None:
                     f"Expected {module['name']} to be less then {NIGHTLY_ALLOWED_DELTA} days. But its {date_m_delta}"
                 )
 
-def test_cuda_runtime_errors_captured():
+def test_cuda_runtime_errors_captured() -> None:
     cuda_exception_missed=True
     try:
         torch._assert_async(torch.tensor(0, device="cuda"))

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -72,7 +72,7 @@ def cuda_runtime_error():
 def smoke_test_cuda(package: str) -> None:
     if not torch.cuda.is_available() and is_cuda_system:
         raise RuntimeError(f"Expected CUDA {gpu_arch_ver}. However CUDA is not loaded.")
-    if torch.cuda.is_available():
+
         if torch.version.cuda != gpu_arch_ver:
             raise RuntimeError(
                 f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}"
@@ -81,7 +81,6 @@ def smoke_test_cuda(package: str) -> None:
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
-        cuda_runtime_error()
 
     if(package == 'all' and is_cuda_system):
         for module in MODULES:
@@ -151,6 +150,10 @@ def main() -> None:
     # only makes sense to check nightly package where dates are known
     if installation_str.find("nightly") != -1:
         check_nightly_binaries_date(options.package)
+
+    # This check has to be run last, since its messing up CUDA runtime
+    if torch.cuda.is_available():
+        cuda_runtime_error()
 
 
 if __name__ == "__main__":

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -56,17 +56,18 @@ def check_nightly_binaries_date(package: str) -> None:
                 )
 
 def cuda_runtime_error():
+    cuda_exception_missed=True
     try:
-        torch._assert_async(torch.tensor(0, device='cuda'))
-        torch._assert_async(torch.tensor(0 + 0j, device='cuda'))
-        raise RuntimeError( f"Expected CUDA RuntimeError but have not received anything")
+        torch._assert_async(torch.tensor(0, device="cuda"))
+        torch._assert_async(torch.tensor(0 + 0j, device="cuda"))
     except RuntimeError as e:
-        if re.search("CUDA", f'{e}'):
+        if re.search("CUDA", f"{e}"):
             print(f"Caught CUDA exception with success: {e}")
+            cuda_exception_missed = False
         else:
             raise(e)
-    except Exception as e:
-        raise(e)
+    if(cuda_exception_missed):
+        raise RuntimeError( f"Expected CUDA RuntimeError but have not received!")
 
 def smoke_test_cuda(package: str) -> None:
     if not torch.cuda.is_available() and is_cuda_system:


### PR DESCRIPTION
Adds smoke tests to cover for: https://github.com/pytorch/pytorch/issues/91758

This tests CUDA exception catching, here is log of successful run:
```
/opt/conda/conda-bld/pytorch_1676103216844/work/aten/src/ATen/native/cuda/TensorCompare.cu:106: _assert_async_cuda_kernel: block: [0,0,0], thread: [0,0,0] Assertion `input[0] != 0` failed.
Caught CUDA exception with success: CUDA error: device-side assert triggered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions
```


Test with pytorch version that hides this error:
```
2.0.0.dev20230105+cu117
  tensor = torch.zeros(1024, device='cuda')
../aten/src/ATen/native/cuda/TensorCompare.cu:106: _assert_async_cuda_kernel: block: [0,0,0], thread: [0,0,0] Assertion `input[0] != 0` failed.
Traceback (most recent call last):
  File "/data/home/atalman/testvscode/test2.py", line 31, in <module>
    task()
  File "/data/home/atalman/testvscode/test2.py", line 25, in task
    raise RuntimeError( f"Expected CUDA RuntimeError but have not received anything")
RuntimeError: Expected CUDA RuntimeError but have not received anything
``