### PR TITLE
Pin delocate to latest 0.10.4 release rathen then master

### DIFF
--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -194,7 +194,7 @@ echo "Finished setup.py bdist_wheel at $(date)"
 
 if [[ $package_type != 'libtorch' ]]; then
     echo "delocating wheel dependencies"
-    retry pip install https://github.com/matthew-brett/delocate/archive/master.zip
+    retry pip install https://github.com/matthew-brett/delocate/archive/refs/tags/0.10.4.zip
     echo "found the following wheels:"
     find $whl_tmp_dir -name "*.whl"
     echo "running delocate"


### PR DESCRIPTION
Should resolve nightly build failure on macos wheels when running delocate:
https://github.com/pytorch/pytorch/actions/runs/5118526219/jobs/9202670430

Test: https://github.com/pytorch/pytorch/actions/runs/5121450405/jobs/9209233558?pr=102531

Failure seems to be related to this PR: https://github.com/matthew-brett/delocate/pull/186

Here is the failure log:
```
2023-05-30T07:44:37.8592970Z Collecting https://github.com/matthew-brett/delocate/archive/master.zip
2023-05-30T07:44:38.2254920Z   Downloading https://github.com/matthew-brett/delocate/archive/master.zip
2023-05-30T07:44:38.3178740Z      \ 243.2 kB 3.2 MB/s 0:00:00
2023-05-30T07:44:38.3671260Z   Installing build dependencies: started
2023-05-30T07:44:40.5969340Z   Installing build dependencies: finished with status 'done'
2023-05-30T07:44:40.5987220Z   Getting requirements to build wheel: started
2023-05-30T07:44:40.7699670Z   Getting requirements to build wheel: finished with status 'error'
2023-05-30T07:44:40.7935770Z   error: subprocess-exited-with-error
2023-05-30T07:44:40.7936310Z   
2023-05-30T07:44:40.7946220Z   × Getting requirements to build wheel did not run successfully.
2023-05-30T07:44:40.7952100Z   │ exit code: 1
2023-05-30T07:44:40.7952560Z   ╰─> [35 lines of output]
2023-05-30T07:44:40.7952830Z       Traceback (most recent call last):
2023-05-30T07:44:40.7953440Z         File "/Users/runner/work/_temp/anaconda/envs/wheel_py39/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
2023-05-30T07:44:40.7953860Z           main()
2023-05-30T07:44:40.7954400Z         File "/Users/runner/work/_temp/anaconda/envs/wheel_py39/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
2023-05-30T07:44:40.7954940Z           json_out['return_val'] = hook(**hook_input['kwargs'])
2023-05-30T07:44:40.7955580Z         File "/Users/runner/work/_temp/anaconda/envs/wheel_py39/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
2023-05-30T07:44:40.7956060Z           return hook(config_settings)
2023-05-30T07:44:40.7956700Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
2023-05-30T07:44:40.7957340Z           return self._get_build_requires(config_settings, requirements=['wheel'])
2023-05-30T07:44:40.7958020Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
2023-05-30T07:44:40.7958720Z           self.run_setup()
2023-05-30T07:44:40.7959790Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 338, in run_setup
2023-05-30T07:44:40.7960520Z           exec(code, locals())
2023-05-30T07:44:40.7960950Z         File "<string>", line 7, in <module>
2023-05-30T07:44:40.7962090Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 107, in setup
2023-05-30T07:44:40.7963060Z           return distutils.core.setup(**attrs)
2023-05-30T07:44:40.7963710Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 147, in setup
2023-05-30T07:44:40.7964190Z           _setup_distribution = dist = klass(attrs)
2023-05-30T07:44:40.7964790Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 496, in __init__
2023-05-30T07:44:40.7965220Z           _Distribution.__init__(
2023-05-30T07:44:40.7966010Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 283, in __init__
2023-05-30T07:44:40.7966480Z           self.finalize_options()
2023-05-30T07:44:40.7967080Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 935, in finalize_options
2023-05-30T07:44:40.7967640Z           ep(self)
2023-05-30T07:44:40.7968210Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools_scm/integration.py", line 127, in infer_version
2023-05-30T07:44:40.7968680Z           _assign_version(dist, config)
2023-05-30T07:44:40.7969400Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools_scm/integration.py", line 63, in _assign_version
2023-05-30T07:44:40.7969880Z           _version_missing(config)
2023-05-30T07:44:40.7970480Z         File "/private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-build-env-ilsxo_eq/overlay/lib/python3.9/site-packages/setuptools_scm/__init__.py", line 108, in _version_missing
2023-05-30T07:44:40.7970930Z           raise LookupError(
2023-05-30T07:44:40.7971470Z       LookupError: setuptools-scm was unable to detect version for /private/var/folders/x6/m72yyyh552375jzz14fz2k400000gn/T/pip-req-build-cuj6u3nk.
2023-05-30T07:44:40.7971860Z       
2023-05-30T07:44:40.7972510Z       Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
2023-05-30T07:44:40.7973090Z       
2023-05-30T07:44:40.7973620Z       For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
2023-05-30T07:44:40.7974050Z       [end of output]
2023-05-30T07:44:40.7974250Z   
2023-05-30T07:44:40.7974560Z   note: This error originates from a subprocess, and is likely not a problem with pip.
2023-05-30T07:44:40.7974990Z error: subprocess-exited-with-error
2023-05-30T07:44:40.7975180Z 
2023-05-30T07:44:40.7975410Z × Getting requirements to build wheel did not run successfully.
2023-05-30T07:44:40.7975720Z │ exit code: 1
2023-05-30T07:44:40.7976000Z ╰─> See above for output.
2023-05-30T07:44:40.7976150Z 
2023-05-30T07:44:40.7976350Z note: This error originates from a subprocess, and is likely not a problem with pip.
2023-05-30T07:44:40.9865230Z + sleep 1
2023-05-30T07:44:42.0491940Z + pip install https://github.com/matthew-brett/delocate/archive/master.zip
2023-05-30T07:44:42.4793560Z Collecting https://github.com/matthew-brett/delocate/archive/master.zip
2023-05-30T07:44:42.7654880Z   Using cached https://github.com/matthew-brett/delocate/archive/master.zip
2023-05-30T07:44:42.8618150Z   Installing build dependencies: started
2023-05-30T07:44:44.8931520Z   Installing build dependencies: finished with status 'done'
2023-05-30T07:44:44.8951860Z   Getting requirements to build wheel: started
2023-05-30T07:44:45.0543710Z   Getting requirements to build wheel: finished with status 'error'
2023-05-30T07:44:45.0629950Z   error: subprocess-exited-with-error
2023-05-30T07:44:45.0630240Z   
```