### PR TITLE
Update aarch64 Scripts for CI worflow

### DIFF
--- a/aarch64_linux/aarch64_ci_build.sh
+++ b/aarch64_linux/aarch64_ci_build.sh
@@ -12,7 +12,7 @@ PATH=/opt/conda/bin:$PATH
 # Install OS dependent packages
 ###############################################################################
 yum -y install epel-release
-yum -y install less zstd
+yum -y install less zstd git
 
 ###############################################################################
 # Install conda
@@ -25,7 +25,7 @@ chmod +x /mambaforge.sh
 /mambaforge.sh -b -p /opt/conda
 rm /mambaforge.sh
 /opt/conda/bin/conda config --set ssl_verify False
-/opt/conda/bin/conda install -y -c conda-forge python=${DESIRED_PYTHON} numpy pyyaml setuptools patchelf
+/opt/conda/bin/conda install -y -c conda-forge python=${DESIRED_PYTHON} numpy pyyaml setuptools patchelf pygit2
 python --version
 conda --version
 
@@ -37,16 +37,18 @@ conda --version
 # ubuntu's libgfortran.a which is compiled with -fPIC
 ###############################################################################
 cd ~/
-curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-6ubuntu1_arm64.deb
-ar x ~/libgfortran-10-dev.deb
+curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-8ubuntu1_arm64.deb
+ar -x libgfortran-10-dev.deb
 tar --use-compress-program=unzstd -xvf data.tar.zst -C ~/
 cp -f ~/usr/lib/gcc/aarch64-linux-gnu/10/libgfortran.a /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/
 
 ###############################################################################
 # Run aarch64 builder python
 ###############################################################################
-cd /
+cd /pytorch
 # adding safe directory for git as the permissions will be
 # on the mounted pytorch repo
 git config --global --add safe.directory /pytorch
+pip install -r /pytorch/requirements.txt
+pip install auditwheel
 python /builder/aarch64_linux/aarch64_wheel_ci_build.py --enable-mkldnn


### PR DESCRIPTION
Upon working with the WorkFlow on PyTorch, found the aarch64 CI build scripts needed updates for pathing and PyTorch repo changes. Have updated the scripts to work with the PyTorch aarch64 build workflow and have successfully tested the changes on my fork with an available aarch64 Actions agent.

Changes:
* Moved requirements install to bash script
* Added git and pygit2 to bash script to solve a git error and pull data on the active PyTorch Repo
* Fixed path issues with the python script
* Update to repo checkout to get the needed branches of expected sub package. most of the time, this will be main/master or nightly, but can do versions if the mapping is updated.
