### PR TITLE
Add filelock and networkx deps

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -44,6 +44,8 @@ requirements:
     - intel-openmp # [win]
     - typing_extensions
     - sympy
+    - filelock
+    - networkx
     {% if cross_compile_arm64 == 0 %}
     - blas * mkl
     {% endif %}


### PR DESCRIPTION
To match dependencies for wheel files defined in https://github.com/pytorch/pytorch/blob/ed1957dc1989417cb978d3070a4e3d20520674b4/setup.py#L1021-L1024

Tested in https://github.com/pytorch/pytorch/pull/95780