### PR TITLE
s3: Allow tar.gz as an accepted file extension

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -17,7 +17,7 @@ S3 = boto3.resource('s3')
 CLIENT = boto3.client('s3')
 BUCKET = S3.Bucket('pytorch')
 
-ACCEPTED_FILE_EXTENSIONS = ("whl", "zip")
+ACCEPTED_FILE_EXTENSIONS = ("whl", "zip", "tar.gz")
 ACCEPTED_SUBDIR_PATTERNS = [
     r"cu[0-9]+",           # for cuda
     r"rocm[0-9]+\.[0-9]+", # for rocm


### PR DESCRIPTION
Allow tar.gz as an accepted file extension since lit is a tar.gz and was not getting properly indexed in our indices.

![Screenshot 2023-02-17 at 11 31 10 AM](https://user-images.githubusercontent.com/1700823/219769877-f9552d00-2bc3-43c8-a28f-0ae05937cf60.png)

Should resolve https://github.com/pytorch/pytorch/issues/95081

