### PR TITLE
Use `linux.12xlarge.ephemeral` for conda docker builds

### DIFF
--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build-docker:
-    runs-on: ubuntu-22.04
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["11.8", "12.1", "cpu"]


### PR DESCRIPTION
As `ubuntu.20.04` often OOM/failed to fetch data from RHEL repo