### PR TITLE
Pin miniconda version for Windows

### DIFF
--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -44,7 +44,7 @@ set "tmp_conda=%CONDA_HOME%"
 set "miniconda_exe=%CD%\miniconda.exe"
 rmdir /s /q conda
 del miniconda.exe
-curl --retry 3 -k https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o "%miniconda_exe%"
+curl --retry 3 -k https://repo.anaconda.com/miniconda/Miniconda3-py311_23.9.0-0-Windows-x86_64.exe -o "%miniconda_exe%"
 call ..\conda\install_conda.bat
 if ERRORLEVEL 1 exit /b 1
 set "ORIG_PATH=%PATH%"


### PR DESCRIPTION
To Miniconda3-py311_23.9.0-0-Windows-x86_64.exe

Without this, conda tries to pull in `openblas` instead of `netlib` when building PyTorch on 3.10 and 3.11 and subsequently fails during smoke test https://github.com/pytorch/pytorch/actions/runs/6973576467.  As the issue doesn't happen in nightly, I believe this is the missing cherry pick