### PR TITLE
Minor tweak to fbgemmgpu version to ignore RC suffix

### DIFF
--- a/release/promote.sh
+++ b/release/promote.sh
@@ -12,7 +12,13 @@ TORCHAUDIO_VERSION=${TORCHAUDIO_VERSION:-2.1.1}
 TORCHTEXT_VERSION=${TORCHTEXT_VERSION:-0.16.1}
 TORCHDATA_VERSION=${TORCHDATA_VERSION:-0.7.1}
 TORCHREC_VERSION=${TORCHREC_VERSION:-0.6.0}
-FBGEMMGPU_VERSION=${FBGEMMGPU_VERSION:-0.6.0}
+
+# NB: FBGEMMGPU uses the practice of keeping rc version in the filename, i.e.
+# fbgemm_gpu-0.6.0rc1+cpu-cp311-cp311. On the other hand, its final RC will
+# be without rc suffix, fbgemm_gpu-0.6.0+cpu-cp311-cp311, and that's the one
+# ready to be promoted. So, keeping a + here in the version name allows the
+# promote script to find the correct binaries
+FBGEMMGPU_VERSION=${FBGEMMGPU_VERSION:-0.6.0+}
 
 DRY_RUN=${DRY_RUN:-enabled}
 

--- a/release/release_versions.sh
+++ b/release/release_versions.sh
@@ -7,4 +7,10 @@ TORCHAUDIO_VERSION=${TORCHAUDIO_VERSION:-2.2.0}
 TORCHTEXT_VERSION=${TORCHTEXT_VERSION:-0.17.0}
 TORCHDATA_VERSION=${TORCHDATA_VERSION:-0.7.1}
 TORCHREC_VERSION=${TORCHREC_VERSION:-0.6.0}
-FBGEMMGPU_VERSION=${FBGEMMGPU_VERSION:-0.6.0}
+
+# NB: FBGEMMGPU uses the practice of keeping rc version in the filename, i.e.
+# fbgemm_gpu-0.6.0rc1+cpu-cp311-cp311. On the other hand, its final RC will
+# be without rc suffix, fbgemm_gpu-0.6.0+cpu-cp311-cp311, and that's the one
+# ready to be promoted. So, keeping a + here in the version name allows the
+# promote script to find the correct binaries
+FBGEMMGPU_VERSION=${FBGEMMGPU_VERSION:-0.6.0+}


### PR DESCRIPTION
As fbgemm now publishes the final RC without the RC suffix for promotion, we need to tweak the script a bit to ignore all binaries with RC suffix and only promote the one without it.

### Testing

The promotion script correctly finds all 0.6.0 binaries.

```
bash promote.sh
=-=-=-= Promoting fbgemm_gpu's v0.6.0+ whl packages' =-=-=-=
+ TEST_PYTORCH_PROMOTE_VERSION=0.6.0+
+ PACKAGE_NAME=fbgemm_gpu
+ PACKAGE_TYPE=whl
+ TEST_WITHOUT_GIT_TAG=1
+ DRY_RUN=enabled
+ /tmp/builder/release/promote/s3_to_s3.sh
+ aws s3 cp --dryrun --only-show-errors --acl public-read --recursive --exclude '*' --include '*fbgemm_gpu-0.6.0+*' s3://pytorch/whl/test s3://pytorch/whl/
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp310-cp310-manylinux2014_aarch64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp310-cp310-manylinux2014_aarch64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp310-cp310-manylinux2014_x86_64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp310-cp310-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp311-cp311-manylinux2014_aarch64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp311-cp311-manylinux2014_aarch64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp311-cp311-manylinux2014_x86_64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp311-cp311-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp312-cp312-manylinux2014_aarch64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp312-cp312-manylinux2014_aarch64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp312-cp312-manylinux2014_x86_64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp312-cp312-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp38-cp38-manylinux2014_aarch64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp38-cp38-manylinux2014_aarch64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp38-cp38-manylinux2014_x86_64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp38-cp38-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp39-cp39-manylinux2014_aarch64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp39-cp39-manylinux2014_aarch64.whl
(dryrun) copy: s3://pytorch/whl/test/cpu/fbgemm_gpu-0.6.0+cpu-cp39-cp39-manylinux2014_x86_64.whl to s3://pytorch/whl/cpu/fbgemm_gpu-0.6.0+cpu-cp39-cp39-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu118/fbgemm_gpu-0.6.0+cu118-cp310-cp310-manylinux2014_x86_64.whl to s3://pytorch/whl/cu118/fbgemm_gpu-0.6.0+cu118-cp310-cp310-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu118/fbgemm_gpu-0.6.0+cu118-cp311-cp311-manylinux2014_x86_64.whl to s3://pytorch/whl/cu118/fbgemm_gpu-0.6.0+cu118-cp311-cp311-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu118/fbgemm_gpu-0.6.0+cu118-cp312-cp312-manylinux2014_x86_64.whl to s3://pytorch/whl/cu118/fbgemm_gpu-0.6.0+cu118-cp312-cp312-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu118/fbgemm_gpu-0.6.0+cu118-cp38-cp38-manylinux2014_x86_64.whl to s3://pytorch/whl/cu118/fbgemm_gpu-0.6.0+cu118-cp38-cp38-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu118/fbgemm_gpu-0.6.0+cu118-cp39-cp39-manylinux2014_x86_64.whl to s3://pytorch/whl/cu118/fbgemm_gpu-0.6.0+cu118-cp39-cp39-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu121/fbgemm_gpu-0.6.0+cu121-cp310-cp310-manylinux2014_x86_64.whl to s3://pytorch/whl/cu121/fbgemm_gpu-0.6.0+cu121-cp310-cp310-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu121/fbgemm_gpu-0.6.0+cu121-cp311-cp311-manylinux2014_x86_64.whl to s3://pytorch/whl/cu121/fbgemm_gpu-0.6.0+cu121-cp311-cp311-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu121/fbgemm_gpu-0.6.0+cu121-cp312-cp312-manylinux2014_x86_64.whl to s3://pytorch/whl/cu121/fbgemm_gpu-0.6.0+cu121-cp312-cp312-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu121/fbgemm_gpu-0.6.0+cu121-cp38-cp38-manylinux2014_x86_64.whl to s3://pytorch/whl/cu121/fbgemm_gpu-0.6.0+cu121-cp38-cp38-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/cu121/fbgemm_gpu-0.6.0+cu121-cp39-cp39-manylinux2014_x86_64.whl to s3://pytorch/whl/cu121/fbgemm_gpu-0.6.0+cu121-cp39-cp39-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp310-cp310-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp310-cp310-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp311-cp311-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp311-cp311-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp312-cp312-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp312-cp312-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp38-cp38-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp38-cp38-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp39-cp39-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.6/fbgemm_gpu-0.6.0+rocm5.6-cp39-cp39-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp310-cp310-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp310-cp310-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp311-cp311-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp311-cp311-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp312-cp312-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp312-cp312-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp38-cp38-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp38-cp38-manylinux2014_x86_64.whl
(dryrun) copy: s3://pytorch/whl/test/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp39-cp39-manylinux2014_x86_64.whl to s3://pytorch/whl/rocm5.7/fbgemm_gpu-0.6.0+rocm5.7-cp39-cp39-manylinux2014_x86_64.whl
```