### PR TITLE
Add pytorch-triton-rocm as an install dependency for ROCm

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -215,11 +215,12 @@ fi
 # Add triton install dependency
 if [[ $(uname) == "Linux" ]]; then
     TRITON_SHORTHASH=$(cut -c1-10 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton-rocm.txt)
+    TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 
     if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
-        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton-rocm==2.1.0+${TRITON_SHORTHASH}"
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton-rocm==${TRITON_VERSION}+${TRITON_SHORTHASH}"
     else
-        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton-rocm==2.1.0+${TRITON_SHORTHASH}"
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton-rocm==${TRITON_VERSION}+${TRITON_SHORTHASH}"
     fi
 fi
 

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -212,6 +212,17 @@ elif [[ $ROCM_INT -ge 50600 ]]; then
     DEPS_AUX_DSTLIST+=(${RCCL_SHARE_FILES[@]/#/$RCCL_SHARE_DST/})
 fi
 
+# Add triton install dependency
+if [[ $(uname) == "Linux" ]]; then
+    TRITON_SHORTHASH=$(cut -c1-10 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton-rocm.txt)
+
+    if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton-rocm==2.1.0+${TRITON_SHORTHASH}"
+    else
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton-rocm==2.1.0+${TRITON_SHORTHASH}"
+    fi
+fi
+
 
 echo "PYTORCH_ROCM_ARCH: ${PYTORCH_ROCM_ARCH}"
 


### PR DESCRIPTION
This mimics the setup for CUDA wheels, ensuring that PyTorch ROCm wheels from pytorch.org will have pytorch-triton-rocm as an install dependency, instead of an extra_install dependency as specified in setup.py: https://github.com/pytorch/pytorch/blob/9c225c9b9a07eedaede9c27c74188181184fb022/setup.py#L1034

The only difference from the CUDA implementation in [manywheel/build_cuda.sh](https://github.com/pytorch/builder/blob/e67e20964175d96005d9721ee76bf20fa1848369/manywheel/build_cuda.sh#L262) is that we use the file `.ci/docker/ci_commit_pins/triton-rocm.txt` from the PyTorch repo, as there is no symlinked triton hash file for ROCm in `.github/ci_commit_pins/`.

cc @jeffdaily @dllehr-amd 