### PR TITLE
Remove restriction on 3.11

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - sympy
     - filelock
     - networkx
-    - jinja2 # [py <= 310]
+    - jinja2
     - pyyaml
     {% if cross_compile_arm64 == 0 %}
     - blas * mkl


### PR DESCRIPTION
Its available from anaconda - this restriction is not required anymore