### PR TITLE
Fix aarch64 nightly builds

### DIFF
--- a/aarch64_linux/aarch64_ci_build.sh
+++ b/aarch64_linux/aarch64_ci_build.sh
@@ -37,7 +37,7 @@ conda --version
 # ubuntu's libgfortran.a which is compiled with -fPIC
 ###############################################################################
 cd ~/
-curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-8ubuntu1_arm64.deb
+curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-9ubuntu1_arm64.deb
 ar x ~/libgfortran-10-dev.deb
 tar --use-compress-program=unzstd -xvf data.tar.zst -C ~/
 cp -f ~/usr/lib/gcc/aarch64-linux-gnu/10/libgfortran.a /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/


### PR DESCRIPTION
Fixes nightly failures:
https://hud.pytorch.org/hud/pytorch/pytorch/nightly/1?per_page=50&name_filter=aarch64

Following package:
http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-8ubuntu1_arm64.deb

Was replaced by:
http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-9ubuntu1_arm64.deb

Test:
```
atalman@devvm18003.prn0 /data/users/atalman/builder (fix_aarch64)]$ curl -O http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-9ubuntu1_arm64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  452k  100  452k    0     0   374k      0  0:00:01  0:00:01 --:--:--  374k
[atalman@devvm18003.prn0 /data/users/atalman/builder (fix_aarch64)]$ ls
[atalman@devvm18003.prn0 /data/users/atalman/builder (fix_aarch64)]$ ar x libgfortran-10-dev_10.4.0-9ubuntu1_arm64.deb 
[atalman@devvm18003.prn0 /data/users/atalman/builder (fix_aarch64)]$ ls
[atalman@devvm18003.prn0 /data/users/atalman/builder (fix_aarch64)]$ curl -O http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.4.0-8ubuntu1_arm64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   278  100   278    0     0    627      0 --:--:-- --:--:-- --:--:--   627
[atalman@devvm18003.prn0 /data/users/atalman/builder (fix_aarch64)]$ ar x libgfortran-10-dev_10.4.0-8ubuntu1_arm64.deb 
ar: libgfortran-10-dev_10.4.0-8ubuntu1_arm64.deb: File format not recognized
```