### PR TITLE
Fix poetry and pypi validations when version is specified

### DIFF
--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -2,15 +2,21 @@ conda create -yn ${ENV_NAME}_pypi python=${MATRIX_PYTHON_VERSION} numpy ffmpeg
 conda activate ${ENV_NAME}_pypi
 
 TEST_SUFFIX=""
+RELEASE_SUFFIX=""
+# if RELESE version is passed as parameter - install speific version
+if [[ ! -z ${RELEASE_VERSION} ]]; then
+    RELEASE_SUFFIX="==${RELEASE_VERSION}"
+fi
+
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
-    pip3 install --pre torch --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+    pip3 install --pre torch${RELEASE_SUFFIX} --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
 else
     if [[ ${MATRIX_CHANNEL} != "release" ]]; then
-        pip3 install --pre torch --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+        pip3 install --pre torch${RELEASE_SUFFIX}  --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
         pip3 install --pre torchvision torchaudio --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
     else
-        pip3 install torch torchvision torchaudio
+        pip3 install torch${RELEASE_SUFFIX}  torchvision torchaudio
     fi
 fi
 

--- a/.github/scripts/validate_poetry.sh
+++ b/.github/scripts/validate_poetry.sh
@@ -13,25 +13,16 @@ if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
 fi
 
-if [[ ${MATRIX_CHANNEL} != "release" ]]; then
-    # Installing poetry from our custom repo. We need to configure it before use and disable authentication
-    export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-    poetry source add --priority=explicit domains "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
-    poetry source add --priority=supplemental pytorch-channel "https://download.pytorch.org/whl/${MATRIX_CHANNEL}"
-    poetry source add --priority=supplemental pytorch "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
-    poetry --quiet add --source pytorch torch
+RELEASE_SUFFIX=""
+# if RELESE version is passed as parameter - install speific version
+if [[ ! -z ${RELEASE_VERSION} ]]; then
+    RELEASE_SUFFIX="@${RELEASE_VERSION}"
+fi
 
-    if [[ ${TORCH_ONLY} != 'true' ]]; then
-        poetry --quiet add --source domains torchvision torchaudio
-    fi
+if [[ ${TORCH_ONLY} == 'true' ]]; then
+    poetry --quiet add torch${RELEASE_SUFFIX}
 else
-    export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-    poetry source add --priority=explicit pytorch "https://download.pytorch.org/whl/${MATRIX_DESIRED_CUDA}"
-    if [[ ${TORCH_ONLY} == 'true' ]]; then
-        poetry --quiet add torch
-    else
-        poetry --quiet add --source pytorch torch torchaudio torchvision
-    fi
+    poetry --quiet add torch${RELEASE_SUFFIX} torchaudio torchvision
 fi
 
 python ../test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -114,7 +114,7 @@ jobs:
       ref: ${{ inputs.ref || github.ref }}
       torchonly: ${{ inputs.torchonly }}
       version: ${{ inputs.version }}
-      release-matrix: ${{ needs.generate-rlease-matrix.outputs.matrix }}
+      release-matrix: ${{ needs.generate-release-matrix.outputs.matrix }}
 
   mac-arm64:
     if:  inputs.os == 'macos' || inputs.os == 'all'

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -93,7 +93,10 @@ jobs:
         # Special case PyPi installation package. And Install of PyPi package via poetry
         if [[ ${MATRIX_PACKAGE_TYPE} == "manywheel" && ${MATRIX_GPU_ARCH_VERSION} == "12.1" ]]; then
           source ./.github/scripts/validate_pipy.sh
-          source ./.github/scripts/validate_poetry.sh
+
+          if [[ ${MATRIX_CHANNEL} == "release" ]]; then
+            source ./.github/scripts/validate_poetry.sh
+          fi
         fi
 
         # Standart case: Validate binaries


### PR DESCRIPTION
1. restrict poetry validation to only release, add support for version. Please note testing using test or nightly channel does not makes much sence. Hence keeping it to release only
2. pypi validation should allow version to be specified
3. fix typo for macos validations

Test: https://github.com/pytorch/builder/actions/runs/6945113935