### PR TITLE
Fix processor affinity for fork child

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -42,6 +42,9 @@ requirements:
     {% endif %}
     - libuv # [win]
     - intel-openmp # [win]
+    # llvm-openmp 16 leads to wrong processor affinity for fork child, see #99625.
+    # Before a decent fix, force llvm-openmp version <16.
+    - llvm-openmp <16 # [linux]
     - typing_extensions
     - sympy
     - filelock


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/99625.

Empirically, a conda environment created with
```
conda create -n wrong -c pytorch python=3.9 pytorch cpuonly
```
sets wrong processor affinity for fork child, while
```
conda create -n correct -c pytorch python=3.9 pytorch cpuonly 'llvm-openmp<16'
```
fixes this issue (both llvm-openmp 14 and 15 works).

So I added this requirement to the runtime dependency section.

CC @malfet 