### PR TITLE
feat: Update OpenSSL to latest supported version

### DIFF
--- a/common/install_openssl.sh
+++ b/common/install_openssl.sh
@@ -2,13 +2,14 @@
 
 set -ex
 
-OPENSSL=openssl-1.1.1l
+OPENSSL=openssl-3.2.1
 
-wget -q -O ${OPENSSL}.tar.gz "https://ossci-linux.s3.amazonaws.com/${OPENSSL}.tar.gz"
+wget -q -O ${OPENSSL}.tar.gz "https://www.openssl.org/source/${OPENSSL}.tar.gz"
 tar xf "${OPENSSL}.tar.gz"
 cd "${OPENSSL}"
 ./config --prefix=/opt/openssl -d '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
-# NOTE: opensl errors out when built with the -j option
-make install_sw
+make -j $(nproc)
+make install
+ldconfig
 cd ..
 rm -rf "${OPENSSL}"


### PR DESCRIPTION
OpenSSL 1.1.1 reached EOL 6 months ago https://endoflife.date/openssl
