### PR TITLE
Add fsspec dependency to list of allowed dependencies

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -41,6 +41,7 @@ PACKAGE_ALLOW_LIST = {
     "cmake",
     "colorama",
     "filelock",
+    "fsspec",
     "idna",
     "Jinja2",
     "lit",


### PR DESCRIPTION
Add fsspec dependency to list of allowed dependencies
Required after https://github.com/pytorch/pytorch/pull/99768