### PR TITLE
Run make_wheel_record parallel in background

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -390,7 +390,7 @@ for pkg in /$WHEELHOUSE_DIR/torch*linux*.whl /$LIBTORCH_HOUSE_DIR/libtorch*.zip;
         : > "$record_file"
         # generate records for folders in wheel
         find * -type f | while read fname; do
-            make_wheel_record "$fname" >>"$record_file"
+            make_wheel_record "$fname" >>"$record_file" &
         done
     fi
 


### PR DESCRIPTION
By running `make_wheel_record` parallel in background, this saves ~8 minutes on my 12-core intel machine with a full cuda wheel build.

https://unix.stackexchange.com/questions/42544/does-redirecting-output-to-a-file-apply-a-lock-on-the-file/42564#42564
This answer suggested that each line will still be a line will written in parallel to the record file.

https://unix.stackexchange.com/questions/103920/parallelize-a-bash-for-loop/436713#436713
If overloading CPU is a concern, we may try this native `wait -n` bash trick to limit the concurrency. 