### PR TITLE
Torch compile test for python 3.8-3.11 linux only

### DIFF
--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -167,8 +167,8 @@ def smoke_test_cuda(package: str, runtime_error_check: str) -> None:
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
 
-        # torch.compile is available only on Linux and python 3.8-3.10
-        if sys.platform in ["linux", "linux2"] and (sys.version_info < (3, 11, 0) or channel != "release"):
+        # torch.compile is available only on Linux and python 3.8-3.11
+        if sys.platform in ["linux", "linux2"] and sys.version_info =< (3, 11, 0):
             smoke_test_compile()
 
         if runtime_error_check == "enabled":

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -168,7 +168,7 @@ def smoke_test_cuda(package: str, runtime_error_check: str) -> None:
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
 
         # torch.compile is available only on Linux and python 3.8-3.11
-        if sys.platform in ["linux", "linux2"] and sys.version_info =< (3, 11, 0):
+        if sys.platform in ["linux", "linux2"] and sys.version_info =< (3, 11, 0): # noqa: E999
             smoke_test_compile()
 
         if runtime_error_check == "enabled":

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -168,7 +168,7 @@ def smoke_test_cuda(package: str, runtime_error_check: str) -> None:
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")
 
         # torch.compile is available only on Linux and python 3.8-3.11
-        if sys.platform in ["linux", "linux2"] and sys.version_info =< (3, 11, 0): # noqa: E999
+        if (sys.platform in ["linux", "linux2"]) and sys.version_info < (3, 12, 0):
             smoke_test_compile()
 
         if runtime_error_check == "enabled":


### PR DESCRIPTION
This should fix failure on with Python 3.12 validations:
https://github.com/pytorch/builder/actions/runs/7064433251/job/19232483984#step:11:4859