### PR TITLE
Pin MSVC version to 2019

### DIFF
--- a/windows/internal/vc_install_helper.bat
+++ b/windows/internal/vc_install_helper.bat
@@ -1,5 +1,8 @@
 if "%VC_YEAR%" == "2019" powershell windows/internal/vs2019_install.ps1
-if "%VC_YEAR%" == "2022" powershell windows/internal/vs2022_install.ps1
+if "%VC_YEAR%" == "2022" (
+  echo "Upgrading MSVC to 2022 is not supported in the CI for reliability reason. Please contact PyTorch Dev Infra for more information"
+  set VC_YEAR=2019
+)
 
 set VC_VERSION_LOWER=17
 set VC_VERSION_UPPER=18


### PR DESCRIPTION
This is to avoid flaky issues in the CI on non-ephemeral runners per my comment in https://github.com/pytorch/pytorch/pull/100094#issuecomment-1548283208.  Upgrading MSVC to 2022 should be done in the AMI instead (https://github.com/pytorch/test-infra/pull/1175)