### PR TITLE
Add `lit` to list of allowed packages

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -41,6 +41,7 @@ PACKAGE_ALLOW_LIST = {
     "cmake",
     "filelock",
     "idna",
+    "lit",
     "mpmath",
     "nestedtensor",
     "networkx",


### PR DESCRIPTION
As it is now mandatory (albeit spurious) dependency of pytorch-triton

See https://pypi.org/project/lit/ for more details