### PR TITLE
s3: Add tqdm package req for text

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -60,6 +60,7 @@ PACKAGE_ALLOW_LIST = {
     "torchrec",
     "torchtext",
     "torchvision",
+    "tqdm",
     "typing_extensions",
     "urllib3",
 }


### PR DESCRIPTION
s3: Add tqdm package req for text.

Torchtext installation:
```
(py310cpu) atalman@ip-10-200-93-49:~/testrel$ pip install torchtext --extra-index-url https://download.pytorch.org/whl/test/cpu
Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/test/cpu
Collecting torchtext
  Using cached https://download.pytorch.org/whl/test/torchtext-0.15.0%2Bcpu-cp310-cp310-linux_x86_64.whl (2.0 MB)
Collecting torchdata==0.6.0
  Using cached https://download.pytorch.org/whl/test/torchdata-0.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.6 MB)
Requirement already satisfied: requests in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torchtext) (2.28.1)
Requirement already satisfied: torch in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torchtext) (2.0.0+cpu)
Collecting tqdm
  Using cached tqdm-4.64.1-py2.py3-none-any.whl (78 kB)
Requirement already satisfied: numpy in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torchtext) (1.24.1)
Requirement already satisfied: urllib3>=1.25 in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torchdata==0.6.0->torchtext) (1.26.13)
Requirement already satisfied: filelock in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torch->torchtext) (3.9.0)
Requirement already satisfied: typing-extensions in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torch->torchtext) (4.4.0)
Requirement already satisfied: networkx in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torch->torchtext) (2.6.3)
Requirement already satisfied: sympy in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from torch->torchtext) (1.11.1)
Requirement already satisfied: idna<4,>=2.5 in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from requests->torchtext) (3.4)
Requirement already satisfied: charset-normalizer<3,>=2 in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from requests->torchtext) (2.1.1)
Requirement already satisfied: certifi>=2017.4.17 in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from requests->torchtext) (2022.12.7)
Requirement already satisfied: mpmath>=0.19 in /data/home/atalman/miniconda3/envs/py310cpu/lib/python3.10/site-packages (from sympy->torch->torchtext) (1.2.1)
Installing collected packages: tqdm, torchdata, torchtext
Successfully installed torchdata-0.6.0 torchtext-0.15.0+cpu tqdm-4.64.1
```