### PR TITLE
Pin numpy to 1.21.3 for python 3.10

### DIFF
--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -12,7 +12,7 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     if "%%v" == "3.7" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
     if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
     if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy>=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.22.3 "mkl=2020.2" pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
+    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.21.3 "mkl=2020.2" pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
     if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 "mkl=2020.2" pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
     if "%%v" == "3" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
 )


### PR DESCRIPTION
Follow up after: https://github.com/pytorch/builder/pull/1406

Fixes: https://github.com/pytorch/pytorch/issues/102101

According to: https://anaconda.org/conda-forge/numpy/files?version=1.21.3
Version 1.21.3 is the first one to support python 3.10 on windows

Test:
```
base) C:\Windows\system32>conda create -n py310 -q -c=conda-forge numpy=1.21.3 "mkl=2020.2" pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=3.10
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: C:\tools\miniconda3\envs\py310

  added / updated specs:
    - boto3
    - cmake=3.19.6
    - mkl=2020.2
    - ninja
    - numpy=1.21.3
    - python=3.10
    - pyyaml
    - typing_extensions


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    boto3-1.26.138             |     pyhd8ed1ab_0          76 KB  conda-forge
    botocore-1.29.138          |     pyhd8ed1ab_0         5.8 MB  conda-forge
    brotlipy-0.7.0             |py310h8d17308_1005         332 KB  conda-forge
    bzip2-1.0.8                |       h8ffe710_4         149 KB  conda-forge
    ca-certificates-2023.5.7   |       h56e8100_0         145 KB  conda-forge
    certifi-2023.5.7           |     pyhd8ed1ab_0         149 KB  conda-forge
    cffi-1.15.1                |  py310h628cb3f_3         228 KB  conda-forge
    cmake-3.19.6               |       h39d44d4_0        11.4 MB  conda-forge
    cryptography-40.0.2        |  py310h6e82f81_0         1.0 MB  conda-forge
    idna-3.4                   |     pyhd8ed1ab_0          55 KB  conda-forge
    intel-openmp-2023.1.0      |   h57928b3_46319         2.5 MB  conda-forge
    jmespath-1.0.1             |     pyhd8ed1ab_0          21 KB  conda-forge
    libblas-3.9.0              |5_hd5c7e75_netlib         197 KB  conda-forge
    libcblas-3.9.0             |5_hd5c7e75_netlib          95 KB  conda-forge
    libffi-3.4.2               |       h8ffe710_5          41 KB  conda-forge
    liblapack-3.9.0            |5_hd5c7e75_netlib         2.7 MB  conda-forge
    libsqlite-3.42.0           |       hcfcfb64_0         820 KB  conda-forge
    libzlib-1.2.13             |       hcfcfb64_4          70 KB  conda-forge
    m2w64-gcc-libgfortran-5.3.0|                6         342 KB  conda-forge
    m2w64-gcc-libs-5.3.0       |                7         520 KB  conda-forge
    m2w64-gcc-libs-core-5.3.0  |                7         214 KB  conda-forge
    m2w64-gmp-6.1.0            |                2         726 KB  conda-forge
    m2w64-libwinpthread-git-5.0.0.4634.697f757|                2          31 KB  conda-forge
    mkl-2020.2                 |     h57928b3_256       170.7 MB  conda-forge
    msys2-conda-epoch-20160418 |                1           3 KB  conda-forge
    ninja-1.11.1               |       h91493d7_0         273 KB  conda-forge
    numpy-1.21.3               |  py310h5ebf175_1         5.6 MB  conda-forge
    openssl-3.1.0              |       hcfcfb64_3         7.1 MB  conda-forge
    pip-23.1.2                 |     pyhd8ed1ab_0         1.3 MB  conda-forge
    pycparser-2.21             |     pyhd8ed1ab_0         100 KB  conda-forge
    pyopenssl-23.1.1           |     pyhd8ed1ab_0         125 KB  conda-forge
    pysocks-1.7.1              |     pyh0701188_6          19 KB  conda-forge
    python-3.10.11             |h4de0772_0_cpython        15.3 MB  conda-forge
    python-dateutil-2.8.2      |     pyhd8ed1ab_0         240 KB  conda-forge
    python_abi-3.10            |          3_cp310           6 KB  conda-forge
    pyyaml-6.0                 |  py310h8d17308_5         148 KB  conda-forge
    s3transfer-0.6.1           |     pyhd8ed1ab_0          59 KB  conda-forge
    setuptools-67.7.2          |     pyhd8ed1ab_0         569 KB  conda-forge
    six-1.16.0                 |     pyh6c4a22f_0          14 KB  conda-forge
    tk-8.6.12                  |       h8ffe710_0         3.5 MB  conda-forge
    typing_extensions-4.6.0    |     pyha770c72_0          33 KB  conda-forge
    tzdata-2023c               |       h71feb2d_0         115 KB  conda-forge
    ucrt-10.0.22621.0          |       h57928b3_0         1.2 MB  conda-forge
    urllib3-1.26.15            |     pyhd8ed1ab_0         110 KB  conda-forge
    vc-14.3                    |      hb25d44b_16          16 KB  conda-forge
    vc14_runtime-14.34.31931   |      h5081d32_16         709 KB  conda-forge
    vs2015_runtime-14.34.31931 |      hed1258a_16          16 KB  conda-forge
    wheel-0.40.0               |     pyhd8ed1ab_0          54 KB  conda-forge
    win_inet_pton-1.1.0        |     pyhd8ed1ab_6           8 KB  conda-forge
    xz-5.2.6                   |       h8d14728_0         213 KB  conda-forge
    yaml-0.2.5                 |       h8ffe710_2          62 KB  conda-forge
    ------------------------------------------------------------
                                           Total:       235.3 MB

The following NEW packages will be INSTALLED:

  boto3              conda-forge/noarch::boto3-1.26.138-pyhd8ed1ab_0
  botocore           conda-forge/noarch::botocore-1.29.138-pyhd8ed1ab_0
  brotlipy           conda-forge/win-64::brotlipy-0.7.0-py310h8d17308_1005
  bzip2              conda-forge/win-64::bzip2-1.0.8-h8ffe710_4
  ca-certificates    conda-forge/win-64::ca-certificates-2023.5.7-h56e8100_0
  certifi            conda-forge/noarch::certifi-2023.5.7-pyhd8ed1ab_0
  cffi               conda-forge/win-64::cffi-1.15.1-py310h628cb3f_3
  cmake              conda-forge/win-64::cmake-3.19.6-h39d44d4_0
  cryptography       conda-forge/win-64::cryptography-40.0.2-py310h6e82f81_0
  idna               conda-forge/noarch::idna-3.4-pyhd8ed1ab_0
  intel-openmp       conda-forge/win-64::intel-openmp-2023.1.0-h57928b3_46319
  jmespath           conda-forge/noarch::jmespath-1.0.1-pyhd8ed1ab_0
  libblas            conda-forge/win-64::libblas-3.9.0-5_hd5c7e75_netlib
  libcblas           conda-forge/win-64::libcblas-3.9.0-5_hd5c7e75_netlib
  libffi             conda-forge/win-64::libffi-3.4.2-h8ffe710_5
  liblapack          conda-forge/win-64::liblapack-3.9.0-5_hd5c7e75_netlib
  libsqlite          conda-forge/win-64::libsqlite-3.42.0-hcfcfb64_0
  libzlib            conda-forge/win-64::libzlib-1.2.13-hcfcfb64_4
  m2w64-gcc-libgfor~ conda-forge/win-64::m2w64-gcc-libgfortran-5.3.0-6
  m2w64-gcc-libs     conda-forge/win-64::m2w64-gcc-libs-5.3.0-7
  m2w64-gcc-libs-co~ conda-forge/win-64::m2w64-gcc-libs-core-5.3.0-7
  m2w64-gmp          conda-forge/win-64::m2w64-gmp-6.1.0-2
  m2w64-libwinpthre~ conda-forge/win-64::m2w64-libwinpthread-git-5.0.0.4634.697f757-2
  mkl                conda-forge/win-64::mkl-2020.2-h57928b3_256
  msys2-conda-epoch  conda-forge/win-64::msys2-conda-epoch-20160418-1
  ninja              conda-forge/win-64::ninja-1.11.1-h91493d7_0
  numpy              conda-forge/win-64::numpy-1.21.3-py310h5ebf175_1
  openssl            conda-forge/win-64::openssl-3.1.0-hcfcfb64_3
  pip                conda-forge/noarch::pip-23.1.2-pyhd8ed1ab_0
  pycparser          conda-forge/noarch::pycparser-2.21-pyhd8ed1ab_0
  pyopenssl          conda-forge/noarch::pyopenssl-23.1.1-pyhd8ed1ab_0
  pysocks            conda-forge/noarch::pysocks-1.7.1-pyh0701188_6
  python             conda-forge/win-64::python-3.10.11-h4de0772_0_cpython
  python-dateutil    conda-forge/noarch::python-dateutil-2.8.2-pyhd8ed1ab_0
  python_abi         conda-forge/win-64::python_abi-3.10-3_cp310
  pyyaml             conda-forge/win-64::pyyaml-6.0-py310h8d17308_5
  s3transfer         conda-forge/noarch::s3transfer-0.6.1-pyhd8ed1ab_0
  setuptools         conda-forge/noarch::setuptools-67.7.2-pyhd8ed1ab_0
  six                conda-forge/noarch::six-1.16.0-pyh6c4a22f_0
  tk                 conda-forge/win-64::tk-8.6.12-h8ffe710_0
  typing_extensions  conda-forge/noarch::typing_extensions-4.6.0-pyha770c72_0
  tzdata             conda-forge/noarch::tzdata-2023c-h71feb2d_0
  ucrt               conda-forge/win-64::ucrt-10.0.22621.0-h57928b3_0
  urllib3            conda-forge/noarch::urllib3-1.26.15-pyhd8ed1ab_0
  vc                 conda-forge/win-64::vc-14.3-hb25d44b_16
  vc14_runtime       conda-forge/win-64::vc14_runtime-14.34.31931-h5081d32_16
  vs2015_runtime     conda-forge/win-64::vs2015_runtime-14.34.31931-hed1258a_16
  wheel              conda-forge/noarch::wheel-0.40.0-pyhd8ed1ab_0
  win_inet_pton      conda-forge/noarch::win_inet_pton-1.1.0-pyhd8ed1ab_6
  xz                 conda-forge/win-64::xz-5.2.6-h8d14728_0
  yaml               conda-forge/win-64::yaml-0.2.5-h8ffe710_2


Proceed ([y]/n)? n


```