### PR TITLE
Fix erroneous logic that was skipping msccl files even for ROCm5.6

### DIFF
--- a/manywheel/build_rocm.sh
+++ b/manywheel/build_rocm.sh
@@ -204,10 +204,17 @@ if [[ $ROCM_INT -ge 50500 ]]; then
 
     DEPS_AUX_SRCLIST+=(${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_SRC/})
     DEPS_AUX_DSTLIST+=(${MIOPEN_SHARE_FILES[@]/#/$MIOPEN_SHARE_DST/})
-elif [[ $ROCM_INT -ge 50600 ]]; then
+fi
+
+if [[ $ROCM_INT -ge 50600 ]]; then
     # RCCL library files
-    RCCL_SHARE_SRC=$ROCM_HOME/lib/msccl-algorithms
-    RCCL_SHARE_DST=lib/msccl-algorithms
+    if [[ $ROCM_INT -ge 50700 ]]; then
+        RCCL_SHARE_SRC=$ROCM_HOME/share/rccl/msccl-algorithms
+        RCCL_SHARE_DST=share/rccl/msccl-algorithms
+    else
+        RCCL_SHARE_SRC=$ROCM_HOME/lib/msccl-algorithms
+        RCCL_SHARE_DST=lib/msccl-algorithms
+    fi
     RCCL_SHARE_FILES=($(ls $RCCL_SHARE_SRC))
 
     DEPS_AUX_SRCLIST+=(${RCCL_SHARE_FILES[@]/#/$RCCL_SHARE_SRC/})


### PR DESCRIPTION
Also update msccl path for ROCm5.7

(cherry picked from commit [5e89be52acf79bc5e0bf6b273bc4613bd888182b](https://github.com/pytorch/builder/pull/1541/commits/5e89be52acf79bc5e0bf6b273bc4613bd888182b))

This patch is needed to fix multi-GPU functionality issue with PyTorch 2.1 wheels on ROCm.