### PR TITLE
Provide file hashes in the URLs to avoid unnecessary file downloads (bandwidth saver)

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -3,6 +3,7 @@
 import argparse
 import base64
 import dataclasses
+import functools
 import time
 
 from os import path, makedirs

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -281,9 +281,7 @@ class S3Index:
         out.append('  <body>')
         out.append('    <h1>Links for {}</h1>'.format(package_name.lower().replace("_","-")))
         for obj in sorted(self.gen_file_list(subdir, package_name)):
-            maybe_fragment = ""
-            if obj.checksum:
-                maybe_fragment = f"#sha256={obj.checksum}"
+            maybe_fragment = f"#sha256={obj.checksum}" if obj.checksum else ""
             out.append(f'    <a href="/{obj}{maybe_fragment}">{path.basename(obj).replace("%2B","+")}</a><br/>')
         # Adding html footer
         out.append('  </body>')

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -274,7 +274,10 @@ class S3Index:
         out.append('    <h1>Links for {}</h1>'.format(package_name.lower().replace("_","-")))
         for obj in sorted(self.gen_file_list(subdir, package_name)):
             checksum = self.fetch_checksum_from_s3(obj)
-            out.append(f'    <a href="/{obj}?sha256={checksum}">{path.basename(obj).replace("%2B","+")}</a><br/>')
+            if checksum:
+                out.append(f'    <a href="/{obj}?sha256={checksum}">{path.basename(obj).replace("%2B","+")}</a><br/>')
+            else:
+                out.append(f'    <a href="/{obj}">{path.basename(obj).replace("%2B","+")}</a><br/>')
         # Adding html footer
         out.append('  </body>')
         out.append('</html>')

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -275,7 +275,7 @@ class S3Index:
         for obj in sorted(self.gen_file_list(subdir, package_name)):
             checksum = self.fetch_checksum_from_s3(obj)
             if checksum:
-                out.append(f'    <a href="/{obj}?sha256={checksum}">{path.basename(obj).replace("%2B","+")}</a><br/>')
+                out.append(f'    <a href="/{obj}#sha256={checksum}">{path.basename(obj).replace("%2B","+")}</a><br/>')
             else:
                 out.append(f'    <a href="/{obj}">{path.basename(obj).replace("%2B","+")}</a><br/>')
         # Adding html footer

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -339,7 +339,7 @@ class S3Index:
 
     @classmethod
     def from_S3(cls: Type[S3IndexType], prefix: str) -> S3IndexType:
-        objects = []
+        objects = {}
         prefix = prefix.rstrip("/")
         for obj in BUCKET.objects.filter(Prefix=prefix):
             is_acceptable = any([path.dirname(obj.key) == prefix] + [
@@ -354,7 +354,7 @@ class S3Index:
                 response = obj.meta.client.head_object(Bucket=BUCKET.name, Key=obj.key, ChecksumMode="ENABLED")
                 sha256 = response.get("ChecksumSHA256")
                 sanitized_key = obj.key.replace("+", "%2B")
-                objects.append((sanitized_key, sha256))
+                objects[sanitized_key] = sha256
         return cls(objects, prefix)
 
 

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -255,10 +255,10 @@ class S3Index:
         out.append('  <body>')
         out.append('    <h1>Links for {}</h1>'.format(package_name.lower().replace("_","-")))
         for obj, checksum in sorted(self.gen_file_list(subdir, package_name)):
+            maybe_fragment = ""
             if checksum:
-                out.append(f'    <a href="/{obj}#sha256={checksum}">{path.basename(obj).replace("%2B","+")}</a><br/>')
-            else:
-                out.append(f'    <a href="/{obj}">{path.basename(obj).replace("%2B","+")}</a><br/>')
+                maybe_fragment = f"#sha256={checksum}"
+            out.append(f'    <a href="/{obj}{maybe_fragment}">{path.basename(obj).replace("%2B","+")}</a><br/>')
         # Adding html footer
         out.append('  </body>')
         out.append('</html>')

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -107,6 +107,7 @@ S3IndexType = TypeVar('S3IndexType', bound='S3Index')
 
 
 @dataclasses.dataclass(frozen=True)
+@functools.total_ordering
 class S3Object:
     key: str
     checksum: str | None
@@ -114,20 +115,11 @@ class S3Object:
     def __str__(self):
         return self.key
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
         return self.key == other.key
 
     def __lt__(self, other):
         return self.key < other.key
-
-    def __le__(self, other):
-        return self.key <= other.key
-
-    def __gt__(self, other):
-        return self.key > other.key
-
-    def __ge__(self, other):
-        return self.key >= other.key
 
 
 def extract_package_build_time(full_package_name: str) -> datetime:

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import base64
 import time
 
 from os import path, makedirs

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -165,12 +165,11 @@ class S3Index:
                 to_hide.add(obj)
             else:
                 packages[package_name] += 1
-        nightly_packages = {}
-        for obj, checksum in self.objects.items():
-            normalized_package_version = self.normalize_package_version(obj)
-            if not normalized_package_version in to_hide:
-                nightly_packages[normalized_package_version] = checksum
-        return nightly_packages
+        return {
+            s3_key: checksum
+            for s3_key, checksum in self.objects.items()
+            if self.normalize_package_version(s3_key) not in to_hide
+        }
 
     def is_obj_at_root(self, obj:str) -> bool:
         return path.dirname(obj) == self.prefix

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -352,7 +352,7 @@ class S3Index:
             if is_acceptable:
                 # Add PEP 503-compatible hashes to URLs to allow clients to avoid spurious downloads, if possible.
                 response = obj.meta.client.head_object(Bucket=BUCKET.name, Key=obj.key, ChecksumMode="ENABLED")
-                sha256 = response.get("ChecksumSHA256")
+                sha256 = (_b64 := response.get("ChecksumSHA256")) and base64.b64decode(_b64).hex()
                 sanitized_key = obj.key.replace("+", "%2B")
                 objects[sanitized_key] = sha256
         return cls(objects, prefix)

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -252,7 +252,7 @@ class S3Index:
         out: List[str] = []
         subdir = self._resolve_subdir(subdir)
         is_root = subdir == self.prefix
-        for obj, _ in self.gen_file_list(subdir):
+        for obj in self.gen_file_list(subdir):
             # Strip our prefix
             sanitized_obj = obj.replace(subdir, "", 1)
             if sanitized_obj.startswith('/'):


### PR DESCRIPTION
Supply sha256 query parameters using boto3 to avoid hundreds of extra Gigabytes of downloads each day during pipenv and poetry resolution lock cycles.

Fixes point 1 in https://github.com/pytorch/pytorch/issues/76557
Fixes #1347