### PR TITLE
Add portalocker - required for torchdata

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -50,6 +50,7 @@ PACKAGE_ALLOW_LIST = {
     "networkx",
     "numpy",
     "packaging",
+    "portalocker",
     "pytorch_triton",
     "pytorch_triton_rocm",
     "requests",


### PR DESCRIPTION
Following validation is failing:
https://github.com/pytorch/text/actions/runs/4489354606/jobs/7905918011

```
ERROR: Could not find a version that satisfies the requirement portalocker>=2.0.0 (from torchdata) (from versions: none)
ERROR: No matching distribution found for portalocker>=2.0.0
Error: Process completed with exit code 1.
```

Uploaded portalocker, hence  need to add it to allow list