### PR TITLE
Add fbgemm-gpu to S3 Index

### DIFF
--- a/s3_management/manage.py
+++ b/s3_management/manage.py
@@ -40,6 +40,7 @@ PACKAGE_ALLOW_LIST = {
     "charset_normalizer",
     "cmake",
     "colorama",
+    "fbgemm_gpu",
     "filelock",
     "fsspec",
     "idna",


### PR DESCRIPTION
As pytorch/FBGEMM onboards onto Nova, nightly wheels must be hosted on S3 index. This change allows the indexing to occur correctly for this package.