### PR TITLE
Update toolchain in CXX11-abi docker

### DIFF
--- a/manywheel/Dockerfile_cxx11-abi
+++ b/manywheel/Dockerfile_cxx11-abi
@@ -3,6 +3,7 @@ FROM centos:8 as base
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
+ENV PATH /opt/rh/gcc-toolset-9/root/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # change to a valid repo
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*.repo
@@ -11,7 +12,8 @@ RUN sed -i 's|enabled=0|enabled=1|g' /etc/yum.repos.d/CentOS-Linux-PowerTools.re
 
 RUN yum -y update
 RUN yum install -y wget curl perl util-linux xz bzip2 git patch which zlib-devel
-RUN yum install -y autoconf automake make cmake gdb gcc gcc-c++
+RUN yum install -y autoconf automake make cmake gdb gcc-toolset-9-gcc-c++
+
 
 FROM base as openssl
 ADD ./common/install_openssl.sh install_openssl.sh

--- a/manywheel/Dockerfile_cxx11-abi
+++ b/manywheel/Dockerfile_cxx11-abi
@@ -3,7 +3,7 @@ FROM centos:8 as base
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-ENV PATH /opt/rh/gcc-toolset-9/root/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH /opt/rh/gcc-toolset-11/root/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # change to a valid repo
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*.repo
@@ -12,7 +12,7 @@ RUN sed -i 's|enabled=0|enabled=1|g' /etc/yum.repos.d/CentOS-Linux-PowerTools.re
 
 RUN yum -y update
 RUN yum install -y wget curl perl util-linux xz bzip2 git patch which zlib-devel
-RUN yum install -y autoconf automake make cmake gdb gcc-toolset-9-gcc-c++
+RUN yum install -y autoconf automake make cmake gdb gcc-toolset-11-gcc-c++
 
 
 FROM base as openssl


### PR DESCRIPTION
To gcc-11, as older ones(gcc-8.4 and gcc-9.2) are not compatible with latest PyTorch nor with AVX512

Fixes https://github.com/pytorch/pytorch/issues/120418