### PR TITLE
Add no-sudo to linux-aarch64 tests

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -61,6 +61,7 @@ jobs:
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
       binary-matrix: ${{ toJSON(matrix) }}
+      no-sudo: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"


### PR DESCRIPTION
Linux aarch64 workers do not support sudo, hence this fix