### PR TITLE
Upgrade cmake version to 3.22.1 to build triton

### DIFF
--- a/common/install_conda.sh
+++ b/common/install_conda.sh
@@ -9,5 +9,7 @@ chmod +x  Miniconda3-latest-Linux-x86_64.sh
 bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
 rm Miniconda3-latest-Linux-x86_64.sh
 export PATH=/opt/conda/bin:$PATH
-conda install -y conda-build anaconda-client git ninja
+# cmake-3.22.1 from conda, same as the one used by PyTorch CI. The system cmake
+# is too old to build triton
+conda install -y conda-build anaconda-client git ninja cmake=3.22.1
 conda remove -y --force patchelf

--- a/common/install_patchelf.sh
+++ b/common/install_patchelf.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-# Pin the version to latest release 0.17.2, newer version starts failing
-# to build on the current image
+# Pin the version to latest release 0.17.2, building newer commit starts
+# to fail on the current image
 git clone -b 0.17.2 --single-branch https://github.com/NixOS/patchelf
 cd patchelf
 sed -i 's/serial/parallel/g' configure.ac

--- a/common/install_patchelf.sh
+++ b/common/install_patchelf.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-git clone https://github.com/NixOS/patchelf
+# Pin the version to latest release 0.17.2, newer version starts failing
+# to build on the current image
+git clone -b 0.17.2 --single-branch https://github.com/NixOS/patchelf
 cd patchelf
 sed -i 's/serial/parallel/g' configure.ac
 ./bootstrap.sh

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -21,9 +21,10 @@ RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &
     rpm -ivh epel-release-latest-7.noarch.rpm && \
     rm -f epel-release-latest-7.noarch.rpm
 
-# cmake-3.18.4 from pip
+# cmake-3.22.1 from pip, same as the one used by PyTorch CI. cmake-3.18.4 is
+# too old to build triton now
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.18.4 && \
+    python3 -mpip install cmake==3.22.1 && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake
 
 RUN yum install -y autoconf aclocal automake make


### PR DESCRIPTION
I try to upgrade cmake version in builder images to 3.22.1, same as the version used by PyTorch CI, to build triton.  The newer triton pinned commit is now complaining about cmake version https://github.com/pytorch/pytorch/actions/runs/4332758131:

* manywheel uses cmake-3.18.4 from pip
* conda uses system cmake-3.17.5

Both are upgraded to cmake-3.22.1.

I also need to pin patcheft version to the current latest ([0.17.2](https://github.com/NixOS/patchelf/releases/tag/0.17.2)) instead of cloning the latest commit from GitHub as the build starts to fail https://github.com/pytorch/builder/actions/runs/4339776911/jobs/7577682033.  We might need to investigate this further if it's important to use the latest commit for some reasons.

### Testing
Let me know if I need to do some further testing.