### PR TITLE
Enable torch compile for python 3.11 smoke tests

### DIFF
--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -128,8 +128,10 @@ def smoke_test_cuda(package: str, runtime_error_check: str) -> None:
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
 
-        # torch.compile is available only on Linux
-        if (sys.platform == "linux" or sys.platform == "linux2"):
+        # torch.compile is available only on Linux and python 3.8-3.10
+        if (sys.platform == "linux" or sys.platform == "linux2") and sys.version_info < (3, 11, 0) and channel == "release":
+            smoke_test_compile()
+        elif (sys.platform == "linux" or sys.platform == "linux2") and channel != "release:
             smoke_test_compile()
 
         if(runtime_error_check == "enabled"):

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -131,7 +131,7 @@ def smoke_test_cuda(package: str, runtime_error_check: str) -> None:
         # torch.compile is available only on Linux and python 3.8-3.10
         if (sys.platform == "linux" or sys.platform == "linux2") and sys.version_info < (3, 11, 0) and channel == "release":
             smoke_test_compile()
-        elif (sys.platform == "linux" or sys.platform == "linux2") and channel != "release:
+        elif (sys.platform == "linux" or sys.platform == "linux2") and channel != "release":
             smoke_test_compile()
 
         if(runtime_error_check == "enabled"):

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -128,8 +128,8 @@ def smoke_test_cuda(package: str, runtime_error_check: str) -> None:
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
 
-        # torch.compile is available only on Linux and python 3.8-3.10
-        if (sys.platform == "linux" or sys.platform == "linux2") and sys.version_info < (3, 11, 0):
+        # torch.compile is available only on Linux
+        if (sys.platform == "linux" or sys.platform == "linux2"):
             smoke_test_compile()
 
         if(runtime_error_check == "enabled"):


### PR DESCRIPTION
Enable torch compile on python 3.11