### PR TITLE
add magma build for CUDA12.1

### DIFF
--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: linux.2xlarge
     strategy:
       matrix:
-        cuda_version: ["118", "117", "116"]
+        cuda_version: ["121", "118", "117"]
     steps:
       - name: Checkout PyTorch builder
         uses: actions/checkout@v3

--- a/magma/Makefile
+++ b/magma/Makefile
@@ -2,7 +2,7 @@ SHELL=/usr/bin/env bash
 
 DESIRED_CUDA ?= 11.7
 PACKAGE_NAME ?= magma-cuda117
-CUDA_ARCH_LIST ?= -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86
+CUDA_ARCH_LIST ?= -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86
 
 DOCKER_RUN = set -eou pipefail; docker run --rm -i \
 	-v $(shell git rev-parse --show-toplevel):/builder \
@@ -33,13 +33,14 @@ magma-cuda121:
 .PHONY: magma-cuda118
 magma-cuda118: DESIRED_CUDA := 11.8
 magma-cuda118: PACKAGE_NAME := magma-cuda118
-magma-cuda118: CUDA_ARCH_LIST += -gencode arch=compute_90,code=sm_90
+magma-cuda118: CUDA_ARCH_LIST += -gencode arch=compute_37,code=sm_37 -gencode arch=compute_90,code=sm_90
 magma-cuda118:
 	$(DOCKER_RUN)
 
 .PHONY: magma-cuda117
 magma-cuda117: DESIRED_CUDA := 11.7
 magma-cuda117: PACKAGE_NAME := magma-cuda117
+magma-cuda117: CUDA_ARCH_LIST += -gencode arch=compute_37,code=sm_37
 magma-cuda117:
 	$(DOCKER_RUN)
 

--- a/magma/Makefile
+++ b/magma/Makefile
@@ -1,7 +1,7 @@
 SHELL=/usr/bin/env bash
 
-DESIRED_CUDA ?= 11.6
-PACKAGE_NAME ?= magma-cuda116
+DESIRED_CUDA ?= 11.7
+PACKAGE_NAME ?= magma-cuda117
 CUDA_ARCH_LIST ?= -gencode arch=compute_37,code=sm_37 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86
 
 DOCKER_RUN = set -eou pipefail; docker run --rm -i \
@@ -14,14 +14,21 @@ DOCKER_RUN = set -eou pipefail; docker run --rm -i \
 	magma/build_magma.sh
 
 .PHONY: all
+all: magma-cuda121
 all: magma-cuda118
 all: magma-cuda117
-all: magma-cuda116
 
 .PHONY:
 clean:
 	$(RM) -r magma-*
 	$(RM) -r output
+
+.PHONY: magma-cuda121
+magma-cuda121: DESIRED_CUDA := 12.1
+magma-cuda121: PACKAGE_NAME := magma-cuda121
+magma-cuda121: CUDA_ARCH_LIST += -gencode arch=compute_90,code=sm_90
+magma-cuda121:
+	$(DOCKER_RUN)
 
 .PHONY: magma-cuda118
 magma-cuda118: DESIRED_CUDA := 11.8
@@ -36,8 +43,3 @@ magma-cuda117: PACKAGE_NAME := magma-cuda117
 magma-cuda117:
 	$(DOCKER_RUN)
 
-.PHONY: magma-cuda116
-magma-cuda116: DESIRED_CUDA := 11.6
-magma-cuda116: PACKAGE_NAME := magma-cuda116
-magma-cuda116:
-	$(DOCKER_RUN)

--- a/magma/build_magma.sh
+++ b/magma/build_magma.sh
@@ -12,6 +12,7 @@ cp ${PACKAGE_FILES}/thread_queue.patch ${PACKAGE_DIR}/thread_queue.patch
 cp ${PACKAGE_FILES}/cmakelists.patch ${PACKAGE_DIR}/cmakelists.patch
 cp ${PACKAGE_FILES}/getrf_shfl.patch ${PACKAGE_DIR}/getrf_shfl.patch
 cp ${PACKAGE_FILES}/getrf_nbparam.patch ${PACKAGE_DIR}/getrf_nbparam.patch
+cp ${PACKAGE_FILES}/CMake.patch ${PACKAGE_DIR}/CMake.patch
 
 conda install -yq conda-build conda-verify
 . ./conda/switch_cuda_version.sh "${DESIRED_CUDA}"

--- a/magma/package_files/CMake.patch
+++ b/magma/package_files/CMake.patch
@@ -1,0 +1,41 @@
+--- CMake.src	2023-03-28 00:54:32.407886936 -0700
++++ CMake.src	2023-03-28 00:50:44.109755496 -0700
+@@ -279,10 +279,10 @@
+ magmablas/zcaxpycp.cu
+ magmablas/zgeadd.cu
+ magmablas/zgeadd2.cu
+-magmablas/zgemm_fermi.cu
++#magmablas/zgemm_fermi.cu
+ magmablas/zgemm_reduce.cu
+ magmablas/zgemv_conj.cu
+-magmablas/zgemv_fermi.cu
++#magmablas/zgemv_fermi.cu
+ magmablas/zgerbt.cu
+ magmablas/zgerbt_kernels.cu
+ magmablas/zgetmatrix_transpose.cpp
+@@ -988,18 +988,18 @@
+ magmablas/sgeadd2.cu
+ magmablas/dgeadd2.cu
+ magmablas/cgeadd2.cu
+-magmablas/sgemm_fermi.cu
+-magmablas/dgemm_fermi.cu
+-magmablas/cgemm_fermi.cu
++#magmablas/sgemm_fermi.cu
++#magmablas/dgemm_fermi.cu
++#magmablas/cgemm_fermi.cu
+ magmablas/sgemm_reduce.cu
+ magmablas/dgemm_reduce.cu
+ magmablas/cgemm_reduce.cu
+ magmablas/sgemv_conj.cu
+ magmablas/dgemv_conj.cu
+ magmablas/cgemv_conj.cu
+-magmablas/sgemv_fermi.cu
+-magmablas/dgemv_fermi.cu
+-magmablas/cgemv_fermi.cu
++#magmablas/sgemv_fermi.cu
++#magmablas/dgemv_fermi.cu
++#magmablas/cgemv_fermi.cu
+ magmablas/sgerbt.cu
+ magmablas/dgerbt.cu
+ magmablas/cgerbt.cu
+

--- a/magma/package_files/CMake.patch
+++ b/magma/package_files/CMake.patch
@@ -1,9 +1,9 @@
---- CMake.src	2023-03-28 00:54:32.407886936 -0700
-+++ CMake.src	2023-03-28 00:50:44.109755496 -0700
-@@ -279,10 +279,10 @@
- magmablas/zcaxpycp.cu
+--- CMake.src.cuda	2023-03-29 10:05:32.136954140 +0000
++++ CMake.src.cuda	2023-03-29 10:05:50.281318043 +0000
+@@ -283,10 +283,10 @@
  magmablas/zgeadd.cu
  magmablas/zgeadd2.cu
+ magmablas/zgeam.cu
 -magmablas/zgemm_fermi.cu
 +#magmablas/zgemm_fermi.cu
  magmablas/zgemm_reduce.cu
@@ -13,10 +13,10 @@
  magmablas/zgerbt.cu
  magmablas/zgerbt_kernels.cu
  magmablas/zgetmatrix_transpose.cpp
-@@ -988,18 +988,18 @@
- magmablas/sgeadd2.cu
- magmablas/dgeadd2.cu
- magmablas/cgeadd2.cu
+@@ -1009,18 +1009,18 @@
+ magmablas/sgeam.cu
+ magmablas/dgeam.cu
+ magmablas/cgeam.cu
 -magmablas/sgemm_fermi.cu
 -magmablas/dgemm_fermi.cu
 -magmablas/cgemm_fermi.cu
@@ -38,4 +38,3 @@
  magmablas/sgerbt.cu
  magmablas/dgerbt.cu
  magmablas/cgerbt.cu
-

--- a/magma/package_files/meta.yaml
+++ b/magma/package_files/meta.yaml
@@ -9,6 +9,7 @@ source:
      - thread_queue.patch
      - getrf_shfl.patch  # incorrect results for <7.0 arch
      - getrf_nbparam.patch  # fixes "too many resources requested for launch" error
+     - CMake.patch # removes fermi for CUDA12+
 
 build:
   number: 1


### PR DESCRIPTION
This PR adds magma builds for CUDA 12.1 and removes CUDA 11.6 builds.
Additionally, the `CMake.src` file needs to be patched to drop the deprecated `fermi` architecture.
Note that `fermi` is sm_20/sm_21 and is already not supported, so no changes should be needed for CUDA11.x builds.

CC @atalman @malfet 
