### PR TITLE
Add torch-tensorrt to S3 PyPI Index

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -80,6 +80,7 @@ PACKAGE_ALLOW_LIST = {
     "requests",
     "sympy",
     "torch",
+    "torch_tensorrt",
     "torcharrow",
     "torchaudio",
     "torchcsprng",


### PR DESCRIPTION
As pytorch/tensorrt moves off of CCI onto Nova, we must to host their nightlies on our S3 index. This change allows the indexing to occur correctly for this package.