### PR TITLE
Torchmetrics in S3 Index

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -85,6 +85,7 @@ PACKAGE_ALLOW_LIST = {
     "torchcsprng",
     "torchdata",
     "torchdistx",
+    "torchmetrics",
     "torchrec",
     "torchtext",
     "torchvision",


### PR DESCRIPTION
We will need the stable torchmetrics wheel in the S3 index, since torchrec depends on it. This is similar to how pytorch depends on numpy, etc. and these binaries need to be hosted in our index when uses try to pip install from download.pytorch.org.