### PR TITLE
fix "desired_cuda" check for 12.1

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -265,7 +265,7 @@ else
     . ./switch_cuda_version.sh "$desired_cuda"
     # TODO, simplify after anaconda fixes their cudatoolkit versioning inconsistency.
     # see: https://github.com/conda-forge/conda-forge.github.io/issues/687#issuecomment-460086164
-    if [[ "desired_cuda" == "12.1" ]]; then
+    if [[ "$desired_cuda" == "12.1" ]]; then
 	export CONDA_CUDATOOLKIT_CONSTRAINT="    - pytorch-cuda >=12.1,<12.2 # [not osx]"
 	export MAGMA_PACKAGE="    - magma-cuda121 # [not osx and not win]"
     elif [[ "$desired_cuda" == "11.8" ]]; then


### PR DESCRIPTION
Fixes the typo from https://github.com/pytorch/builder/pull/1374 
Related to failures in: https://github.com/pytorch/pytorch/pull/98492
Example job failure from https://github.com/pytorch/pytorch/actions/runs/4628062780/jobs/8186712739?pr=98492:
```
CUDNN_VERSION=8.8.1
+ [[ desired_cuda == \1\2\.\1 ]]
+ [[ 12.1 == \1\1\.\8 ]]
+ [[ 12.1 == \1\1\.\7 ]]
+ echo 'unhandled desired_cuda: 12.1'
unhandled desired_cuda: 12.1
+ exit 1
```


CC @atalman @malfet 