### PR TITLE
Don't prepend system-wide PATH when installing Python for binary smoke test

### DIFF
--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -44,7 +44,11 @@ del python-amd64.exe
 curl --retry 3 -kL "%PYTHON_INSTALLER_URL%" --output python-amd64.exe
 if errorlevel 1 exit /b 1
 
-start /wait "" python-amd64.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0 TargetDir=%CD%\Python
+:: According to https://docs.python.org/3/using/windows.html, setting PrependPath to 1 will prepend
+:: the installed Python to PATH system-wide. Even calling set PATH=%ORIG_PATH% later on won't make
+:: a change. As the builder directory will be removed after the smoke test, all subsequent non-binary
+:: jobs will fail to find any Python executable there
+start /wait "" python-amd64.exe /quiet InstallAllUsers=1 PrependPath=0 Include_test=0 TargetDir=%CD%\Python
 if errorlevel 1 exit /b 1
 
 set "PATH=%CD%\Python%PYTHON_VERSION%\Scripts;%CD%\Python;%PATH%"


### PR DESCRIPTION
The PATH has already been set and restored manually in the script. According to https://docs.python.org/3/using/windows.html, setting PrependPath to 1 will prepend the installed Python to PATH system-wide. Even calling `set PATH=%ORIG_PATH%` later on won't make a difference. As the builder directory will be removed after the smoke test, all subsequent non-binary jobs will fail to find any Python executable there, for example https://github.com/pytorch/pytorch/actions/runs/4971423518/jobs/8895937503, a regular CI Windows job.

```
Unable to create process using 'C:\actions-runner\_work\pytorch\pytorch\builder\windows\Python\python.exe "C:\actions-runner\_work\pytorch\pytorch\.github\scripts\parse_ref.py" ': The system cannot find the file specified
```

### Testing

I will re-run nightly smoke tests after merge to confirm the fix