### PR TITLE
Add magma build for CUDA12.4

### DIFF
--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: linux.2xlarge
     strategy:
       matrix:
-        cuda_version: ["121", "118"]
+        cuda_version: ["124", "121", "118"]
     steps:
       - name: Checkout PyTorch builder
         uses: actions/checkout@v3

--- a/magma/Makefile
+++ b/magma/Makefile
@@ -24,9 +24,9 @@ clean:
 	$(RM) -r output
 
 .PHONY: magma-cuda124
-magma-cuda121: DESIRED_CUDA := 12.4
-magma-cuda121: PACKAGE_NAME := magma-cuda124
-magma-cuda121:
+magma-cuda124: DESIRED_CUDA := 12.4
+magma-cuda124: PACKAGE_NAME := magma-cuda124
+magma-cuda124:
 	$(DOCKER_RUN)
 
 .PHONY: magma-cuda121

--- a/magma/Makefile
+++ b/magma/Makefile
@@ -14,6 +14,7 @@ DOCKER_RUN = set -eou pipefail; docker run --rm -i \
 	magma/build_magma.sh
 
 .PHONY: all
+all: magma-cuda124
 all: magma-cuda121
 all: magma-cuda118
 
@@ -21,6 +22,12 @@ all: magma-cuda118
 clean:
 	$(RM) -r magma-*
 	$(RM) -r output
+
+.PHONY: magma-cuda124
+magma-cuda121: DESIRED_CUDA := 12.4
+magma-cuda121: PACKAGE_NAME := magma-cuda124
+magma-cuda121:
+	$(DOCKER_RUN)
 
 .PHONY: magma-cuda121
 magma-cuda121: DESIRED_CUDA := 12.1


### PR DESCRIPTION
This PR adds magma builds for CUDA 12.4 according to https://github.com/pytorch/builder/blob/main/CUDA_UPGRADE_GUIDE.MD 

cc @atalman @malfet @ptrblck 