### PR TITLE
Make sure we don't use GPU runners for any of libtorch validations

### DIFF
--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -56,6 +56,7 @@ jobs:
     name: ${{ matrix.build_name }}
     with:
       runner: ${{ matrix.validation_runner }}
+      runner: ${{ matrix.package_type == 'libtorch' && 'windows.4xlarge' || matrix.validation_runner }}
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -55,7 +55,6 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     name: ${{ matrix.build_name }}
     with:
-      runner: ${{ matrix.validation_runner }}
       runner: ${{ matrix.package_type == 'libtorch' && 'windows.4xlarge' || matrix.validation_runner }}
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}


### PR DESCRIPTION
Make sure we don't use GPU runners for any of libtorch validations