### PR TITLE
Remove custom PyTorch build dependency logic on 3.11

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -142,7 +142,7 @@ if [[ "$cuda_ver" != 'cpu' ]]; then
     fi
 fi
 
-# Check that OpenBlas is not linked to on Macs
+# Check that OpenBlas is not linked to on MacOS
 if [[ "$(uname)" == 'Darwin' ]]; then
     echo "Checking the OpenBLAS is not linked to"
     all_dylibs=($(find "$(python -c "import site; print(site.getsitepackages()[0])")"/torch -name '*.dylib'))
@@ -153,6 +153,9 @@ if [[ "$(uname)" == 'Darwin' ]]; then
             exit 1
         fi
     done
+
+    echo "Checking that OpenMP is available"
+    python -c "import torch; exit(0 if torch.backends.openmp.is_available() else 1)"
 fi
 
 popd

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -182,11 +182,8 @@ tmp_env_name="wheel_py$python_nodot"
 conda create ${EXTRA_CONDA_INSTALL_FLAGS} -yn "$tmp_env_name" python="$desired_python"
 source activate "$tmp_env_name"
 
-if [[ "$desired_python" == "3.11" ]]; then
-  retry pip install -q "numpy${NUMPY_PINNED_VERSION}" "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" typing_extensions requests
-else
-  retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" typing_extensions requests
-fi
+retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq "numpy${NUMPY_PINNED_VERSION}" nomkl "setuptools${SETUPTOOLS_PINNED_VERSION}" "pyyaml${PYYAML_PINNED_VERSION}" typing_extensions requests
+
 if [[ "$(uname -m)" == "arm64" ]]; then
   retry conda install ${EXTRA_CONDA_INSTALL_FLAGS} -yq cmake ninja
 else


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/114721, we had an obsolete custom logic for 3.11 when it comes to install build dependencies.  Specifically, the 3.11 if branch  doesn't include `nomkl`.

I think this can be removed because the else branch works for 3.12.

If this works out, I will cherry pick the change to 2.2.1.