### PR TITLE
Restrict jinja2 to py 3.10 or less

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - sympy
     - filelock
     - networkx
-    - jinja2
+    - jinja2 # [py <= 310]
     {% if cross_compile_arm64 == 0 %}
     - blas * mkl
     {% endif %}


### PR DESCRIPTION
Restrict jinja2 to py 3.10 or less
Jinja2 not available for py311 yet: https://anaconda.org/anaconda/jinja2/files?version=3.1.2