### PR TITLE
Revert "Restrict jinja to py 3.10 or less"

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - sympy
     - filelock
     - networkx
-    - jinja2 # [py <= 310]
+    - jinja2
     {% if cross_compile_arm64 == 0 %}
     - blas * mkl
     {% endif %}


### PR DESCRIPTION
Reverts pytorch/builder#1346 as Jinja2 for Python-3.11 is now available on default channel, see https://anaconda.org/anaconda/jinja2