### PR TITLE
ci: aarch64 linux: fix torch performance regression with conda openblas package

### DIFF
--- a/aarch64_linux/aarch64_ci_setup.sh
+++ b/aarch64_linux/aarch64_ci_setup.sh
@@ -30,7 +30,7 @@ if [[ "$DESIRED_PYTHON"  == "3.8" ]]; then
 else
     NUMPY_VERSION="1.26.2"
 fi
-conda install -y -c conda-forge numpy==${NUMPY_VERSION} pyyaml==6.0.1 patchelf==0.17.2 pygit2==1.13.2 openblas==0.3.25 ninja==1.11.1 scons==4.5.2
+conda install -y -c conda-forge numpy==${NUMPY_VERSION} pyyaml==6.0.1 patchelf==0.17.2 pygit2==1.13.2 openblas==0.3.25=*openmp* ninja==1.11.1 scons==4.5.2
 
 python --version
 conda --version


### PR DESCRIPTION
changing the conda openblas package from pthread version to openmp version to match torch openmp runtime.  The pthread version was conflicting with the openmp runtime and causing thread over-subscription and performance degradation.

This fixes the regression introduced when the wheel builder was moved from local openblas builds to conda package in PyTorch 2.1.