### PR TITLE
[aarch64] Pin ACl to v22.11

### DIFF
--- a/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/aarch64_linux/aarch64_wheel_ci_build.py
@@ -20,7 +20,10 @@ def build_ArmComputeLibrary(git_clone_flags: str = "") -> None:
     '''
     print('Building Arm Compute Library')
     os.system("cd / && mkdir /acl")
-    os.system(f"git clone https://github.com/ARM-software/ComputeLibrary.git -b v23.05.1 {git_clone_flags}")
+    os.system(f"git clone https://github.com/ARM-software/ComputeLibrary.git -b v22.11 {git_clone_flags}")
+    os.system('sed -i -e \'s/"armv8.2-a"/"armv8-a"/g\' ComputeLibrary/SConscript; '
+              'sed -i -e \'s/-march=armv8.2-a+fp16/-march=armv8-a/g\' ComputeLibrary/SConstruct; '
+              'sed -i -e \'s/"-march=armv8.2-a"/"-march=armv8-a"/g\' ComputeLibrary/filedefs.json')
     os.system("cd ComputeLibrary; export acl_install_dir=/acl; "
               "scons Werror=1 -j8 debug=0 neon=1 opencl=0 os=linux openmp=1 cppthreads=0 arch=armv8a multi_isa=1 build=native build_dir=$acl_install_dir/build; "
               "cp -r arm_compute $acl_install_dir; "


### PR DESCRIPTION
This switches ACL back to working configuration.

At a time of this PR:
https://github.com/pytorch/builder/pull/1370

This code was added in Compute Library v23.05 :
```
if 'v8a' in env['arch']:
        print("INFO: multi_isa armv8-a architecture build doesn't enable __ARM_FEATURE_FP16_VECTOR_ARITHMETIC. Use armv8.2-a or beyond to enable FP16 vector arithmetic support")
        env.Append(CXXFLAGS = ['-march=armv8-a']) # note: this will disable fp16 extension __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
```
Ref:
https://github.com/ARM-software/ComputeLibrary/commit/6c713f090601ea839d944a30888ea56eb2f43988#diff-d78c5c377c03dd251edc72cdb0ae7d9986fa08361eb392187218f8c670c0bc4eR311