### PR TITLE
Remove linux-aarch64 installation workaround

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -69,8 +69,6 @@ jobs:
         source ./aarch64_linux/aarch64_ci_setup.sh
         echo "/opt/conda/bin" >> $GITHUB_PATH
 
-        MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"index-url"/"extra-index-url"}
-
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="linux-aarch64"
         export TORCH_ONLY=${{ inputs.torchonly }}


### PR DESCRIPTION
After https://github.com/pytorch/test-infra/pull/4536 this is not needed anymore