### PR TITLE
Move manywheel builds to `linux.12xlarge.ephemeral`

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: ubuntu-22.04
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["12.1", "11.8"]


### PR DESCRIPTION
Should be faster and as secure as GH one