### PR TITLE
Do not hardcode triton version in builder code

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -275,8 +275,9 @@ else
     fi
     if [[ "$OSTYPE" != "msys" ]]; then
         # TODO: Remove me when Triton has a proper release channel
+        TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
         TRITON_SHORTHASH=$(cut -c1-10 $pytorch_rootdir/.github/ci_commit_pins/triton.txt)
-        export CONDA_TRITON_CONSTRAINT="    - torchtriton==2.1.0+${TRITON_SHORTHASH} # [py < 312]"
+        export CONDA_TRITON_CONSTRAINT="    - torchtriton==${TRITON_VERSION}+${TRITON_SHORTHASH} # [py < 312]"
     fi
 
     build_string_suffix="cuda${CUDA_VERSION}_cudnn${CUDNN_VERSION}_${build_string_suffix}"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -275,7 +275,7 @@ else
     fi
     if [[ "$OSTYPE" != "msys" ]]; then
         # TODO: Remove me when Triton has a proper release channel
-        TRITON_VERSION=$(cat $PYTORCH_ROOT/.ci/docker/triton_version.txt)
+        TRITON_VERSION=$(cat $pytorch_rootdir/.ci/docker/triton_version.txt)
         TRITON_SHORTHASH=$(cut -c1-10 $pytorch_rootdir/.github/ci_commit_pins/triton.txt)
         export CONDA_TRITON_CONSTRAINT="    - torchtriton==${TRITON_VERSION}+${TRITON_SHORTHASH} # [py < 312]"
     fi


### PR DESCRIPTION
PyTorch nightly binaries are broken after https://github.com/pytorch/pytorch/pull/115743 because triton version was hardcoded to 2.1.0 on builder conda build.  We should load the version from `$PYTORCH_ROOT/.ci/docker/triton_version.txt` instead.