### PR TITLE
[nightly] Pin miniconda install to py310_23.5.2 for macos and windows

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -201,7 +201,7 @@ if [[ "$(uname)" == 'Darwin' ]]; then
     miniconda_sh="${MAC_PACKAGE_WORK_DIR}/miniconda.sh"
     rm -rf "$tmp_conda"
     rm -f "$miniconda_sh"
-    retry curl -sS https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o "$miniconda_sh"
+    retry curl -sS https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-MacOSX-x86_64.sh -o "$miniconda_sh"
     chmod +x "$miniconda_sh" && \
         "$miniconda_sh" -b -p "$tmp_conda" && \
         rm "$miniconda_sh"
@@ -212,7 +212,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     export miniconda_exe="${WIN_PACKAGE_WORK_DIR}\\miniconda.exe"
     rm -rf "$tmp_conda"
     rm -f "$miniconda_exe"
-    curl -sSk https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o "$miniconda_exe"
+    curl -sSk https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Windows-x86_64.exe -o "$miniconda_exe"
     "$SOURCE_DIR/install_conda.bat" && rm "$miniconda_exe"
     pushd $tmp_conda
     export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"


### PR DESCRIPTION
This fixes nightly conda build for macos and windows:
https://hud.pytorch.org/hud/pytorch/pytorch/nightly/1?per_page=50&name_filter=conda

Working build uses python 3.10:
```
2023-07-11T07:07:07.0675090Z + retry curl -sS https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /Users/runner/work/_temp/miniconda.sh
2023-07-11T07:07:07.0675910Z + curl -sS https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /Users/runner/work/_temp/miniconda.sh
2023-07-11T07:07:07.8608730Z + chmod +x /Users/runner/work/_temp/miniconda.sh
2023-07-11T07:07:07.8632780Z + /Users/runner/work/_temp/miniconda.sh -b -p /Users/runner/work/_temp/conda
2023-07-11T07:07:07.8835460Z PREFIX=/Users/runner/work/_temp/conda
2023-07-11T07:07:08.1268170Z Unpacking payload ...
2023-07-11T07:07:09.4981680Z 
2023-07-11T07:07:18.9638590Z   0%|          | 0/43 [00:00<?, ?it/s]
2023-07-11T07:07:18.9639610Z Extracting : python-3.10.10-h218abb5_2.conda:   0%|          | 0/43 [00:09<?, ?it/s]
2023-07-11T07:07:18.9640690Z Extracting : python-3.10.10-h218abb5_2.conda:   2%|▏         | 1/43 [00:09<06:37,  9.47s/it]
2023-07-11T07:07:18.9641250Z Extracting : idna-3.4-py310hecd8cb5_0.conda:   2%|▏         | 1/43 [00:09<06:37,  9.47s/it] 
2023-07-11T07:07:18.9641740Z Extracting : zstandard-0.19.0-py310h6c40b1e_0.conda:   5%|▍         | 2/43 [00:09<06:28,  9.47s/it]
2023-07-11T07:07:18.9643140Z Extracting : sqlite-3.41.1-h6c40b1e_0.conda:   7%|▋         | 3/43 [00:09<06:18,  9.47s/it]        
2023-07-11T07:07:18.9643630Z Extracting : xz-5.2.10-h6c40b1e_1.conda:   9
```

Failing uses 3.11:
```
023-07-12T18:46:04.7640850Z + retry curl -sS https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /Users/runner/work/_temp/miniconda.sh
2023-07-12T18:46:04.7642650Z + curl -sS https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /Users/runner/work/_temp/miniconda.sh
2023-07-12T18:46:05.9750850Z + chmod +x /Users/runner/work/_temp/miniconda.sh
2023-07-12T18:46:05.9777850Z + /Users/runner/work/_temp/miniconda.sh -b -p /Users/runner/work/_temp/conda
2023-07-12T18:46:06.0046890Z PREFIX=/Users/runner/work/_temp/conda
2023-07-12T18:46:06.3156340Z Unpacking payload ...
2023-07-12T18:46:08.0006310Z 
2023-07-12T18:46:08.6788990Z   0%|          | 0/66 [00:00<?, ?it/s]
2023-07-12T18:46:08.6791670Z Extracting : ruamel.yaml-0.17.21-py311h6c40b1e_0.conda:   0%|          | 0/66 [00:00<?, ?it/s]
2023-07-12T18:46:08.6795900Z Extracting : ruamel.yaml-0.17.21-py311h6c40b1e_0.conda:   2%|▏         | 1/66 [00:00<00:44,  1.47it/s]
2023-07-12T18:46:12.5678770Z Extracting : pycosat-0.6.4-py311h6c40b1e_0.conda:   2%|▏         | 1/66 [00:00<00:44,  1.47it/s]      
2023-07-12T18:46:12.5680620Z Extracting : krb5-1.20.1-h428f121_1.conda:   3%|▎         | 2/66 [00:04<00:43,  1.47it/s]       
2023-07-12T18:46:12.5800100Z Extracting : krb5-1.20.1-h428f121_1.conda:   5%|▍         | 3/66 [00:04<01:41,  1.62s/it]
2023-07-12T18:46:17.5207640Z Extracting : libcurl-8.1.1-hf20ceda_1.conda:   5%|▍         | 3/66 [00:04<01:41,  1.62s/it]
2023-07-12T18:46:17.5209650Z Extracting : setuptools-67.8.0-py311hecd8cb5_0.conda:   6%|▌         | 4/66 [00:09<01:40,  1.62s/it]
2023-07-12T18:46:17.5212270Z Extracting : setuptools-67.8.0-py311hecd8cb5_0.conda:   8%|▊         | 5/66 [00:09<02:05,  2.06s/it]
2023-07-12T18:46:17.5213100Z Extracting : pyopenssl-23.0.0-py311hecd8cb5_0.conda:   8%|▊         | 5/66 [00:09<02:05,  2.06s/it] 
2023-07-12T18:46:17.5213630Z Extracting : yaml-cpp-0.7.0-he9d5cce_1.conda:   9%|▉         | 6/66 [00:09<02:03,  2.06s/it]       
2023-07-12T18:46:23.3632200Z Extracting : python.app-3-py311h6c40b1e_0.conda:  11%|█         | 7/66 [00:09<02:01,  2.06s/it]
2023-07-12T18:46:23.3632790Z Extracting : python-3.11.4-hf27a42d_0.conda:  12%|█▏        | 8/66 [00:15<01:59,  2.06s/it]    
2023-07-12T18:46:23.3634660Z Extracting : python-3.11.4-hf27a42d_0.conda:  14%|█
```

And failure:
```
UnsatisfiableError: The following specifications were found
to be incompatible with the existing python installation in your environment:

Specifications:

  - conda==22.9.0 -> python[version='>=3.10,<3.11.0a0|>=3.7,<3.8.0a0|>=3.8,<3.9.0a0|>=3.9,<3.10.0a0']

Your python: python=3.11
```