### PR TITLE
Fix path issue when building aarch64 wheels

### DIFF
--- a/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/aarch64_linux/aarch64_wheel_ci_build.py
@@ -106,8 +106,8 @@ if __name__ == '__main__':
         print("build pytorch without mkldnn backend")
 
     # work around to fix Raspberry pie crash
-    os.system(f"cd $HOME && git clone https://github.com/pytorch/builder.git")
-    os.system(f"cd $HOME/pytorch/third_party/ideep/mkl-dnn && patch -p1 < $HOME/builder/mkldnn_fix/aarch64-fix-default-build-flags-to-armv8-a.patch")
+    print("Applying mkl-dnn patch to fix Raspberry pie crash")
+    os.system(f"cd /pytorch/third_party/ideep/mkl-dnn && patch -p1 < /builder/mkldnn_fix/aarch64-fix-default-build-flags-to-armv8-a.patch")
     os.system(f"cd /pytorch; {build_vars} python3 setup.py bdist_wheel")
     pytorch_wheel_name = complete_wheel("pytorch")
     print(f"Build Compelete. Created {pytorch_wheel_name}..")


### PR DESCRIPTION
Fix following error during build:
https://github.com/pytorch/pytorch/actions/runs/6377268592/job/17305610211#step:15:4761

```
2023-10-02T07:51:18.2867405Z sh: line 0: cd: /root/pytorch/third_party/ideep/mkl-dnn: No such file or directory
```

