### PR TITLE
Add aarch64 conda env lib to LD_LIBRARY_PATH

### DIFF
--- a/aarch64_linux/aarch64_ci_setup.sh
+++ b/aarch64_linux/aarch64_ci_setup.sh
@@ -6,8 +6,9 @@ set -eux -o pipefail
 
 CONDA_PYTHON_EXE=/opt/conda/bin/python
 CONDA_EXE=/opt/conda/bin/conda
+CONDA_ENV_NAME=aarch64_env
 PATH=/opt/conda/bin:$PATH
-LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
+LD_LIBRARY_PATH=/opt/conda/envs/${CONDA_ENV_NAME}/lib/:/opt/conda/lib:$LD_LIBRARY_PATH
 
 ###############################################################################
 # Install conda
@@ -21,8 +22,8 @@ chmod +x /mambaforge.sh
 rm /mambaforge.sh
 source /opt/conda/etc/profile.d/conda.sh
 conda config --set ssl_verify False
-conda create -y -c conda-forge -n aarch64_env python=${DESIRED_PYTHON}
-conda activate aarch64_env
+conda create -y -c conda-forge -n "${CONDA_ENV_NAME}" python=${DESIRED_PYTHON}
+conda activate "${CONDA_ENV_NAME}"
 
 if [[ "$DESIRED_PYTHON"  == "3.8" ]]; then
     NUMPY_VERSION="1.24.4"


### PR DESCRIPTION
After the change on https://github.com/pytorch/builder/pull/1586, nightly aarch64 wheel fails to find `libopenblas.so` which is now installed under `/opt/conda/envs/aarch64_env/lib/` instead of the base conda `/opt/conda/lib`.  Using CPU nightly wheels on aarch64 from Nov 16 then ends up with the error as described in https://github.com/pytorch/pytorch/issues/114862: `Calling torch.geqrf on a CPU tensor requires compiling PyTorch with LAPACK. Please use PyTorch built with LAPACK support`.  The error can be found on night build log https://github.com/pytorch/pytorch/actions/runs/6887666324/job/18735230109#step:15:4933

Fixes https://github.com/pytorch/pytorch/issues/114862