### PR TITLE
Fix test_ops scripts on release validation testing

### DIFF
--- a/.github/scripts/validate_test_ops.sh
+++ b/.github/scripts/validate_test_ops.sh
@@ -7,7 +7,7 @@ retry () {
 }
 
 BRANCH=""
-if [[ ${MATRIX_CHANNEL} == "test" ]]; then
+if [[ ${MATRIX_CHANNEL} == "test" || ${MATRIX_CHANNEL} == "release" ]]; then
     SHORT_VERSION=${MATRIX_STABLE_VERSION%.*}
     BRANCH="--branch release/${SHORT_VERSION}"
 fi


### PR DESCRIPTION
During validation we should run validation script from release branch rather then main branch