### PR TITLE
S3 Management Job Outside Docker

### DIFF
--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -1,7 +1,6 @@
 name: Update S3 HTML indices for download.pytorch.org
 
 on:
-  pull_request:
   schedule:
     # Update the indices every 30 minutes
     - cron: "*/30 * * * *"

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -1,4 +1,5 @@
 name: Update S3 HTML indices for download.pytorch.org
+
 on:
   # TODO: remove before merging
   pull_request:

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-s3:
+  update:
     strategy:
       matrix:
         prefix: ["whl", "whl/test", "whl/nightly", "whl/lts/1.8"]

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       repository: pytorch/builder
       timeout: 60
+      secrets-env: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
       script: |
         set -ex
 

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -28,8 +28,8 @@ jobs:
         conda activate ./run_env
 
         # Set Envs
-        export AWS_ACCESS_KEY_ID = ${SECRET_AWS_ACCESS_KEY_ID}
-        export AWS_SECRET_ACCESS_KEY = ${SECRET_AWS_SECRET_ACCESS_KEY}
+        export AWS_ACCESS_KEY_ID="${SECRET_AWS_ACCESS_KEY_ID}"
+        export AWS_SECRET_ACCESS_KEY="${SECRET_AWS_SECRET_ACCESS_KEY}"
 
         # Install requirements
         pip install -r s3_management/requirements.txt

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -1,0 +1,36 @@
+name: Update S3 HTML indices for download.pytorch.org
+on:
+  # TODO: remove before merging
+  pull_request:
+  schedule:
+    # Update the indices every 30 minutes
+    - cron: "*/30 * * * *"
+  # Have the ability to trigger this job manually using the API as well
+  workflow_dispatch:
+
+jobs:
+  update-s3:
+    strategy:
+      matrix:
+        prefix: ["whl", "whl/test", "whl/nightly", "whl/lts/1.8"]
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      repository: pytorch/builder
+      timeout: 60
+      secrets-env: "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"
+      script: |
+        set -ex
+
+        # Create Conda Environment
+        git config --global --add safe.directory /__w/builder/builder
+        conda create --quiet -y --prefix run_env python="3.8"
+        conda activate ./run_env
+
+        # Set Envs
+        export AWS_ACCESS_KEY_ID = ${SECRET_AWS_ACCESS_KEY_ID}
+        export AWS_SECRET_ACCESS_KEY = ${SECRET_AWS_SECRET_ACCESS_KEY}
+
+        # Install requirements
+        pip install -r s3_management/requirements.txt
+        python s3_management/manage.py --generate-pep503 ${{ matrix.prefix }}

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -1,12 +1,10 @@
 name: Update S3 HTML indices for download.pytorch.org
 
 on:
-  # TODO: remove before merging
   pull_request:
   schedule:
     # Update the indices every 30 minutes
     - cron: "*/30 * * * *"
-  # Have the ability to trigger this job manually using the API as well
   workflow_dispatch:
 
 jobs:
@@ -16,7 +14,6 @@ jobs:
     with:
       repository: pytorch/builder
       timeout: 60
-      secrets-env: "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"
       script: |
         set -ex
 

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   update:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    secrets: inherit
     with:
       repository: pytorch/builder
       timeout: 60

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   update:
+    strategy:
+      matrix:
+        prefix: ["whl", "whl/test", "whl/nightly", "whl/lts/1.8"]
+      fail-fast: False
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     secrets: inherit
     with:
@@ -29,5 +33,4 @@ jobs:
 
         # Install requirements
         pip install -r s3_management/requirements.txt
-        # python s3_management/manage.py --generate-pep503 ${{ matrix.prefix }}
-        python s3_management/manage.py --generate-pep503 whl
+        python s3_management/manage.py --generate-pep503 ${{ matrix.prefix }}

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         prefix: ["whl", "whl/test", "whl/nightly", "whl/lts/1.8"]
-      fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       repository: pytorch/builder

--- a/.github/workflows/update-s3-html.yml
+++ b/.github/workflows/update-s3-html.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   update:
-    strategy:
-      matrix:
-        prefix: ["whl", "whl/test", "whl/nightly", "whl/lts/1.8"]
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
       repository: pytorch/builder
@@ -32,4 +29,5 @@ jobs:
 
         # Install requirements
         pip install -r s3_management/requirements.txt
-        python s3_management/manage.py --generate-pep503 ${{ matrix.prefix }}
+        # python s3_management/manage.py --generate-pep503 ${{ matrix.prefix }}
+        python s3_management/manage.py --generate-pep503 whl


### PR DESCRIPTION
To update the S3 index, we build a docker image and run that from a GHA in `pytorch/pytorch`. This docker image has not been rebuilt in 3 months, and so changes to `s3_management` are not reflected. The docker image also basically just installed requirements and run this python script, so rebuilding and maintaining that image just added overhead. We will do the S3 management from this new GHA that runs the script directly instead of using a docker image.