### PR TITLE
Update Docker base images for conda and libtorch

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -1,6 +1,6 @@
 ARG CUDA_VERSION=10.2
 ARG BASE_TARGET=cuda${CUDA_VERSION}
-FROM nvidia/cuda:9.2-devel-centos7 as base
+FROM nvidia/cuda:11.4.3-devel-centos7 as base
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -1,6 +1,6 @@
 ARG CUDA_VERSION=10.2
 ARG BASE_TARGET=cuda${CUDA_VERSION}
-FROM nvidia/cuda:11.4.3-devel-centos7 as base
+FROM centos:7 as base
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/conda/build_docker.sh
+++ b/conda/build_docker.sh
@@ -5,11 +5,7 @@ set -eou pipefail
 export DOCKER_BUILDKIT=1
 TOPDIR=$(git rev-parse --show-toplevel)
 
-CUDA_VERSION=${CUDA_VERSION:-10.2}
-DEVTOOLSET_VERSION="9"
-if [[ ${CUDA_VERSION:0:2} == "10" ]]; then
-  DEVTOOLSET_VERSION="7"
-fi
+CUDA_VERSION=${CUDA_VERSION:-11.7}
 
 case ${CUDA_VERSION} in
   cpu)
@@ -32,7 +28,7 @@ esac
     --target final \
     --build-arg "BASE_TARGET=${BASE_TARGET}" \
     --build-arg "CUDA_VERSION=${CUDA_VERSION}" \
-    --build-arg "DEVTOOLSET_VERSION=${DEVTOOLSET_VERSION}" \
+    --build-arg "DEVTOOLSET_VERSION=9" \
     -t "pytorch/conda-builder:${DOCKER_TAG}" \
     -f "${TOPDIR}/conda/Dockerfile" \
     ${TOPDIR}

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TARGET=base
-ARG GPU_IMAGE=nvidia/cuda:11.4.3-devel-ubuntu18.04
+ARG GPU_IMAGE=ubuntu:18.04
 FROM ${GPU_IMAGE} as base
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TARGET=base
-ARG GPU_IMAGE=nvidia/cuda:10.2-devel-ubuntu18.04
+ARG GPU_IMAGE=nvidia/cuda:11.4.3-devel-ubuntu18.04
 FROM ${GPU_IMAGE} as base
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -5,7 +5,7 @@ FROM ${GPU_IMAGE} as base
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get clean && apt-get update
-RUN apt-get install -y curl locales git-all autoconf automake make cmake wget unzip
+RUN apt-get install -y curl locales g++ git-all autoconf automake make cmake wget unzip
 # Just add everything as a safe.directory for git since these will be used in multiple places with git
 RUN git config --global --add safe.directory '*'
 

--- a/libtorch/build_docker.sh
+++ b/libtorch/build_docker.sh
@@ -15,13 +15,13 @@ case ${GPU_ARCH_TYPE} in
     cpu)
         BASE_TARGET=cpu
         DOCKER_TAG=cpu
-        GPU_IMAGE=nvidia/cuda:10.2-devel-ubuntu18.04
+        GPU_IMAGE=nvidia/cuda:11.4.3-devel-ubuntu18.04
         DOCKER_GPU_BUILD_ARG=""
         ;;
     cuda)
         BASE_TARGET=cuda${GPU_ARCH_VERSION}
         DOCKER_TAG=cuda${GPU_ARCH_VERSION}
-        GPU_IMAGE=nvidia/cuda:10.2-devel-ubuntu18.04
+        GPU_IMAGE=nvidia/cuda:11.4.3-devel-ubuntu18.04
         DOCKER_GPU_BUILD_ARG=""
         ;;
     rocm)

--- a/libtorch/build_docker.sh
+++ b/libtorch/build_docker.sh
@@ -15,13 +15,13 @@ case ${GPU_ARCH_TYPE} in
     cpu)
         BASE_TARGET=cpu
         DOCKER_TAG=cpu
-        GPU_IMAGE=nvidia/cuda:11.4.3-devel-ubuntu18.04
+        GPU_IMAGE=ubuntu:18.04
         DOCKER_GPU_BUILD_ARG=""
         ;;
     cuda)
         BASE_TARGET=cuda${GPU_ARCH_VERSION}
         DOCKER_TAG=cuda${GPU_ARCH_VERSION}
-        GPU_IMAGE=nvidia/cuda:11.4.3-devel-ubuntu18.04
+        GPU_IMAGE=ubuntu:18.04
         DOCKER_GPU_BUILD_ARG=""
         ;;
     rocm)


### PR DESCRIPTION
Followup after https://github.com/pytorch/builder/pull/1446

CUDA-10.2 and moreover CUDA-9.2 docker images are gone per [Nvidia's Container Support Policy](https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md):
> After a period of Six Months time, the EOL tags WILL BE DELETED from Docker Hub and Nvidia GPU Cloud (NGC). This deletion ensures unsupported tags (and image layers) are not left lying around for customers to continue using after they have long been abandoned.

Also, as all our Docker script install CUDA toolkit anyway, what's the point of using `nvidia/cuda` images at all instead of `centos:7`/`ubuntu:18.04` that former are based on, according to https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.4.3/centos7/base/Dockerfile

Explicitly install `g++` to `libtorch/Docker` base image, as it's needed by `patchelf`

Please note, that `libtorch/Docker` can not be completed without buildkit, as `rocm` step depends on `python3` which is not available in `cpu` image
