### PR TITLE
Handle symlink when using robocopy

### DIFF
--- a/windows/internal/clone.bat
+++ b/windows/internal/clone.bat
@@ -6,7 +6,8 @@ if exist "%NIGHTLIES_PYTORCH_ROOT%" (
     if exist pytorch (
       rmdir /s /q pytorch
     )
-    robocopy "%NIGHTLIES_PYTORCH_ROOT%" pytorch\ /e /np /nfl
+    :: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy
+    robocopy "%NIGHTLIES_PYTORCH_ROOT%" pytorch\ /e /np /nfl /sl
     cd pytorch
 )
 if exist "%NIGHTLIES_PYTORCH_ROOT%" goto submodule


### PR DESCRIPTION
https://github.com/pytorch/builder/commit/860d444515fa2bee44dfac16385702f7abb8a4e0 doesn't seem to fix the infinite symlink copy as I still can see it happens in the recent run https://github.com/pytorch/pytorch/actions/runs/4886072909/jobs/8720944212

The fix should be to handle symlink with `/sl` flag accordingly to https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy

### Testing
SSM to the runner, run `Robocopy.exe  .\pytorch\third_party\ittapi\ C:\actions-runner\_work\_temp\debug /e /np /nfl` ends up with the infinite loop while `Robocopy.exe  .\pytorch\third_party\ittapi\ C:\actions-runner\_work\_temp\debug /e /np /nfl /sl` works.

```
PS C:\actions-runner\_work\pytorch\pytorch> ls C:\actions-runner\_work\_temp\debug\rust\ittapi-sys\


    Directory: C:\actions-runner\_work\_temp\debug\rust\ittapi-sys


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d----l         5/4/2023   6:16 PM                c-library
d----l         5/4/2023   6:16 PM                LICENSES
d-----         5/4/2023   6:16 PM                src
d-----         5/4/2023   6:16 PM                tests
-a----         5/4/2023   6:16 PM            527 build.rs
-a----         5/4/2023   6:16 PM            644 Cargo.toml
-a----         5/4/2023   6:16 PM           2490 README.md
```

The `c-library` shows as a symlink correctly.

```
PS C:\actions-runner\_work\pytorch\pytorch> ls C:\actions-runner\_work\_temp\debug\rust\ittapi-sys\c-library\


    Directory: C:\actions-runner\_work\_temp\debug\rust\ittapi-sys\c-library


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----         5/4/2023   6:16 PM                .github
d-----         5/4/2023   6:16 PM                include
d-----         5/4/2023   6:16 PM                LICENSES
d-----         5/4/2023   6:16 PM                rust
d-----         5/4/2023   6:16 PM                src
-a----         5/4/2023   6:16 PM              8 .gitignore
-a----         5/4/2023   6:16 PM           6020 buildall.py
-a----         5/4/2023   6:16 PM           2606 CMakeLists.txt
-a----         5/4/2023   6:16 PM           1739 README.md
```