### PR TITLE
[ROCm] Do not uninstall MIOpen if skipping build-from-source

### DIFF
--- a/common/install_miopen.sh
+++ b/common/install_miopen.sh
@@ -33,8 +33,6 @@ if [[ $ROCM_INT -lt 40001 ]]; then
     exit 0
 fi
 
-yum remove -y miopen-hip
-
 # Function to retry functions that sometimes timeout or have flaky failures
 retry () {
     $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
@@ -84,6 +82,8 @@ else
     echo "Unhandled ROCM_VERSION ${ROCM_VERSION}"
     exit 1
 fi
+
+yum remove -y miopen-hip
 
 git clone https://github.com/ROCmSoftwarePlatform/MIOpen -b ${MIOPEN_BRANCH}
 pushd MIOpen


### PR DESCRIPTION
Bug-fix for bug introduced via https://github.com/pytorch/builder/pull/1541/commits/25592a79c2a00325b622c5cac47c244d83753158 in PR https://github.com/pytorch/builder/pull/1541.

More context [here](https://github.com/pytorch/builder/pull/1541#discussion_r1329580391).

cc @jeffdaily 