### PR TITLE
Add MarkupSafe to S3 Index

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -43,6 +43,7 @@ PACKAGE_ALLOW_LIST = {
     "idna",
     "Jinja2",
     "lit",
+    "MarkupSafe",
     "mpmath",
     "nestedtensor",
     "networkx",


### PR DESCRIPTION
Continued efforts to fix https://github.com/pytorch/pytorch/issues/95986 

Thanks @seemethere for root-causing the missing dependency of dependency (Jinja2) 