### PR TITLE
[Release-Only] Use the correct triton version for 2.1.0 release

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -274,9 +274,8 @@ else
         exit 1
     fi
     if [[ "$OSTYPE" != "msys" ]]; then
-        # TODO: Remove me when Triton has a proper release channel
-        TRITON_SHORTHASH=$(cut -c1-10 $pytorch_rootdir/.github/ci_commit_pins/triton.txt)
-        export CONDA_TRITON_CONSTRAINT="    - torchtriton==2.1.0+${TRITON_SHORTHASH}"
+        # Prepare for 2.1.0 release
+        export CONDA_TRITON_CONSTRAINT="    - torchtriton==2.1.0"
     fi
 
     build_string_suffix="cuda${CUDA_VERSION}_cudnn${CUDNN_VERSION}_${build_string_suffix}"

--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -257,14 +257,14 @@ else
     exit 1
 fi
 
-# TODO: Remove me when Triton has a proper release channel
+# Prepare for 2.1.0 release
 if [[ $(uname) == "Linux" ]]; then
-    TRITON_SHORTHASH=$(cut -c1-10 $PYTORCH_ROOT/.github/ci_commit_pins/triton.txt)
+    TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 
     if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
-        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton==2.1.0+${TRITON_SHORTHASH}"
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton==${TRITON_VERSION}"
     else
-        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton==2.1.0+${TRITON_SHORTHASH}"
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton==${TRITON_VERSION}"
     fi
 fi
 

--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -214,15 +214,14 @@ elif [[ $ROCM_INT -ge 50600 ]]; then
     DEPS_AUX_DSTLIST+=(${RCCL_SHARE_FILES[@]/#/$RCCL_SHARE_DST/})
 fi
 
-# Add triton install dependency
+# Prepare for 2.1.0 release
 if [[ $(uname) == "Linux" ]]; then
-    TRITON_SHORTHASH=$(cut -c1-10 $PYTORCH_ROOT/.ci/docker/ci_commit_pins/triton-rocm.txt)
     TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
 
     if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
-        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton-rocm==${TRITON_VERSION}+${TRITON_SHORTHASH}"
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="pytorch-triton-rocm==${TRITON_VERSION}"
     else
-        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton-rocm==${TRITON_VERSION}+${TRITON_SHORTHASH}"
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="${PYTORCH_EXTRA_INSTALL_REQUIREMENTS} | pytorch-triton-rocm==${TRITON_VERSION}"
     fi
 fi
 


### PR DESCRIPTION
Part of https://github.com/pytorch/pytorch/issues/108154, PyTorch RC now uses the correct version Triton version