### PR TITLE
[aarch64][CICD]Add aarch64 docker image build.

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cpu-aarch64:
-    runs-on: ubuntu-22.04
+    runs-on: linux.t4g.2xlarge
     env:
       GPU_ARCH_TYPE: cpu-aarch64
     steps:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - .github/workflows/build-manywheel-images.yml
       - manywheel/Dockerfile
+      - manywheel/Dockerfile_aarch64
       - manywheel/Dockerfile_cxx11-abi
       - manywheel/build_docker.sh
       - 'common/*'
@@ -19,6 +20,7 @@ on:
     paths:
       - .github/workflows/build-manywheel-images.yml
       - manywheel/Dockerfile
+      - manywheel/Dockerfile_aarch64
       - manywheel/Dockerfile_cxx11-abi
       - 'common/*'
       - manywheel/build_docker.sh
@@ -71,6 +73,21 @@ jobs:
           manywheel/build_docker.sh
   build-docker-cpu:
     runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout PyTorch
+        uses: actions/checkout@v3
+      - name: Authenticate if WITH_PUSH
+        run: |
+          if [[ "${WITH_PUSH}" == true ]]; then
+            echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_ID}" --password-stdin
+          fi
+      - name: Build Docker Image
+        run: |
+          manywheel/build_docker.sh
+  build-docker-cpu-aarch64:
+    runs-on: ubuntu-22.04
+    env:
+      GPU_ARCH_TYPE: cpu-aarch64
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v3

--- a/aarch64_linux/aarch64_ci_setup.sh
+++ b/aarch64_linux/aarch64_ci_setup.sh
@@ -10,12 +10,6 @@ PATH=/opt/conda/bin:$PATH
 LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
 
 ###############################################################################
-# Install OS dependent packages
-###############################################################################
-yum -y install epel-release
-yum -y install less zstd libgomp
-
-###############################################################################
 # Install conda
 # disable SSL_verify due to getting "Could not find a suitable TLS CA certificate bundle, invalid path"
 # when using Python version, less than the conda latest
@@ -26,19 +20,6 @@ chmod +x /mambaforge.sh
 /mambaforge.sh -b -p /opt/conda
 rm /mambaforge.sh
 /opt/conda/bin/conda config --set ssl_verify False
-/opt/conda/bin/conda install -y -c conda-forge python=${DESIRED_PYTHON} numpy pyyaml setuptools patchelf pygit2 openblas
+/opt/conda/bin/conda install -y -c conda-forge python=${DESIRED_PYTHON} numpy pyyaml setuptools patchelf pygit2 openblas ninja scons
 python --version
 conda --version
-
-###############################################################################
-# Exec libglfortran.a hack
-#
-# libgfortran.a from quay.io/pypa/manylinux2014_aarch64 is not compiled with -fPIC.
-# This causes __stack_chk_guard@@GLIBC_2.17 on pytorch build. To solve, get
-# ubuntu's libgfortran.a which is compiled with -fPIC
-###############################################################################
-cd ~/
-curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.5.0-1ubuntu1_arm64.deb
-ar x ~/libgfortran-10-dev.deb
-tar --use-compress-program=unzstd -xvf data.tar.zst -C ~/
-cp -f ~/usr/lib/gcc/aarch64-linux-gnu/10/libgfortran.a /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/

--- a/manywheel/Dockerfile_aarch64
+++ b/manywheel/Dockerfile_aarch64
@@ -4,11 +4,6 @@ FROM quay.io/pypa/manylinux2014_aarch64 as base
 # Graviton needs GCC 10 for the build
 ARG DEVTOOLSET_VERSION=10
 
-# There is a bug with manylinux and CentOS docker (AML2 linux) and makes
-# the yum package system slow as the ulimit is to high. Setting the
-# ulimit to 1024 provides a large boost in installing yum packages.
-ARG ULIMIT="ulimit -n 1024"
-
 # Language variabes
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
@@ -16,9 +11,9 @@ ENV LANGUAGE=en_US.UTF-8
 
 # Installed needed OS packages. This is to support all
 # the binary builds (torch, vision, audio, text, data)
-RUN ${ULIMIT} && yum -y install epel-release
-RUN ${ULIMIT} && yum -y update
-RUN ${ULIMIT} && yum install -y \
+RUN yum -y install epel-release
+RUN yum -y update
+RUN yum install -y \
   autoconf \
   automake \
   bison \

--- a/manywheel/Dockerfile_aarch64
+++ b/manywheel/Dockerfile_aarch64
@@ -1,0 +1,91 @@
+FROM quay.io/pypa/manylinux2014_aarch64 as base
+
+
+# Graviton needs GCC 10 for the build
+ARG DEVTOOLSET_VERSION=10
+
+# There is a bug with manylinux and CentOS docker (AML2 linux) and makes
+# the yum package system slow as the ulimit is to high. Setting the
+# ulimit to 1024 provides a large boost in installing yum packages.
+ARG ULIMIT="ulimit -n 1024"
+
+# Language variabes
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+
+# Installed needed OS packages. This is to support all
+# the binary builds (torch, vision, audio, text, data)
+RUN ${ULIMIT} && yum -y install epel-release
+RUN ${ULIMIT} && yum -y update
+RUN ${ULIMIT} && yum install -y \
+  autoconf \
+  automake \
+  bison \
+  bzip2 \
+  curl \
+  diffutils \
+  file \
+  git \
+  make \
+  patch \
+  perl \
+  unzip \
+  util-linux \
+  wget \
+  which \
+  xz \
+  yasm \
+  less \
+  zstd \
+  libgomp \
+  devtoolset-${DEVTOOLSET_VERSION}-gcc \
+  devtoolset-${DEVTOOLSET_VERSION}-gcc-c++ \
+  devtoolset-${DEVTOOLSET_VERSION}-gcc-gfortran \
+  devtoolset-${DEVTOOLSET_VERSION}-binutils
+
+# Ensure the expected devtoolset is used
+ENV PATH=/opt/rh/devtoolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/devtoolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
+
+
+# git236+ would refuse to run git commands in repos owned by other users
+# Which causes version check to fail, as pytorch repo is bind-mounted into the image
+# Override this behaviour by treating every folder as safe
+# For more details see https://github.com/pytorch/pytorch/issues/78659#issuecomment-1144107327
+RUN git config --global --add safe.directory "*"
+
+
+###############################################################################
+# libglfortran.a hack
+#
+# libgfortran.a from quay.io/pypa/manylinux2014_aarch64 is not compiled with -fPIC.
+# This causes __stack_chk_guard@@GLIBC_2.17 on pytorch build. To solve, get
+# ubuntu's libgfortran.a which is compiled with -fPIC
+# NOTE: Need a better way to get this library as Ubuntu's package can be removed by the vender, or changed
+###############################################################################
+RUN cd ~/ \
+  && curl -L -o ~/libgfortran-10-dev.deb http://ports.ubuntu.com/ubuntu-ports/pool/universe/g/gcc-10/libgfortran-10-dev_10.5.0-1ubuntu1_arm64.deb \
+  && ar x ~/libgfortran-10-dev.deb \
+  && tar --use-compress-program=unzstd -xvf data.tar.zst -C ~/ \
+  && cp -f ~/usr/lib/gcc/aarch64-linux-gnu/10/libgfortran.a /opt/rh/devtoolset-10/root/usr/lib/gcc/aarch64-redhat-linux/10/
+
+# install cmake
+RUN yum install -y cmake3 && \
+    ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+FROM base as openssl
+# Install openssl (this must precede `build python` step)
+# (In order to have a proper SSL module, Python is compiled
+# against a recent openssl [see env vars above], which is linked
+# statically. We delete openssl afterwards.)
+ADD ./common/install_openssl.sh install_openssl.sh
+RUN bash ./install_openssl.sh && rm install_openssl.sh
+ENV SSL_CERT_FILE=/opt/_internal/certs.pem
+
+FROM openssl as final
+# remove unncessary python versions
+RUN rm -rf /opt/python/cp26-cp26m /opt/_internal/cpython-2.6.9-ucs2
+RUN rm -rf /opt/python/cp26-cp26mu /opt/_internal/cpython-2.6.9-ucs4
+RUN rm -rf /opt/python/cp33-cp33m /opt/_internal/cpython-3.3.6
+RUN rm -rf /opt/python/cp34-cp34m /opt/_internal/cpython-3.4.6

--- a/manywheel/build_all_docker.sh
+++ b/manywheel/build_all_docker.sh
@@ -7,6 +7,8 @@ TOPDIR=$(git rev-parse --show-toplevel)
 GPU_ARCH_TYPE=cpu "${TOPDIR}/manywheel/build_docker.sh"
 MANYLINUX_VERSION=2014 GPU_ARCH_TYPE=cpu "${TOPDIR}/manywheel/build_docker.sh"
 
+GPU_ARCH_TYPE=cpu-aarch64 "${TOPDIR}/manywheel/build_docker.sh"
+
 GPU_ARCH_TYPE=cpu-cxx11-abi "${TOPDIR}/manywheel/build_docker.sh"
 
 for cuda_version in 12.1 11.8; do

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -20,6 +20,14 @@ case ${GPU_ARCH_TYPE} in
         GPU_IMAGE=centos:7
         DOCKER_GPU_BUILD_ARG=" --build-arg DEVTOOLSET_VERSION=9"
         ;;
+    cpu-aarch64)
+        TARGET=final
+        DOCKER_TAG=cpu-aarch64
+        LEGACY_DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/manylinux-cpu-aarch64
+        GPU_IMAGE=arm64v8/centos:7
+        DOCKER_GPU_BUILD_ARG=" --build-arg DEVTOOLSET_VERSION=10"
+        MANY_LINUX_VERSION="aarch64"
+        ;;
     cpu-cxx11-abi)
         TARGET=final
         DOCKER_TAG=cpu-cxx11-abi


### PR DESCRIPTION
# Description of changes
* Formatting cleanup for `aarch64_wheel_ci_build.py`
* Move `scons` and `ninja` install from build python to setup script
* Adding `Dockerfile_aarch64`
* Update docker workflows to include aarch64 Dockerfile to build the aarch64 docker image.

The new docker image with the updated aarch64 pytorch_ci_build was tested [here](https://github.com/xncqr/pytorch/actions/runs/5802108021)