### PR TITLE
Set FORCE_RPATH for PyTorch ROCm wheels

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -14,6 +14,8 @@ export USE_STATIC_NCCL=1
 export ATEN_STATIC_CUDA=1
 export USE_CUDA_STATIC_LINK=1
 export INSTALL_TEST=0 # dont install test binaries into site-packages
+# Set RPATH instead of RUNPATH when using patchelf to avoid LD_LIBRARY_PATH override
+export FORCE_RPATH="--force-rpath"
 
 # Keep an array of cmake variables to add to
 if [[ -z "$CMAKE_ARGS" ]]; then


### PR DESCRIPTION
Using PyTorch ROCm wheels in an environment with ROCm pre-installed can result in errors when running PyTorch. This is because, if LD_LIBRARY_PATH is set in the environment to point to the ROCm installation, it will override the RUNPATH setting for the PyTorch libraries (eg. `libtorch_hip.so`) in the wheel package, thus potentially linking to incompatible libraries.

This PR sets the RPATH instead of RUNPATH, so that LD_LIBRARY_PATH will not interfere with the PyTorch libraries linking to the ROCm libraries packaged in the wheel.