### PR TITLE
Pin conda-build to 3.28.4

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -208,7 +208,8 @@ if [[ "$(uname)" == 'Darwin' ]]; then
         "$miniconda_sh" -b -p "$tmp_conda" && \
         rm "$miniconda_sh"
     export PATH="$tmp_conda/bin:$PATH"
-    retry conda install -yq conda-build
+    # TODO(huydhn): We can revert the pin after https://github.com/conda/conda-build/issues/5167 is resolved
+    retry conda install -yq conda-build=3.28.4
 elif [[ "$OSTYPE" == "msys" ]]; then
     export tmp_conda="${WIN_PACKAGE_WORK_DIR}\\conda"
     export miniconda_exe="${WIN_PACKAGE_WORK_DIR}\\miniconda.exe"
@@ -219,7 +220,8 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     pushd $tmp_conda
     export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"
     popd
-    retry conda install -yq conda-build
+    # TODO(huydhn): We can revert the pin after https://github.com/conda/conda-build/issues/5167 is resolved
+    retry conda install -yq conda-build=3.28.4
 fi
 
 cd "$SOURCE_DIR"
@@ -351,8 +353,6 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
       conda install -y conda-package-handling conda==22.9.0
     else
       conda install -y conda-package-handling conda==23.5.2
-      # NS: To be removed after conda docker images are updated
-      conda update -y conda-build
     fi
 
     echo "Calling conda-build at $(date)"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -220,8 +220,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     pushd $tmp_conda
     export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"
     popd
-    # TODO(huydhn): We can revert the pin after https://github.com/conda/conda-build/issues/5167 is resolved
-    retry conda install -yq conda-build=3.28.4
+    retry conda install -yq conda-build
 fi
 
 cd "$SOURCE_DIR"


### PR DESCRIPTION
Conda build 24.1.0 release is botched with a pretty serious bug https://github.com/conda/conda-build/issues/5167 where successful builds are reported as failures.  This causes nightly conda build to fail on MacOS.  It's a bit weird that Linux and Windows conda builds are still working.

There might be a better workaround coming from https://github.com/conda/conda-build/issues/5167, but it's easy to pin the version for the time being.