### PR TITLE
Add nccl version print for cuda related smoke test

### DIFF
--- a/test/smoke_test/smoke_test.py
+++ b/test/smoke_test/smoke_test.py
@@ -163,6 +163,7 @@ def smoke_test_cuda(package: str, runtime_error_check: str) -> None:
                 f"Wrong CUDA version. Loaded: {torch.version.cuda} Expected: {gpu_arch_ver}"
             )
         print(f"torch cuda: {torch.version.cuda}")
+        print(f"torch nccl version: {torch.cuda.nccl.version()}" )
         # todo add cudnn version validation
         print(f"torch cudnn: {torch.backends.cudnn.version()}")
         print(f"cuDNN enabled? {torch.backends.cudnn.enabled}")


### PR DESCRIPTION
Print nccl version during validation tests
Related to: https://github.com/pytorch/pytorch/issues/116977
