### PR TITLE
Update build_docker.sh

### DIFF
--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -33,12 +33,8 @@ case ${GPU_ARCH_TYPE} in
         DOCKER_TAG=cuda${GPU_ARCH_VERSION}
         LEGACY_DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/manylinux-cuda${GPU_ARCH_VERSION//./}
         # Keep this up to date with the minimum version of CUDA we currently support
-        GPU_IMAGE=nvidia/cuda:10.2-devel-centos7
-        DEVTOOLSET_VERSION="9"
-        if [[ ${GPU_ARCH_VERSION:0:2} == "10" ]]; then
-            DEVTOOLSET_VERSION="7"
-        fi
-        DOCKER_GPU_BUILD_ARG="--build-arg BASE_CUDA_VERSION=${GPU_ARCH_VERSION} --build-arg DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}"
+        GPU_IMAGE=nvidia/cuda:11.4.3-devel-centos7
+        DOCKER_GPU_BUILD_ARG="--build-arg BASE_CUDA_VERSION=${GPU_ARCH_VERSION} --build-arg DEVTOOLSET_VERSION=9"
         ;;
     rocm)
         TARGET=rocm_final


### PR DESCRIPTION
Use [`nvidia/cuda:11.4.3-devel-centos7`](https://hub.docker.com/layers/nvidia/cuda/11.4.3-devel-centos7/images/sha256-e2201a4954dfd65958a6f5272cd80b968902789ff73f26151306907680356db8?context=explore) because `nvidia/cuda:10.2-devel-centos7` was deleted in accordance with [Nvidia's Container Support Policy](https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md):
> After a period of Six Months time, the EOL tags WILL BE DELETED from Docker Hub and Nvidia GPU Cloud (NGC). This deletion ensures unsupported tags (and image layers) are not left lying around for customers to continue using after they have long been abandoned.

Also delete redundant DEVTOOLSET=7 clause