### PR TITLE
Switch deprecated ubuntu-18.04 runner to ubuntu-latest

### DIFF
--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-docker:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cuda_version: ["11.6", "11.7", "11.8", "cpu"]

--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-docker:
-    runs-on: linux.2xlarge
+    runs-on: linux.c5.4xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["11.6", "11.7", "11.8", "cpu"]

--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         cuda_version: ["11.6", "11.7", "11.8", "cpu"]

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.2xlarge
+    runs-on:  linux.large.ephemeral
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]
@@ -44,7 +44,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-rocm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -63,7 +63,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-cpu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]
@@ -44,7 +44,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-rocm:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -63,7 +63,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-cpu:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]
@@ -44,7 +44,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-rocm:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -63,7 +63,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-cpu:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on:  linux.large.ephemeral
+    runs-on: linux.c5.4xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]
@@ -44,7 +44,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-rocm:
-    runs-on: linux.2xlarge
+    runs-on: linux.c5.4xlarge.ephemeral
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -63,7 +63,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-cpu:
-    runs-on: linux.2xlarge
+    runs-on: linux.c5.4xlarge.ephemeral
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3

--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -38,7 +38,7 @@ jobs:
   push-windows-magma:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment: magma
-    runs-on: linux.large.ephemeral
+    runs-on: ubuntu-latest
     needs: build-windows-magma
     steps:
       - name: Download all artifacts

--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -38,7 +38,7 @@ jobs:
   push-windows-magma:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment: magma
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     needs: build-windows-magma
     steps:
       - name: Download all artifacts

--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -38,7 +38,7 @@ jobs:
   push-windows-magma:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment: magma
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-windows-magma
     steps:
       - name: Download all artifacts

--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -38,7 +38,7 @@ jobs:
   push-windows-magma:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment: magma
-    runs-on: linux.2xlarge
+    runs-on: linux.large.ephemeral
     needs: build-windows-magma
     steps:
       - name: Download all artifacts

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]
@@ -46,7 +46,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-rocm:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -65,7 +65,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu-cxx11-abi:
-    runs-on: linux.c5.4xlarge.ephemeral
+    runs-on: ubuntu-latest
     env:
       GPU_ARCH_TYPE: cpu-cxx11-abi
     steps:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.2xlarge
+    runs-on: linux.c5.4xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-rocm:
-    runs-on: linux.2xlarge
+    runs-on: linux.c5.4xlarge.ephemeral
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -65,7 +65,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu:
-    runs-on: linux.2xlarge
+    runs-on: linux.c5.4xlarge.ephemeral
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu-cxx11-abi:
-    runs-on: linux.2xlarge
+    runs-on: linux.c5.4xlarge.ephemeral
     env:
       GPU_ARCH_TYPE: cpu-cxx11-abi
     steps:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]
@@ -46,7 +46,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-rocm:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -65,7 +65,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu-cxx11-abi:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     env:
       GPU_ARCH_TYPE: cpu-cxx11-abi
     steps:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         cuda_version: ["11.8", "11.7", "11.6"]
@@ -46,7 +46,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-rocm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rocm_version: ["5.3", "5.4.2"]
@@ -65,7 +65,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu-cxx11-abi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GPU_ARCH_TYPE: cpu-cxx11-abi
     steps:

--- a/.github/workflows/build-nvidia-images.yml
+++ b/.github/workflows/build-nvidia-images.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-nvidia-docker:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     steps:
       - name: Build Nvidia Docker Image
         run: |

--- a/.github/workflows/build-nvidia-images.yml
+++ b/.github/workflows/build-nvidia-images.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-nvidia-docker:
-    runs-on: linux.2xlarge
+    runs-on: ubuntu-18.04
     steps:
       - name: Build Nvidia Docker Image
         run: |


### PR DESCRIPTION
GitHub ubuntu-18.04 runner will be deprecated soon https://github.com/actions/runner-images/issues/6002, so switching to our ~~self-hosted 2xlarge~~ ephemeral ubuntu-latest runner.

I will rerun all nightly after the Docker images are rebuild.