### PR TITLE
Fix validation workflow on aarch64 with conda 23.11.0 and GLIBC_2.25

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -39,11 +39,14 @@ else
         ${PWD}/check_binary.sh
     fi
 
-    # NB: The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that
-    # require GLIBC_2.25, which is not available in the current aarch64 image causing the
-    # suqsequence git command to fail. Basically, they don't work with CentOS 7 which AML 2
-    # is based on https://github.com/ContinuumIO/anaconda-issues/issues/12822
-    unset LD_LIBRARY_PATH
+    if [[ ${TARGET_OS} == 'linux-aarch64' ]]; then
+        OLD_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+        # NB: The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that
+        # require GLIBC_2.25, which is not available in the current aarch64 image causing the
+        # suqsequence git command to fail. Basically, they don't work with CentOS 7 which AML 2
+        # is based on https://github.com/ContinuumIO/anaconda-issues/issues/12822
+        unset LD_LIBRARY_PATH
+    fi
 
     if [[ ${TARGET_OS} == 'windows' ]]; then
         python  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX}
@@ -57,4 +60,8 @@ else
 
     conda deactivate
     conda env remove -n ${ENV_NAME}
+
+    if [[ ${TARGET_OS} == 'linux-aarch64' ]]; then
+        LD_LIBRARY_PATH=${OLD_LD_LIBRARY_PATH}
+    fi
 fi

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -39,6 +39,12 @@ else
         ${PWD}/check_binary.sh
     fi
 
+    # NB: The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that
+    # require GLIBC_2.25, which is not available in the current aarch64 image causing the
+    # suqsequence git command to fail. Basically, they don't work with CentOS 7 which AML 2
+    # is based on https://github.com/ContinuumIO/anaconda-issues/issues/12822
+    unset LD_LIBRARY_PATH
+
     if [[ ${TARGET_OS} == 'windows' ]]; then
         python  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX}
     else

--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -39,15 +39,6 @@ else
         ${PWD}/check_binary.sh
     fi
 
-    if [[ ${TARGET_OS} == 'linux-aarch64' ]]; then
-        OLD_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
-        # NB: The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that
-        # require GLIBC_2.25, which is not available in the current aarch64 image causing the
-        # suqsequence git command to fail. Basically, they don't work with CentOS 7 which AML 2
-        # is based on https://github.com/ContinuumIO/anaconda-issues/issues/12822
-        unset LD_LIBRARY_PATH
-    fi
-
     if [[ ${TARGET_OS} == 'windows' ]]; then
         python  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX}
     else
@@ -60,8 +51,4 @@ else
 
     conda deactivate
     conda env remove -n ${ENV_NAME}
-
-    if [[ ${TARGET_OS} == 'linux-aarch64' ]]; then
-        LD_LIBRARY_PATH=${OLD_LD_LIBRARY_PATH}
-    fi
 fi

--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -95,5 +95,11 @@ jobs:
         printf '%s\n' ${{ toJson(inputs.release-matrix) }} > release_matrix.json
         eval "$(conda shell.bash hook)"
 
-        # Standart case: Validate binaries
+        # NB: The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that
+        # require GLIBC_2.25, which is not available in the current aarch64 image causing the
+        # subsequence git command to fail. Basically, they don't work with CentOS 7 which AML 2
+        # is based on https://github.com/ContinuumIO/anaconda-issues/issues/12822
+        unset LD_LIBRARY_PATH
+
+        # Standard case: Validate binaries
         source ./.github/scripts/validate_binaries.sh

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -268,10 +268,6 @@ def smoke_test_modules():
                     raise RuntimeError(
                         f"Cloning {module['repo']} FAIL: {exc.returncode} Output: {exc.output}"
                     ) from exc
-                try:
-                    subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
-                except subprocess.CalledProcessError as exc:
-                    raise RuntimeError(f"Cloning {module['repo']} FAIL: {exc.returncode} Output: {exc.output}") from exc
             try:
                 smoke_test_command = f"python3 {module['smoke_test']}"
                 if target_os == 'windows':

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -259,6 +259,16 @@ def smoke_test_modules():
             if not os.path.exists(f"{cwd}/{module['repo_name']}"):
                 print(f"Path does not exist: {cwd}/{module['repo_name']}")
                 try:
+                    subprocess.check_output(
+                        f"git clone --depth 1 {module['repo']}",
+                        stderr=subprocess.STDOUT,
+                        shell=True,
+                    )
+                except subprocess.CalledProcessError as exc:
+                    raise RuntimeError(
+                        f"Cloning {module['repo']} FAIL: {exc.returncode} Output: {exc.output}"
+                    ) from exc
+                try:
                     subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
                 except subprocess.CalledProcessError as exc:
                     raise RuntimeError(f"Cloning {module['repo']} FAIL: {exc.returncode} Output: {exc.output}") from exc

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -261,7 +261,6 @@ def smoke_test_modules():
                 try:
                     output = subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
                 except subprocess.CalledProcessError as exc:
-                    print(f"==== {output}")
                     raise RuntimeError(f"CLONE FAIL: {exc.returncode} {exc.output}") from exc
             try:
                 smoke_test_command = f"python3 {module['smoke_test']}"

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -258,7 +258,11 @@ def smoke_test_modules():
         if module["repo"]:
             if not os.path.exists(f"{cwd}/{module['repo_name']}"):
                 print(f"Path does not exist: {cwd}/{module['repo_name']}")
-                subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
+                try:
+                    output = subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
+                except subprocess.CalledProcessError as exc:
+                    print(f"==== {output}")
+                    raise RuntimeError(f"CLONE FAIL: {exc.returncode} {exc.output}") from exc
             try:
                 smoke_test_command = f"python3 {module['smoke_test']}"
                 if target_os == 'windows':

--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -259,9 +259,9 @@ def smoke_test_modules():
             if not os.path.exists(f"{cwd}/{module['repo_name']}"):
                 print(f"Path does not exist: {cwd}/{module['repo_name']}")
                 try:
-                    output = subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
+                    subprocess.check_output(f"git clone --depth 1 {module['repo']}", stderr=subprocess.STDOUT, shell=True)
                 except subprocess.CalledProcessError as exc:
-                    raise RuntimeError(f"CLONE FAIL: {exc.returncode} {exc.output}") from exc
+                    raise RuntimeError(f"Cloning {module['repo']} FAIL: {exc.returncode} Output: {exc.output}") from exc
             try:
                 smoke_test_command = f"python3 {module['smoke_test']}"
                 if target_os == 'windows':


### PR DESCRIPTION
The latest conda 23.11.0 pulls in some dependencies of conda-libmamba-solver that require GLIBC_2.25, which is not available in the current aarch64 image causing the subsequence git command to fail. Basically, they don't work with CentOS 7 which AML 2 is based on https://github.com/ContinuumIO/anaconda-issues/issues/12822

The simple fix is to not set LD_LIBRARY_PATH which picks up libraries in /opt/conda/lib before the smoke test.  This step is not needed at this point.

### Testing

https://github.com/pytorch/builder/actions/runs/7227335815/job/19694776867