### PR TITLE
[Release/2.1] [Manywheel] Restrict `triton` to x86-64 Linux

### DIFF
--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -261,7 +261,7 @@ fi
 if [[ $(uname) == "Linux" ]]; then
     TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
     if [[ -z "$PYTORCH_EXTRA_INSTALL_REQUIREMENTS" ]]; then
-        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="triton==${TRITON_VERSION}"
+        export PYTORCH_EXTRA_INSTALL_REQUIREMENTS="triton==${TRITON_VERSION}; platform_system == 'Linux' and platform_machine == 'x86_64'"
     fi
 fi
 


### PR DESCRIPTION
Spiritual cherry-pick of https://github.com/pytorch/builder/commit/2a750ebb877695947146a307b22cf27b6c0d0302 into release/2.1 branch

Should fix https://github.com/pytorch/pytorch/issues/114042 when new release is pushed