### PR TITLE
s3: Add pytorch_triton_rocm to index

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -47,6 +47,7 @@ PACKAGE_ALLOW_LIST = {
     "numpy",
     "packaging",
     "pytorch_triton",
+    "pytorch_triton_rocm",
     "requests",
     "sympy",
     "torch",


### PR DESCRIPTION
Follow up to https://github.com/pytorch/test-infra/pull/3804