### PR TITLE
Add pytorch-cuda constraints for CUDA 12.1

### DIFF
--- a/conda/pytorch-cuda/meta.yaml
+++ b/conda/pytorch-cuda/meta.yaml
@@ -27,6 +27,14 @@
 {% set libcusparse_constraints=">=11.7.5.86,<12.0.0.76" %}
 {% set libnpp_constraints=">=11.8.0.86,<12.0.0.30" %}
 {% set libnvjpeg_constraints=">=11.9.0.86,<12.0.0.28" %}
+{% elif version == '12.1' %}
+{% set cuda_constraints=">=12.1,<12.2" %}
+{% set libcufft_constraints=">=11.0.2.4" %}
+{% set libcublas_constraints=">=12.1.0.26" %}
+{% set libcusolver_constraints=">=11.4.4.55" %}
+{% set libcusparse_constraints=">=12.0.2.55" %}
+{% set libnpp_constraints=">=12.0.2.50" %}
+{% set libnvjpeg_constraints=">=12.1.0.39" %}
 {% endif %}
 
 package:


### PR DESCRIPTION
Related to: https://github.com/pytorch/pytorch/pull/98492
Example error from https://github.com/pytorch/pytorch/actions/runs/4633728345/jobs/8200376224:
```
conda install -yq -c nvidia -c pytorch-nightly pytorch-cuda=12.1
+ local cmd=install
+ case "$cmd" in
+ __conda_exe install -yq -c nvidia -c pytorch-nightly pytorch-cuda=12.1
+ /opt/conda/bin/conda install -yq -c nvidia -c pytorch-nightly pytorch-cuda=12.1
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.

PackagesNotFoundError: The following packages are not available from current channels:

  - pytorch-cuda=12.1
```

CC @malfet @atalman 