### PR TITLE
Upload to docker.io when pushing release tag

### DIFF
--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -24,7 +24,7 @@ env:
   DOCKER_BUILDKIT: 1
   DOCKER_ID: ${{ secrets.DOCKER_ID }}
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')) }}
+  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || (startsWith(github.event.ref, 'refs/tags/')) }}
 
 jobs:
   build-docker:

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -26,7 +26,7 @@ env:
   DOCKER_BUILDKIT: 1
   DOCKER_ID: ${{ secrets.DOCKER_ID }}
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')) }}
+  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || (startsWith(github.event.ref, 'refs/tags/')) }}
 
 jobs:
   build-docker-cuda:

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -30,7 +30,7 @@ env:
   DOCKER_BUILDKIT: 1
   DOCKER_ID: ${{ secrets.DOCKER_ID }}
   DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')) }}
+  WITH_PUSH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release') || (startsWith(github.event.ref, 'refs/tags/')) }}
 
 jobs:
   build-docker-cuda:


### PR DESCRIPTION
I notice that there is no `-2.1` tag for conda and libtorch images on docker hub:
* https://registry.hub.docker.com/r/pytorch/conda-builder/tags
* https://registry.hub.docker.com/r/pytorch/libtorch-cxx11-builder/tags

On the other hand, manywheel images have it:
* https://registry.hub.docker.com/r/pytorch/manylinux-builder/tags

It turns out that the images are pushed only when some file are touched on the release branch, not when RC is cut.  Thus, this change added the same logic as docker-release workflow from PyTorch https://github.com/pytorch/pytorch/blob/main/.github/workflows/docker-release.yml#L29C3-L29C196 to address this issue.