### PR TITLE
Run release validation testing once a day, run nightly a little later in the day

### DIFF
--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -3,8 +3,8 @@ name: cron
 
 on:
   schedule:
-    # At 2:30 pm UTC (7:30 am PDT)
-    - cron: "30 14 * * *"
+    # At 3:30 pm UTC (8:30 am PDT)
+    - cron: "30 15 * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
   push:

--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -3,8 +3,8 @@ name: cron
 
 on:
   schedule:
-    # At 3 am and 2 pm UTC (7 am and 8 pm PDT)
-    - cron: "0 3,14 * * *"
+    # At 3 am UTC (7 am PDT)
+    - cron: "0 3 * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
   push:


### PR DESCRIPTION
Run release validation testing once a day only - so that statistics is more representative of actual failure
Run nightly validation a little later in the day - let the nightly build finish