### PR TITLE
[aarch64] Release pypi prep script change for aarch64 builds

### DIFF
--- a/release/pypi/promote_pypi_to_staging.sh
+++ b/release/pypi/promote_pypi_to_staging.sh
@@ -34,13 +34,13 @@ PLATFORM="${MACOS_X86_64}"       VERSION_SUFFIX=""                              
 PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                                upload_pypi_to_staging torch "${PYTORCH_VERSION}" # m1 mac
 
 PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
-PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
+PLATFORM="linux_aarch64"         VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 PLATFORM="win_amd64"             VERSION_SUFFIX="${WIN_VERSION_SUFFIX}"   upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 PLATFORM="${MACOS_X86_64}"       VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 
 PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
-PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
+PLATFORM="linux_aarch64"         VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
 PLATFORM="win_amd64"             VERSION_SUFFIX="${WIN_VERSION_SUFFIX}"   upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
 PLATFORM="${MACOS_X86_64}"       VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
 PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"

--- a/release/pypi/upload_pypi_to_staging.sh
+++ b/release/pypi/upload_pypi_to_staging.sh
@@ -42,10 +42,16 @@ fi
 
 for pkg in ${pkgs_to_promote}; do
     pkg_basename="$(basename "${pkg}")"
-    # Don't attempt to change if manylinux2014
-    if [[ "${pkg}" != *manylinux2014* ]]; then
+
+    if [[ "${pkg}" != *aarch64* ]]; then
         # sub out linux for manylinux1
         pkg_basename="$(basename "${pkg//linux/manylinux1}")"
+    elif [[ "${pkg}" == *manylinux_2_17_aarch64* ]]; then
+        # strip manylinux_2_17 from core filename
+        pkg_basename="$(basename "${pkg//manylinux_2_17_aarch64./}")"
+    elif [[ "${pkg}" == *linux_aarch64* ]]; then
+        # domains change linux_aarch64 to manylinux2014_aarch64
+        pkg_basename="$(basename "${pkg//linux_aarch64/manylinux2014_aarch64}")"
     fi
     orig_pkg="${tmp_dir}/${pkg_basename}"
     (


### PR DESCRIPTION
This is to achieve following renaming of wheels:
``
torch-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl ->
torch-2.1.1-cp310-cp310-manylinux2014_aarch64.whl
``
``
torchvision-0.16.1-cp310-cp310-linux_aarch64.whl -> torchvision-0.16.1-cp310-cp310-manylinux2014_aarch64.whl
``