### PR TITLE
update NCCL==2.18.3

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -32,8 +32,6 @@ else
 
     if [[ ${TARGET_OS} == 'windows' ]]; then
         python  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX}
-    elif [[ ${TARGET_OS} == 'linux-aarch64'  ]]; then
-        python3  ./test/smoke_test/smoke_test.py  --package=torchonly
     else
         python3  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX}
     fi

--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -1,18 +1,19 @@
-conda create -yp ${ENV_NAME}_pypi python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
+conda create -yn ${ENV_NAME}_pypi python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
+conda activate ${ENV_NAME}_pypi
 
 TEST_SUFFIX=""
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
-    conda run -p ${ENV_NAME}_pypi pip install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+    pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
 else
     if [[ ${MATRIX_CHANNEL} != "release" ]]; then
-        conda run -p ${ENV_NAME}_pypi pip install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
-        conda run -p ${ENV_NAME}_pypi pip install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
+        pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+        pip3 install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
     else
-        conda run -p ${ENV_NAME}_pypi pip install torch torchvision torchaudio
+        pip3 install torch torchvision torchaudio
     fi
 fi
 
-conda run -p ${ENV_NAME}_pypi python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
+python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
 conda deactivate
 conda env remove -p ${ENV_NAME}_pypi

--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -1,12 +1,18 @@
 conda create -yp ${ENV_NAME}_pypi python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
 
-if [[ ${MATRIX_CHANNEL} != "release" ]]; then
+TEST_SUFFIX=""
+if [[ ${TORCH_ONLY} == 'true' ]]; then
+    TEST_SUFFIX=" --package torchonly"
     conda run -p ${ENV_NAME}_pypi pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
-    conda run -p ${ENV_NAME}_pypi pip3 install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
 else
-    conda run -p ${ENV_NAME}_pypi pip3 install torch torchvision torchaudio
+    if [[ ${MATRIX_CHANNEL} != "release" ]]; then
+        conda run -p ${ENV_NAME}_pypi pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+        conda run -p ${ENV_NAME}_pypi pip3 install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
+    else
+        conda run -p ${ENV_NAME}_pypi pip3 install torch torchvision torchaudio
+    fi
 fi
 
-conda run -p ${ENV_NAME}_pypi python ./test/smoke_test/smoke_test.py
+conda run -p ${ENV_NAME}_pypi python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
 conda deactivate
 conda env remove -p ${ENV_NAME}_pypi

--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -1,20 +1,18 @@
 conda create -yp ${ENV_NAME}_pypi python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
-conda activate ${ENV_NAME}_pypi
 
 TEST_SUFFIX=""
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
-    pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+    conda run -p ${ENV_NAME}_pypi pip install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
 else
     if [[ ${MATRIX_CHANNEL} != "release" ]]; then
-        pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
-        pip3 install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
+        conda run -p ${ENV_NAME}_pypi pip install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+        conda run -p ${ENV_NAME}_pypi pip install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
     else
-        pip3 install torch torchvision torchaudio
+        conda run -p ${ENV_NAME}_pypi pip install torch torchvision torchaudio
     fi
 fi
 
-python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
-
+conda run -p ${ENV_NAME}_pypi python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
 conda deactivate
 conda env remove -p ${ENV_NAME}_pypi

--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -4,11 +4,11 @@ conda activate ${ENV_NAME}_pypi
 TEST_SUFFIX=""
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
-    pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+    pip3 install --pre torch --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
 else
     if [[ ${MATRIX_CHANNEL} != "release" ]]; then
-        pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
-        pip3 install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
+        pip3 install --pre torch --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+        pip3 install --pre torchvision torchaudio --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
     else
         pip3 install torch torchvision torchaudio
     fi

--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -1,18 +1,20 @@
 conda create -yp ${ENV_NAME}_pypi python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
+conda activate ${ENV_NAME}_pypi
 
 TEST_SUFFIX=""
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
-    conda run -p ${ENV_NAME}_pypi pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+    pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
 else
     if [[ ${MATRIX_CHANNEL} != "release" ]]; then
-        conda run -p ${ENV_NAME}_pypi pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
-        conda run -p ${ENV_NAME}_pypi pip3 install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
+        pip3 install --pre torch --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+        pip3 install --pre torchvision torchaudio --index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
     else
-        conda run -p ${ENV_NAME}_pypi pip3 install torch torchvision torchaudio
+        pip3 install torch torchvision torchaudio
     fi
 fi
 
-conda run -p ${ENV_NAME}_pypi python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
+python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
+
 conda deactivate
 conda env remove -p ${ENV_NAME}_pypi

--- a/.github/scripts/validate_poetry.sh
+++ b/.github/scripts/validate_poetry.sh
@@ -8,20 +8,32 @@ poetry --version
 poetry new test_poetry
 cd test_poetry
 
+TEST_SUFFIX=""
+if [[ ${TORCH_ONLY} == 'true' ]]; then
+    TEST_SUFFIX=" --package torchonly"
+else
+
 if [[ ${MATRIX_CHANNEL} != "release" ]]; then
     # Installing poetry from our custom repo. We need to configure it before use and disable authentication
     export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
     poetry source add --priority=explicit domains "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
-    poetry source add --priority=supplemental pytorch-nightly "https://download.pytorch.org/whl/${MATRIX_CHANNEL}"
+    poetry source add --priority=supplemental pytorch-channel "https://download.pytorch.org/whl/${MATRIX_CHANNEL}"
     poetry source add --priority=supplemental pytorch "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
     poetry --quiet add --source pytorch torch
-    poetry --quiet add --source domains torchvision torchaudio
+
+    if [[ ${TORCH_ONLY} != 'true' ]]; then
+        poetry --quiet add --source domains torchvision torchaudio
+    fi
 else
     export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-    poetry --quiet add torch torchaudio torchvision
+    if [[ ${TORCH_ONLY} == 'true' ]]; then
+        poetry --quiet add torch
+    else
+        poetry --quiet add torch torchaudio torchvision
+    fi
 fi
 
-python ../test/smoke_test/smoke_test.py
+python ../test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
 conda deactivate
 conda env remove -p ${ENV_NAME}_poetry
 cd ..

--- a/.github/scripts/validate_poetry.sh
+++ b/.github/scripts/validate_poetry.sh
@@ -11,7 +11,7 @@ cd test_poetry
 TEST_SUFFIX=""
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
-else
+fi
 
 if [[ ${MATRIX_CHANNEL} != "release" ]]; then
     # Installing poetry from our custom repo. We need to configure it before use and disable authentication

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -61,6 +61,7 @@ jobs:
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
       binary-matrix: ${{ toJSON(matrix) }}
+      no-sudo: true
       script: |
         set -ex
         export ENV_NAME="conda-env-${{ github.run_id }}"

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -60,6 +60,7 @@ jobs:
       repository: "pytorch/builder"
       ref: ${{ inputs.ref || github.ref }}
       job-name: ${{ matrix.build_name }}
+      docker-image: ${{ matrix.container_image }}
       binary-matrix: ${{ toJSON(matrix) }}
       no-sudo: true
       script: |

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -65,6 +65,9 @@ jobs:
       no-sudo: true
       script: |
         set -ex
+        source ./aarch64_linux/aarch64_ci_setup.sh
+        echo "/opt/conda/bin" >> $GITHUB_PATH
+
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="linux-aarch64"
         export TORCH_ONLY=${{ inputs.torchonly }}

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -69,9 +69,6 @@ jobs:
         source ./aarch64_linux/aarch64_ci_setup.sh
         echo "/opt/conda/bin" >> $GITHUB_PATH
 
-        # todo: Remove after aarch64 filename is fixed
-        export MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"pip3 install"/"pip3 install --pre"}
-
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="linux-aarch64"
         export TORCH_ONLY=${{ inputs.torchonly }}

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -69,6 +69,9 @@ jobs:
         source ./aarch64_linux/aarch64_ci_setup.sh
         echo "/opt/conda/bin" >> $GITHUB_PATH
 
+        # todo: Remove after aarch64 filename is fixed
+        export MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"pip3 install"/"pip3 install --pre"}
+
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="linux-aarch64"
         export TORCH_ONLY=${{ inputs.torchonly }}

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -69,8 +69,6 @@ jobs:
         source ./aarch64_linux/aarch64_ci_setup.sh
         echo "/opt/conda/bin" >> $GITHUB_PATH
 
-        MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"index-url"/"extra-index-url"}
-
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="linux-aarch64"
         export TORCH_ONLY=${{ inputs.torchonly }}

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -65,6 +65,7 @@ jobs:
       no-sudo: true
       script: |
         set -ex
+        export DESIRED_PYTHON=${{ matrix.python_version }}
         source ./aarch64_linux/aarch64_ci_setup.sh
         echo "/opt/conda/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -69,6 +69,8 @@ jobs:
         source ./aarch64_linux/aarch64_ci_setup.sh
         echo "/opt/conda/bin" >> $GITHUB_PATH
 
+        MATRIX_INSTALLATION=${MATRIX_INSTALLATION/"index-url"/"extra-index-url"}
+
         export ENV_NAME="conda-env-${{ github.run_id }}"
         export TARGET_OS="linux-aarch64"
         export TORCH_ONLY=${{ inputs.torchonly }}

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -67,5 +67,14 @@ jobs:
         export TARGET_OS="linux"
         eval "$(conda shell.bash hook)"
 
+        # Special case PyPi installation package. And Install of PyPi package via poetry
+        if [[ ${MATRIX_PACKAGE_TYPE} == "manywheel" ]] && \
+           ([[ ${MATRIX_GPU_ARCH_VERSION} == "12.1" && ${MATRIX_CHANNEL} != "release" ]] || \
+            [[ ${MATRIX_GPU_ARCH_VERSION} == "11.7" && ${MATRIX_CHANNEL} == "release" ]]); then
+          source ./.github/scripts/validate_pipy.sh --runtime-error-check disabled
+          # temporary disable poetry check
+          # source ./.github/scripts/validate_poetry.sh --runtime-error-check disabled
+        fi
+
         # Standart case: Validate binaries
         source ./.github/scripts/validate_binaries.sh

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -71,9 +71,9 @@ jobs:
         if [[ ${MATRIX_PACKAGE_TYPE} == "manywheel" ]] && \
            ([[ ${MATRIX_GPU_ARCH_VERSION} == "12.1" && ${MATRIX_CHANNEL} != "release" ]] || \
             [[ ${MATRIX_GPU_ARCH_VERSION} == "11.7" && ${MATRIX_CHANNEL} == "release" ]]); then
-          source ./.github/scripts/validate_pipy.sh --runtime-error-check disabled
+          source ./.github/scripts/validate_pipy.sh
           # temporary disable poetry check
-          # source ./.github/scripts/validate_poetry.sh --runtime-error-check disabled
+          source ./.github/scripts/validate_poetry.sh
         fi
 
         # Standart case: Validate binaries

--- a/aarch64_linux/aarch64_ci_build.sh
+++ b/aarch64_linux/aarch64_ci_build.sh
@@ -4,6 +4,19 @@ set -eux -o pipefail
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 source $SCRIPTPATH/aarch64_ci_setup.sh
 
+tagged_version() {
+  GIT_DESCRIBE="git --git-dir /pytorch/.git describe --tags --match v[0-9]*.[0-9]*.[0-9]*"
+  if ${GIT_DESCRIBE} --exact >/dev/null; then
+    ${GIT_DESCRIBE}
+  else
+    return 1
+  fi
+}
+
+if tagged_version >/dev/null; then
+  export OVERRIDE_PACKAGE_VERSION="$(tagged_version | sed -e 's/^v//' -e 's/-.*$//')"
+fi
+
 ###############################################################################
 # Run aarch64 builder python
 ###############################################################################

--- a/aarch64_linux/build_aarch64_wheel.py
+++ b/aarch64_linux/build_aarch64_wheel.py
@@ -219,7 +219,7 @@ def install_condaforge_python(host: RemoteHost, python_version="3.8") -> None:
 
 def build_OpenBLAS(host: RemoteHost, git_clone_flags: str = "") -> None:
     print('Building OpenBLAS')
-    host.run_cmd(f"git clone https://github.com/xianyi/OpenBLAS -b v0.3.19 {git_clone_flags}")
+    host.run_cmd(f"git clone https://github.com/xianyi/OpenBLAS -b v0.3.20 {git_clone_flags}")
     make_flags = "NUM_THREADS=64 USE_OPENMP=1 NO_SHARED=1 DYNAMIC_ARCH=1 TARGET=ARMV8"
     host.run_cmd(f"pushd OpenBLAS && make {make_flags} -j8 && sudo make {make_flags} install && popd && rm -rf OpenBLAS")
 
@@ -227,10 +227,7 @@ def build_OpenBLAS(host: RemoteHost, git_clone_flags: str = "") -> None:
 def build_ArmComputeLibrary(host: RemoteHost, git_clone_flags: str = "") -> None:
     print('Building Arm Compute Library')
     acl_build_flags="debug=0 neon=1 opencl=0 os=linux openmp=1 cppthreads=0 arch=armv8a multi_isa=1 build=native"
-    host.run_cmd(f"git clone https://github.com/ARM-software/ComputeLibrary.git -b v22.11 {git_clone_flags}")
-    host.run_cmd(['sed -i -e \'s/"armv8.2-a"/"armv8-a"/g\' ComputeLibrary/SConscript'])
-    host.run_cmd(['sed -i -e \'s/-march=armv8.2-a+fp16/-march=armv8-a/g\' ComputeLibrary/SConstruct'])
-    host.run_cmd(['sed -i -e \'s/"-march=armv8.2-a"/"-march=armv8-a"/g\' ComputeLibrary/filedefs.json'])
+    host.run_cmd(f"git clone https://github.com/ARM-software/ComputeLibrary.git -b v23.05.1 {git_clone_flags}")
     host.run_cmd(f"cd ComputeLibrary && scons Werror=1 -j8 {acl_build_flags}")
 
 

--- a/common/install_cuda.sh
+++ b/common/install_cuda.sh
@@ -55,10 +55,11 @@ function install_121 {
 
     # NCCL license: https://docs.nvidia.com/deeplearning/nccl/#licenses
     mkdir tmp_nccl && cd tmp_nccl
-    wget -q https://developer.download.nvidia.com/compute/redist/nccl/v2.18.1/nccl_2.18.1-1+cuda12.1_x86_64.txz
-    tar xf nccl_2.18.1-1+cuda12.1_x86_64.txz
-    cp -a nccl_2.18.1-1+cuda12.1_x86_64/include/* /usr/local/cuda/include/
-    cp -a nccl_2.18.1-1+cuda12.1_x86_64/lib/* /usr/local/cuda/lib64/
+    # v2.18.13 seems to be a typo, but it works
+    wget -q https://developer.download.nvidia.com/compute/redist/nccl/v2.18.13/nccl_2.18.3-1+cuda12.1_x86_64.txz
+    tar xf nccl_2.18.3-1+cuda12.1_x86_64.txz
+    cp -a nccl_2.18.3-1+cuda12.1_x86_64/include/* /usr/local/cuda/include/
+    cp -a nccl_2.18.3-1+cuda12.1_x86_64/lib/* /usr/local/cuda/lib64/
     cd ..
     rm -rf tmp_nccl
     ldconfig

--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -85,6 +85,7 @@ PACKAGE_ALLOW_LIST = {
     "torchcsprng",
     "torchdata",
     "torchdistx",
+    "torchmetrics",
     "torchrec",
     "torchtext",
     "torchvision",


### PR DESCRIPTION
Move NCCL to `2.18.3` as it was used in `pytorch:main` before the most recent update to `2.18.5`.
Note that NCCL did not release `2.18.5` binaries yet, so we should stick to the latest `2.18.3` version in `torch==2.1.0`.

CC @atalman 