### PR TITLE
Remove http://repo.okay.com.mx

### DIFF
--- a/manywheel/Dockerfile
+++ b/manywheel/Dockerfile
@@ -145,7 +145,6 @@ RUN yum install -y python3-pip && \
     ln -s /usr/local/bin/cmake /usr/bin/cmake
 
 # ninja
-RUN yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-5.el7.noarch.rpm
 RUN yum install -y ninja-build
 
 FROM cpu_final as cuda_final


### PR DESCRIPTION
The domain is down and causes build failures for ROCm and elsewhere, i.e.

* Nightly https://hud.pytorch.org/pytorch/pytorch/commit/07cc1132a95a98c64f7cc76bbd8940f981dd7642
* Vision https://hud.pytorch.org/pytorch/vision/commit/fdea156b80780313d6248847ab16d5d68eef9679

I'm trying to see if we could get rid of this build dependency