### PR TITLE
Revert "Upgrade cmake version to 3.22.1 to build triton (#1331)"

### DIFF
--- a/common/install_conda.sh
+++ b/common/install_conda.sh
@@ -9,7 +9,5 @@ chmod +x  Miniconda3-latest-Linux-x86_64.sh
 bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
 rm Miniconda3-latest-Linux-x86_64.sh
 export PATH=/opt/conda/bin:$PATH
-# cmake-3.22.1 from conda, same as the one used by PyTorch CI. The system cmake
-# is too old to build triton
-conda install -y conda-build anaconda-client git ninja cmake=3.22.1
+conda install -y conda-build anaconda-client git ninja
 conda remove -y --force patchelf

--- a/common/install_conda.sh
+++ b/common/install_conda.sh
@@ -9,5 +9,7 @@ chmod +x  Miniconda3-latest-Linux-x86_64.sh
 bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda
 rm Miniconda3-latest-Linux-x86_64.sh
 export PATH=/opt/conda/bin:$PATH
-conda install -y conda-build anaconda-client git ninja
+# The cmake version here needs to match with the minimum version of cmake
+# supported by PyTorch
+conda install -y conda-build anaconda-client git ninja cmake=3.18.4
 conda remove -y --force patchelf

--- a/common/install_patchelf.sh
+++ b/common/install_patchelf.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-git clone https://github.com/NixOS/patchelf
+# Pin the version to latest release 0.17.2, building newer commit starts
+# to fail on the current image
+git clone -b 0.17.2 --single-branch https://github.com/NixOS/patchelf
 cd patchelf
 sed -i 's/serial/parallel/g' configure.ac
 ./bootstrap.sh

--- a/common/install_patchelf.sh
+++ b/common/install_patchelf.sh
@@ -2,9 +2,7 @@
 
 set -ex
 
-# Pin the version to latest release 0.17.2, building newer commit starts
-# to fail on the current image
-git clone -b 0.17.2 --single-branch https://github.com/NixOS/patchelf
+git clone https://github.com/NixOS/patchelf
 cd patchelf
 sed -i 's/serial/parallel/g' configure.ac
 ./bootstrap.sh

--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -21,10 +21,9 @@ RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &
     rpm -ivh epel-release-latest-7.noarch.rpm && \
     rm -f epel-release-latest-7.noarch.rpm
 
-# cmake-3.22.1 from pip, same as the one used by PyTorch CI. cmake-3.18.4 is
-# too old to build triton now
+# cmake-3.18.4 from pip
 RUN yum install -y python3-pip && \
-    python3 -mpip install cmake==3.22.1 && \
+    python3 -mpip install cmake==3.18.4 && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake
 
 RUN yum install -y autoconf aclocal automake make


### PR DESCRIPTION
This selectively reverts commit 18c5017d9eedd2e5e203608e9ad6c05a2324b3ac now that https://github.com/openai/triton/pull/1303 has been merged into triton.  We can now use the minimum cmake version (3.18.4) supported by Pytorch.