### PR TITLE
Remove unused parameter to limit-win-builds from validation workflows

### DIFF
--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -22,10 +22,6 @@ on:
         default: ""
         required: false
         type: string
-      limit-win-builds:
-        description: "Limit windows builds to single python/cuda config"
-        default: "disable"
-        type: string
   workflow_dispatch:
     inputs:
       os:
@@ -53,11 +49,6 @@ on:
         default: ""
         required: false
         type: string
-      limit-win-builds:
-        description: "Limit windows builds to single python/cuda config"
-        default: "disable"
-        required: false
-        type: string
 
 jobs:
   win:
@@ -66,7 +57,6 @@ jobs:
     with:
       channel: ${{ inputs.channel }}
       ref: ${{ inputs.ref || github.ref }}
-      limit-win-builds: ${{ inputs.limit-win-builds }}
 
   linux:
     if:  inputs.os == 'linux' || inputs.os == 'all'

--- a/.github/workflows/validate-nightly-binaries.yml
+++ b/.github/workflows/validate-nightly-binaries.yml
@@ -24,4 +24,3 @@ jobs:
     with:
       channel: nightly
       os: all
-      limit-win-builds: enable

--- a/.github/workflows/validate-release-binaries.yml
+++ b/.github/workflows/validate-release-binaries.yml
@@ -33,4 +33,3 @@ jobs:
     with:
       channel: release
       os: all
-      limit-win-builds: enable

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -12,10 +12,6 @@ on:
         default: ""
         required: false
         type: string
-      limit-win-builds:
-        description: "Limit windows builds to single python/cuda config"
-        default: "disable"
-        type: string
   workflow_dispatch:
     inputs:
       channel:
@@ -32,11 +28,6 @@ on:
         default: ""
         required: false
         type: string
-      limit-win-builds:
-        description: "Limit windows builds to single python/cuda config"
-        default: "disable"
-        required: false
-        type: string
 
 jobs:
   generate-windows-matrix:
@@ -45,7 +36,6 @@ jobs:
       package-type: all
       os: windows
       channel: ${{ inputs.channel }}
-      limit-win-builds: ${{ inputs.limit-win-builds }}
 
   win:
     needs: generate-windows-matrix


### PR DESCRIPTION
Follow up after: https://github.com/pytorch/test-infra/pull/4434
Builds are limited to single python 3.8 in test-infra anyways. No reason to keep this parameter around.