### PR TITLE
Validate pypi build only for release

### DIFF
--- a/.github/scripts/validate_pipy.sh
+++ b/.github/scripts/validate_pipy.sh
@@ -10,14 +10,9 @@ fi
 
 if [[ ${TORCH_ONLY} == 'true' ]]; then
     TEST_SUFFIX=" --package torchonly"
-    pip3 install --pre torch${RELEASE_SUFFIX} --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
+    pip3 install torch${RELEASE_SUFFIX}
 else
-    if [[ ${MATRIX_CHANNEL} != "release" ]]; then
-        pip3 install --pre torch${RELEASE_SUFFIX}  --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}_pypi_cudnn"
-        pip3 install --pre torchvision torchaudio --extra-index-url "https://download.pytorch.org/whl/${MATRIX_CHANNEL}/${MATRIX_DESIRED_CUDA}"
-    else
-        pip3 install torch${RELEASE_SUFFIX}  torchvision torchaudio
-    fi
+    pip3 install torch${RELEASE_SUFFIX} torchvision torchaudio
 fi
 
 python ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -91,12 +91,9 @@ jobs:
         cat release_matrix.json
 
         # Special case PyPi installation package. And Install of PyPi package via poetry
-        if [[ ${MATRIX_PACKAGE_TYPE} == "manywheel" && ${MATRIX_GPU_ARCH_VERSION} == "12.1" ]]; then
+        if [[ ${MATRIX_PACKAGE_TYPE} == "manywheel" && ${MATRIX_GPU_ARCH_VERSION} == "12.1" && ${MATRIX_CHANNEL} == "release"]]; then
           source ./.github/scripts/validate_pipy.sh
-
-          if [[ ${MATRIX_CHANNEL} == "release" ]]; then
-            source ./.github/scripts/validate_poetry.sh
-          fi
+          source ./.github/scripts/validate_poetry.sh
         fi
 
         # Standart case: Validate binaries


### PR DESCRIPTION
Pypi build is default now as of: https://github.com/pytorch/pytorch/pull/114281
Hence moving pypi validation to release only