### PR TITLE
[aarch64] update readme with the "--enable-mkldnn" option

### DIFF
--- a/aarch64_linux/README.md
+++ b/aarch64_linux/README.md
@@ -16,4 +16,4 @@ __NOTE:__ CI build is currently __EXPERMINTAL__
 This app allows a person to build using AWS EC3 resources and requires AWS-CLI and Boto3 with AWS credentials to support building EC2 instances for the wheel builds. Can be used in a codebuild CD or from a local system.
 
 ### Usage
-```build_aarch64_wheel.py --key-name <YourPemKey> --use-docker --python 3.7 --branch <RCtag>```
+```build_aarch64_wheel.py --key-name <YourPemKey> --use-docker --python 3.8 --os ubuntu20_04 --enable-mkldnn  --branch <RCtag>```

--- a/aarch64_linux/build_aarch64_wheel.py
+++ b/aarch64_linux/build_aarch64_wheel.py
@@ -4,7 +4,7 @@
 # To generate binaries for the release follow these steps:
 # 1. Update mappings for each of the Domain Libraries by adding new row to a table like this:  "v1.11.0": ("0.11.0", "rc1"),
 # 2. Run script with following arguments for each of the supported python versions and specify required RC tag for example: v1.11.0-rc3:
-# build_aarch64_wheel.py --key-name <YourPemKey> --use-docker --python 3.7 --branch <RCtag>
+# build_aarch64_wheel.py --key-name <YourPemKey> --use-docker --python 3.8 --os ubuntu20_04 --enable-mkldnn --branch <RCtag>
 
 
 import boto3


### PR DESCRIPTION
This needs to be enabled for official wheel building.