### PR TITLE
Add pytorch-triton to small wheel

### DIFF
--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -272,9 +272,14 @@ else
 fi
 
 # TODO: Remove me when Triton has a proper release channel
-if [[ $(uname) == "Linux" && -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
+if [[ $(uname) == "Linux" ]]; then
     TRITON_SHORTHASH=$(cut -c1-10 $PYTORCH_ROOT/.github/ci_commit_pins/triton.txt)
-    export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton==2.1.0+${TRITON_SHORTHASH}"
+
+    if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton==2.1.0+${TRITON_SHORTHASH}"
+    else
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton==2.1.0+${TRITON_SHORTHASH}"
+    fi
 fi
 
 # builder/test.sh requires DESIRED_CUDA to know what tests to exclude


### PR DESCRIPTION
Add pytorch-triton to small wheel.
We should have METADATA string like this:
```
Requires-Dist: pytorch-triton (==2.1.0+440fd1bf20)
```

Issue found by validation framework when testing CUDA 12.1 small wheel:
https://github.com/pytorch/builder/actions/runs/5258582247/jobs/9503002091 

Here is the log:
```
raise RuntimeError(
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
RuntimeError: Cannot find a working triton installation. More information on installing Triton can be found at https://github.com/openai/triton


You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True



ERROR conda.cli.main_run:execute(47): `conda run python ./test/smoke_test/smoke_test.py` failed. (See above for error)
```