### PR TITLE
Move libtorch docker builder to `linux.12xlarge.ephemeral`

### DIFF
--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: ubuntu-22.04
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["12.1", "11.8"]


### PR DESCRIPTION
As running it on `ubutu22.04` often results in flay infra failures/running out of disk space, for example, from https://github.com/pytorch/builder/actions/runs/6484948230/job/17609933012
```
cat: write error: No space left on device
```