### PR TITLE
Update build CD for aarch64 Wheel

### DIFF
--- a/aarch64_linux/aarch64_ci_build.sh
+++ b/aarch64_linux/aarch64_ci_build.sh
@@ -12,7 +12,7 @@ PATH=/opt/conda/bin:$PATH
 # Install OS dependent packages
 ###############################################################################
 yum -y install epel-release
-yum -y install less zstd git
+yum -y install less zstd libgomp
 
 ###############################################################################
 # Install conda
@@ -38,14 +38,14 @@ conda --version
 ###############################################################################
 cd ~/
 curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-8ubuntu1_arm64.deb
-ar -x libgfortran-10-dev.deb
+ar x ~/libgfortran-10-dev.deb
 tar --use-compress-program=unzstd -xvf data.tar.zst -C ~/
 cp -f ~/usr/lib/gcc/aarch64-linux-gnu/10/libgfortran.a /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/
 
 ###############################################################################
 # Run aarch64 builder python
 ###############################################################################
-cd /pytorch
+cd /
 # adding safe directory for git as the permissions will be
 # on the mounted pytorch repo
 git config --global --add safe.directory /pytorch

--- a/check_binary.sh
+++ b/check_binary.sh
@@ -343,10 +343,17 @@ if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then
   build_and_run_example_cpp check-torch-mkl
 elif [[ "$(uname -m)" != "arm64" ]]; then
   if [[ "$(uname)" != 'Darwin' || "$PACKAGE_TYPE" != *wheel ]]; then
-    echo "Checking that MKL is available"
-    pushd /tmp
-    python -c 'import torch; exit(0 if torch.backends.mkl.is_available() else 1)'
-    popd
+    if [[ "$(uname -m)" == "aarch64" ]]; then
+      echo "Checking that MKLDNN is available on aarch64"
+      pushd /tmp
+      python -c 'import torch; exit(0 if torch.backends.mkldnn.is_available() else 1)'
+      popd
+    else
+      echo "Checking that MKL is available"
+      pushd /tmp
+      python -c 'import torch; exit(0 if torch.backends.mkl.is_available() else 1)'
+      popd
+    fi
   fi
 fi
 


### PR DESCRIPTION
This is an update to the aarch64 Linux Wheel build for PyTorch CD.

Updates:
* Removed builds of Vision, Audio, Text, and Data as they need to be made on their perspective repos.
* Created separate def for completing the wheel with auditwheel and putting into the artifacts folder.
* Removed git install as it was already installed.
* Added libgomp OS install so it is no longer needed to be injected as auditwheel handles it.
* Added MKLDNN check for aarch64 over standard MKL as aarch64 is not "Intel" based.

This build was tested at https://github.com/xncqr/pytorch/actions/runs/5351891068 with successful build and test of aarch64 wheel build.