### PR TITLE
Skip uninstalling other MSVC versions if they are found

### DIFF
--- a/windows/internal/vs2019_install.ps1
+++ b/windows/internal/vs2019_install.ps1
@@ -27,15 +27,7 @@ if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswher
             echo "Found correctly versioned existing BuildTools installation in $existingPath"
             exit 0
         }
-        echo "Found existing BuildTools installation in $existingPath"
-        $VS_UNINSTALL_ARGS = @("uninstall", "--installPath", "`"$existingPath`"", "--quiet","--wait")
-        $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_UNINSTALL_ARGS -NoNewWindow -Wait -PassThru
-        $exitCode = $process.ExitCode
-        if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
-            echo "Original BuildTools uninstall failed with code $exitCode"
-            exit 1
-        }
-        echo "Original BuildTools uninstalled"
+        echo "Found existing BuildTools installation in $existingPath, keeping it"
     }
 }
 

--- a/windows/internal/vs2022_install.ps1
+++ b/windows/internal/vs2022_install.ps1
@@ -27,15 +27,7 @@ if (Test-Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswher
             echo "Found correctly versioned existing BuildTools installation in $existingPath"
             exit 0
         }
-        echo "Found existing BuildTools installation in $existingPath"
-        $VS_UNINSTALL_ARGS = @("uninstall", "--installPath", "`"$existingPath`"", "--quiet","--wait")
-        $process = Start-Process "${PWD}\vs_installer.exe" -ArgumentList $VS_UNINSTALL_ARGS -NoNewWindow -Wait -PassThru
-        $exitCode = $process.ExitCode
-        if (($exitCode -ne 0) -and ($exitCode -ne 3010)) {
-            echo "Original BuildTools uninstall failed with code $exitCode"
-            exit 1
-        }
-        echo "Original BuildTools uninstalled"
+        echo "Found existing BuildTools installation in $existingPath, keeping it"
     }
 }
 


### PR DESCRIPTION
Although we are using MSVC 2019 in the CI, there is nothing to prevent devs from trying to upgrade to MSVC 2022 such as https://github.com/pytorch/pytorch/pull/100094.  The problem is that share Windows runner + uninstalling other MSVC versions  + no Docker affects trunk reliability when subsequent jobs try to reinstall MSVC 2019 and fail flakily, for example https://github.com/pytorch/pytorch/actions/runs/4951116658/jobs/8857247229.

From MS doc https://learn.microsoft.com/en-us/visualstudio/install/install-visual-studio-versions-side-by-side, there seems to be no bad effect of keeping all MSVC versions, so I want to try this out first as it's easier.  The other option would be to ban MSVC installation on the CI and keep it only in the AMI