### PR TITLE
[aarch64] Install libjpeg when building Torchvision

### DIFF
--- a/aarch64_linux/build_aarch64_wheel.py
+++ b/aarch64_linux/build_aarch64_wheel.py
@@ -301,6 +301,11 @@ def build_torchvision(host: RemoteHost, *,
                                       "v2.0.0": ("0.15.1", "rc2"),
                                   })
     print('Building TorchVision wheel')
+
+    # Please note libnpg and jpeg is required to build image.so extension
+    if(use_conda):
+        host.run_cmd("conda install -y libpng jpeg")
+
     build_vars = ""
     if branch == 'nightly':
         version = host.check_output(["if [ -f vision/version.txt ]; then cat vision/version.txt; fi"]).strip()

--- a/aarch64_linux/build_aarch64_wheel.py
+++ b/aarch64_linux/build_aarch64_wheel.py
@@ -302,7 +302,7 @@ def build_torchvision(host: RemoteHost, *,
                                   })
     print('Building TorchVision wheel')
 
-    # Please note libnpg and jpeg is required to build image.so extension
+    # Please note libnpg and jpeg are required to build image.so extension
     if(use_conda):
         host.run_cmd("conda install -y libpng jpeg")
 

--- a/aarch64_linux/build_aarch64_wheel.py
+++ b/aarch64_linux/build_aarch64_wheel.py
@@ -773,7 +773,7 @@ if __name__ == '__main__':
         configure_system(host,
                          compiler=args.compiler,
                          python_version=python_version,
-                         enable_mkldnn=False)
+                         enable_mkldnn=not args.disable_mkldnn)
         print("Installing PyTorch wheel")
         host.run_cmd("pip3 install torch")
         build_domains(host,


### PR DESCRIPTION
This should fix: https://github.com/pytorch/vision/issues/7104

Here is the build log:
```
Building TorchVision wheel
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /root/miniforge3

  added / updated specs:
    - jpeg
    - libpng


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    jpeg-9e                    |       h2a766a3_3         316 KB  conda-forge
    libpng-1.6.39              |       hf9034f9_0         292 KB  conda-forge
    libzlib-1.2.13             |       h4e544f5_4          72 KB  conda-forge
    zlib-1.2.13                |       h4e544f5_4          98 KB  conda-forge
    ------------------------------------------------------------
                                           Total:         778 KB

The following NEW packages will be INSTALLED:

  jpeg               conda-forge/linux-aarch64::jpeg-9e-h2a766a3_3 
  libpng             conda-forge/linux-aarch64::libpng-1.6.39-hf9034f9_0 

The following packages will be UPDATED:

  libzlib                              1.2.11-hb9de7d4_1013 --> 1.2.13-h4e544f5_4 
  zlib                                 1.2.11-hb9de7d4_1013 --> 1.2.13-h4e544f5_4 


.......
Building wheel torchvision-0.15.1
Compiling extensions with following flags:
  FORCE_CUDA: False
  DEBUG: False
  TORCHVISION_USE_PNG: True
  TORCHVISION_USE_JPEG: True
  TORCHVISION_USE_NVJPEG: True
  TORCHVISION_USE_FFMPEG: True
  TORCHVISION_USE_VIDEO_CODEC: True
  NVCC_FLAGS: 
Found PNG library
Building torchvision with PNG image support
  libpng version: 1.6.39
  libpng include path: /root/miniforge3/include/libpng16
Running build on conda-build: False
Running build on conda: True
Building torchvision with JPEG image support
Building torchvision without NVJPEG image support
Building torchvision without ffmpeg support
Building torchvision without video codec support
......
building 'torchvision.image' extension
creating /root/vision/build/temp.linux-aarch64-3.8/root/vision/torchvision/csrc/io
creating /root/vision/build/temp.linux-aarch64-3.8/root/vision/torchvision/csrc/io/image
creating /root/vision/build/temp.linux-aarch64-3.8/root/vision/torchvision/csrc/io/image/cpu
creating /root/vision/build/temp.linux-aarch64-3.8/root/vision/torchvision/csrc/io/image/cuda
Emitting ninja build file /root/vision/build/temp.linux-aarch64-3.8/build.ninja...
Compiling objects.
.....
```

Build command used:
```
python build_aarch64_wheel.py --key-name key.pem --use-docker --python-version 3.8 --branch v2.0.0-rc6 --use-torch-from-pypi
```
