### PR TITLE
Dynamic MKL windows

### DIFF
--- a/conda/pytorch-nightly/bld.bat
+++ b/conda/pytorch-nightly/bld.bat
@@ -34,11 +34,6 @@ if "%desired_cuda%" == "12.1" (
 
 set DISTUTILS_USE_SDK=1
 
-curl https://s3.amazonaws.com/ossci-windows/mkl_2020.2.254.7z -k -O
-7z x -aoa mkl_2020.2.254.7z -omkl
-set CMAKE_INCLUDE_PATH=%SRC_DIR%\mkl\include
-set LIB=%SRC_DIR%\mkl\lib;%LIB%
-
 set libuv_ROOT=%PREFIX%\Library
 echo libuv_ROOT=%libuv_ROOT%
 

--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -23,7 +23,8 @@ requirements:
     - mkl-include # [x86_64]
     - mkl=2020.2 # [py <= 311 and x86_64 and not win]
     - mkl=2023.1 # [py >= 312 and x86_64]
-    - mkl=2021.4 # [x86_64 and win and py <= 311]
+    - mkl-devel=2021.4.0 # [x86_64 and win and py<=311]
+    - mkl-devel=2023.1 # [x86_64 and win and py>=312]
     {% endif %}
     - typing_extensions
     - ninja
@@ -41,7 +42,9 @@ requirements:
   run:
     - python
     {% if cross_compile_arm64 == 0 %}
-    - mkl >=2018 # [x86_64]
+    - mkl >=2018 # [x86_64 and not win]
+    - mkl=2021.4 # [x86_64 and win and py <= 311]
+    - mkl=2023.1 # [x86_64 and win and py >= 312]
     {% endif %}
     - libuv # [win]
     - intel-openmp # [win]

--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -67,10 +67,6 @@ exit /B 1
 :: Install MKL
 rmdir /s /q mkl
 del mkl_2020.2.254.7z
-curl https://s3.amazonaws.com/ossci-windows/mkl_2020.2.254.7z -k -O
-7z x -aoa mkl_2020.2.254.7z -omkl
-set CMAKE_INCLUDE_PATH=%cd%\mkl\include
-set LIB=%cd%\mkl\lib;%LIB%
 
 :: Download MAGMA Files on CUDA builds
 set MAGMA_VERSION=2.5.4
@@ -126,7 +122,7 @@ for %%v in (%DESIRED_PYTHON_PREFIX%) do (
     ) else (
         set "PATH=%CONDA_HOME%\envs\%%v;%CONDA_HOME%\envs\%%v\scripts;%CONDA_HOME%\envs\%%v\Library\bin;%ORIG_PATH%"
     )
-    pip install ninja
+    pip install ninja mkl-include==2021.4.0 mkl-devel==2021.4.0
     @setlocal
     :: Set Flags
     if not "%CUDA_VERSION%"=="cpu" (

--- a/windows/internal/copy.bat
+++ b/windows/internal/copy.bat
@@ -11,6 +11,10 @@ copy "%CUDA_PATH%\extras\CUPTI\lib64\cupti64_*.dll*" pytorch\torch\lib
 
 copy "C:\Program Files\NVIDIA Corporation\NvToolsExt\bin\x64\nvToolsExt64_1.dll*" pytorch\torch\lib
 copy "%CONDA_LIB_PATH%\libiomp*5md.dll" pytorch\torch\lib
+IF "%PACKAGE_TYPE%"=="libtorch" (
+    copy "%CONDA_LIB_PATH%\mkl_intel_thread.1.dll" pytorch\torch\lib
+    copy "%CONDA_LIB_PATH%\mkl_core.1.dll" pytorch\torch\lib
+)
 :: Should be set in build_pytorch.bat
 copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib
 

--- a/windows/internal/copy_cpu.bat
+++ b/windows/internal/copy_cpu.bat
@@ -1,3 +1,8 @@
 copy "%CONDA_LIB_PATH%\libiomp*5md.dll" pytorch\torch\lib
 :: Should be set in build_pytorch.bat
 copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib
+
+IF "%PACKAGE_TYPE%"=="libtorch" (
+    copy "%CONDA_LIB_PATH%\mkl_intel_thread.1.dll" pytorch\torch\lib
+    copy "%CONDA_LIB_PATH%\mkl_core.1.dll" pytorch\torch\lib
+)

--- a/windows/internal/smoke_test.bat
+++ b/windows/internal/smoke_test.bat
@@ -54,7 +54,7 @@ if errorlevel 1 exit /b 1
 
 set "PATH=%CD%\Python%PYTHON_VERSION%\Scripts;%CD%\Python;%PATH%"
 
-pip install -q numpy protobuf "mkl>=2019"
+pip install -q numpy protobuf 
 if errorlevel 1 exit /b 1
 
 for /F "delims=" %%i in ('where /R "%PYTORCH_FINAL_PACKAGE_DIR:/=\%" *.whl') do pip install "%%i"
@@ -87,14 +87,18 @@ set "PATH=%CONDA_HOME%;%CONDA_HOME%\scripts;%CONDA_HOME%\Library\bin;%PATH%"
 
 conda create -qyn testenv python=%DESIRED_PYTHON%
 if errorlevel 1 exit /b 1
-
+call conda install -yq conda-build 
+if errorlevel 1 exit /b 1
 call %CONDA_HOME%\condabin\activate.bat testenv
 if errorlevel 1 exit /b 1
+set "NO_ARCH_PATH=%PYTORCH_FINAL_PACKAGE_DIR:/=\%\noarch"
+mkdir %NO_ARCH_PATH%
+for /F "delims=" %%i in ('where /R "%PYTORCH_FINAL_PACKAGE_DIR:/=\%" *') do xcopy "%%i" %NO_ARCH_PATH% /Y
+if ERRORLEVEL 1 exit /b 1
+call conda index %PYTORCH_FINAL_PACKAGE_DIR%
+if errorlevel 1 exit /b 1
+call conda install -yq -c "file:///%PYTORCH_FINAL_PACKAGE_DIR%" pytorch==%PYTORCH_BUILD_VERSION% -c pytorch -c numba/label/dev -c nvidia
 
-:: do conda install to make sure all the dependencies are installed
-:: Install numpy see: https://github.com/pytorch/pytorch/issues/107228
-:: todo: Remove numpy install once the issue above is resolved
-call conda install -yq numpy pytorch %CONDA_EXTRA_ARGS%
 if ERRORLEVEL 1 exit /b 1
 
 set /a CUDA_VER=%CUDA_VERSION%
@@ -103,8 +107,7 @@ set CUDA_VER_MINOR=%CUDA_VERSION:~-1,1%
 set CUDA_VERSION_STR=%CUDA_VER_MAJOR%.%CUDA_VER_MINOR%
 
 :: Install package we just build
-for /F "delims=" %%i in ('where /R "%PYTORCH_FINAL_PACKAGE_DIR:/=\%" *.tar.bz2') do call conda install -yq "%%i" --offline
-if ERRORLEVEL 1 exit /b 1
+
 
 :smoke_test
 python -c "import torch"


### PR DESCRIPTION
Updated MKL on Windows to 2021.4.0 in order to have dynamic version on Windows.
Changed the way conda smoke test is done on Windows by creating a local channel in order to test properly that the updated dependency is downloaded.