### PR TITLE
Fix wheel macos arm64 validations

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -9,8 +9,7 @@ else
 
     # Make sure we remove previous installation if it exists
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
-        UNINSTALL=${INSTALLATION/"install"/"uninstall -y"}
-        eval $UNINSTALL
+        pip3 uninstall -y torch torchaudio torchvision
     fi
     eval $INSTALLATION
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -7,9 +7,10 @@ else
     conda activate ${ENV_NAME}
     INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install -y"}
 
-    # Make sure no cache dir is specified during wheel
+    # Make sure we remove previous installation if it exists
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
-        INSTALLATION=${INSTALLATION/"install"/"install --upgrade"}
+        UNINSTALL=${INSTALLATION/"install"/"uninstall"}
+        eval $UNINSTALL
     fi
     eval $INSTALLATION
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -6,6 +6,11 @@ else
     conda create -y -n ${ENV_NAME} python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
     conda activate ${ENV_NAME}
     INSTALLATION=${MATRIX_INSTALLATION/"conda install"/"conda install -y"}
+
+    # Make sure no cache dir is specified during wheel
+    if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
+        INSTALLATION=${INSTALLATION/"install"/"install --no-cache-dir"}
+    fi
     eval $INSTALLATION
 
     if [[ ${TARGET_OS} == 'linux' ]]; then

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -9,7 +9,7 @@ else
 
     # Make sure we remove previous installation if it exists
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
-        UNINSTALL=${INSTALLATION/"install"/"uninstall"}
+        UNINSTALL=${INSTALLATION/"install"/"uninstall -y"}
         eval $UNINSTALL
     fi
     eval $INSTALLATION

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -20,7 +20,12 @@ else
         ${PWD}/check_binary.sh
     fi
 
-    python  ./test/smoke_test/smoke_test.py
+    if [[ ${TARGET_OS} == 'windows' ]]; then
+        python  ./test/smoke_test/smoke_test.py
+    else
+        python3  ./test/smoke_test/smoke_test.py
+    fi
+
     conda deactivate
     conda env remove -n ${ENV_NAME}
 fi

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -20,7 +20,12 @@ else
         ${PWD}/check_binary.sh
     fi
 
-    python3  ./test/smoke_test/smoke_test.py
+    if [[ ${TARGET_OS} == 'windows' ]]; then
+        python  ./test/smoke_test/smoke_test.py
+    else
+        python3  ./test/smoke_test/smoke_test.py
+    fi
+
     conda deactivate
     conda env remove -n ${ENV_NAME}
 fi

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -9,7 +9,7 @@ else
 
     # Make sure no cache dir is specified during wheel
     if [[ ${MATRIX_PACKAGE_TYPE} == 'wheel' ]]; then
-        INSTALLATION=${INSTALLATION/"install"/"install --no-cache-dir"}
+        INSTALLATION=${INSTALLATION/"install"/"install --upgrade"}
     fi
     eval $INSTALLATION
 

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -20,12 +20,7 @@ else
         ${PWD}/check_binary.sh
     fi
 
-    if [[ ${TARGET_OS} == 'windows' ]]; then
-        python  ./test/smoke_test/smoke_test.py
-    else
-        python3  ./test/smoke_test/smoke_test.py
-    fi
-
+    python3  ./test/smoke_test/smoke_test.py
     conda deactivate
     conda env remove -n ${ENV_NAME}
 fi

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -17,15 +17,7 @@ on:
       - .github/workflows/validate-macos-binaries.yml
       - .github/workflows/validate-macos-arm64-binaries.yml
       - test/smoke_test/*
-  pull_request:
-    paths:
-      - .github/workflows/validate-nightly-binaries.yml
-      - .github/workflows/validate-linux-binaries.yml
-      - .github/workflows/validate-windows-binaries.yml
-      - .github/workflows/validate-macos-binaries.yml
-      - .github/workflows/validate-macos-arm64-binaries.yml
-      - .github/scripts/validate_binaries.sh
-      - test/smoke_test/*
+
 jobs:
   nightly:
     uses: ./.github/workflows/validate-binaries.yml

--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -17,6 +17,15 @@ on:
       - .github/workflows/validate-macos-binaries.yml
       - .github/workflows/validate-macos-arm64-binaries.yml
       - test/smoke_test/*
+  pull_request:
+    paths:
+      - .github/workflows/validate-nightly-binaries.yml
+      - .github/workflows/validate-linux-binaries.yml
+      - .github/workflows/validate-windows-binaries.yml
+      - .github/workflows/validate-macos-binaries.yml
+      - .github/workflows/validate-macos-arm64-binaries.yml
+      - .github/scripts/validate_binaries.sh
+      - test/smoke_test/*
 
 jobs:
   release:

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -24,14 +24,14 @@ MODULES = [
     {
         "name": "torchvision",
         "repo": "https://github.com/pytorch/vision.git",
-        "smoke_test": "python ./vision/test/smoke_test.py",
+        "smoke_test": "python3 ./vision/test/smoke_test.py",
         "extension": "extension",
         "repo_name": "vision",
     },
     {
         "name": "torchaudio",
         "repo": "https://github.com/pytorch/audio.git",
-        "smoke_test": "python ./audio/test/smoke_test/smoke_test.py --no-ffmpeg",
+        "smoke_test": "python3 ./audio/test/smoke_test/smoke_test.py --no-ffmpeg",
         "extension": "_extension",
         "repo_name": "audio",
     },

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -16,6 +16,7 @@ gpu_arch_type = os.getenv("MATRIX_GPU_ARCH_TYPE")
 channel = os.getenv("MATRIX_CHANNEL")
 stable_version = os.getenv("MATRIX_STABLE_VERSION")
 package_type = os.getenv("MATRIX_PACKAGE_TYPE")
+target_os = os.getenv("TARGET_OS")
 
 is_cuda_system = gpu_arch_type == "cuda"
 NIGHTLY_ALLOWED_DELTA = 3
@@ -24,14 +25,14 @@ MODULES = [
     {
         "name": "torchvision",
         "repo": "https://github.com/pytorch/vision.git",
-        "smoke_test": "python3 ./vision/test/smoke_test.py",
+        "smoke_test": "./vision/test/smoke_test.py",
         "extension": "extension",
         "repo_name": "vision",
     },
     {
         "name": "torchaudio",
         "repo": "https://github.com/pytorch/audio.git",
-        "smoke_test": "python3 ./audio/test/smoke_test/smoke_test.py --no-ffmpeg",
+        "smoke_test": "./audio/test/smoke_test/smoke_test.py --no-ffmpeg",
         "extension": "_extension",
         "repo_name": "audio",
     },
@@ -212,8 +213,11 @@ def smoke_test_modules():
                 print(f"Path does not exist: {cwd}/{module['repo_name']}")
                 subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
             try:
+                smoke_test_command = f"python3 {module['smoke_test']}"
+                if target_os == 'windows':
+                    smoke_test_command = f"python {module['smoke_test']}"
                 output = subprocess.check_output(
-                    module["smoke_test"], stderr=subprocess.STDOUT, shell=True,
+                    smoke_test_command, stderr=subprocess.STDOUT, shell=True,
                     universal_newlines=True)
             except subprocess.CalledProcessError as exc:
                 raise RuntimeError(


### PR DESCRIPTION
Following error during Release validations. Looks already install nightly packages are picked rather then release :
```
pip3 install torch torchvision torchaudio
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: torch in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (2.1.0.dev20230621)
Requirement already satisfied: torchvision in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (0.16.0.dev20230621)
Requirement already satisfied: torchaudio in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (2.1.0.dev20230621)
Requirement already satisfied: jinja2 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torch) (3.1.2)
Requirement already satisfied: typing-extensions in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torch) (4.4.0)
Requirement already satisfied: filelock in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torch) (3.9.0)
Requirement already satisfied: sympy in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torch) (1.11.1)
Requirement already satisfied: networkx in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torch) (3.0rc1)
Requirement already satisfied: fsspec in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torch) (2023.4.0)
Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torchvision) (9.3.0)
Requirement already satisfied: numpy in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torchvision) (1.24.1)
Requirement already satisfied: requests in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from torchvision) (2.28.1)
Requirement already satisfied: MarkupSafe>=2.0 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from jinja2->torch) (2.1.2)
Requirement already satisfied: charset-normalizer<3,>=2 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from requests->torchvision) (2.1.1)
Requirement already satisfied: idna<4,>=2.5 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from requests->torchvision) (3.4)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from requests->torchvision) (1.26.16)
Requirement already satisfied: certifi>=2017.4.17 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from requests->torchvision) (2022.12.7)
Requirement already satisfied: mpmath>=0.19 in /Users/ec2-user/Library/Python/3.9/lib/python/site-packages (from sympy->torch) (1.2.1)
WARNING: You are using pip version 21.2.4; however, version 23.1.2 is available.
You should consider upgrading via the '/Library/Developer/CommandLineTools/usr/bin/python3 -m pip install --upgrade pip' command.
++ [[ macos-arm64 == \l\i\n\u\x ]]
++ python ./test/smoke_test/smoke_test.py
Traceback (most recent call last):
  File "/Users/ec2-user/runner/_work/builder/builder/pytorch/builder/./test/smoke_test/smoke_test.py", line 6, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```