### PR TITLE
Do not cleanup MSVC and CUDA on Windows non-ephemeral runners

### DIFF
--- a/windows/internal/setup.bat
+++ b/windows/internal/setup.bat
@@ -75,10 +75,6 @@ IF "%DEBUG%" == "" (
     set LIBTORCH_PREFIX=libtorch-win-%VARIANT%-debug
 )
 
-:: remove files to save space.
-rmdir /s /q "C:/Program Files/NVIDIA GPU Computing Toolkit/"
-rmdir /s /q "C:/Program Files (x86)/Microsoft Visual Studio/"
-
 7z a -tzip "%LIBTORCH_PREFIX%-%PYTORCH_BUILD_VERSION%.zip" libtorch\*
 :: Cleanup raw data to save space
 rmdir /s /q libtorch

--- a/windows/internal/vs2019_install.ps1
+++ b/windows/internal/vs2019_install.ps1
@@ -51,6 +51,6 @@ if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     }
     Start-Process "${PWD}\Collect.exe" -NoNewWindow -Wait -PassThru
     New-Item -Path "C:\w\build-results" -ItemType "directory" -Force
-    Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
+    Copy-Item -Path "C:\Users\${env:USERNAME}\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
     exit 1
 }

--- a/windows/internal/vs2022_install.ps1
+++ b/windows/internal/vs2022_install.ps1
@@ -51,6 +51,6 @@ if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
     }
     Start-Process "${PWD}\Collect.exe" -NoNewWindow -Wait -PassThru
     New-Item -Path "C:\w\build-results" -ItemType "directory" -Force
-    Copy-Item -Path "C:\Users\circleci\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
+    Copy-Item -Path "C:\Users\${env:USERNAME}\AppData\Local\Temp\vslogs.zip" -Destination "C:\w\build-results\"
     exit 1
 }


### PR DESCRIPTION
This step cleans up MSVC and CUDA every time after a binary build job, thus breaking the next job on the new Windows non-ephemeral runner.

Also fix the wrong `circleci` username as the job is now running on GitHub