### PR TITLE
OneDNN patch: x64: brdgmm: fix blocking for big bs_group

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -194,7 +194,6 @@ git --no-pager log --max-count 1
 
 # Apply patch for https://github.com/pytorch/pytorch/issues/120547
 pushd "$pytorch_rootdir/third_party/ideep/mkl-dnn/"
-pwd
 git apply "$SOURCE_DIR/../mkldnn_fix/brdgmm.patch"
 popd
 popd
@@ -222,7 +221,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     pushd $tmp_conda
     export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"
     popd
-    retry conda install -yq conda-build=24.1.2 conda=24.1.2
+    retry conda install -yq conda-build
 fi
 
 cd "$SOURCE_DIR"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -191,6 +191,12 @@ pushd "$pytorch_rootdir"
 git submodule update --init --recursive
 echo "Using Pytorch from "
 git --no-pager log --max-count 1
+
+# Apply patch for https://github.com/pytorch/pytorch/issues/120547
+pushd "$pytorch_rootdir/third_party/ideep/mkl-dnn/"
+pwd
+git apply "$SOURCE_DIR/../mkldnn_fix/brdgmm.patch"
+popd
 popd
 
 # Windows builds need to install conda
@@ -216,7 +222,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     pushd $tmp_conda
     export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"
     popd
-    retry conda install -yq conda-build
+    retry conda install -yq conda-build=24.1.2 conda=24.1.2
 fi
 
 cd "$SOURCE_DIR"

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -127,6 +127,9 @@ git apply "$SOURCE_DIR/../mkldnn_fix/brdgmm.patch"
 popd
 
 case ${DESIRED_PYTHON} in
+  cp36-cp36m)
+    retry pip install -q numpy==1.11
+    ;;
   cp3[7-8]*)
     retry pip install -q numpy==1.15
     ;;

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -122,7 +122,6 @@ git submodule update --init --recursive
 
 # Apply patch for https://github.com/pytorch/pytorch/issues/120547
 pushd "$PYTORCH_ROOT/third_party/ideep/mkl-dnn/"
-pwd
 git apply "$SOURCE_DIR/../mkldnn_fix/brdgmm.patch"
 popd
 

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -134,7 +134,7 @@ case ${DESIRED_PYTHON} in
     retry pip install -q numpy==1.15
     ;;
   cp310*)
-    retry pip install -q numpy==2.0.0
+    retry pip install -q numpy==1.21.2
     ;;
   cp311*)
     retry pip install -q numpy==1.23.1

--- a/mkldnn_fix/brdgmm.patch
+++ b/mkldnn_fix/brdgmm.patch
@@ -1,0 +1,34 @@
+From bbaec145f8c64818fd5c3ed2cb9e2ae69daef887 Mon Sep 17 00:00:00 2001
+From: Andrey Kalinin <andrey.kalinin@intel.com>
+Date: Tue, 27 Feb 2024 10:55:32 -0800
+Subject: [PATCH] x64: brdgmm: fix blocking for big bs_group
+
+---
+ src/cpu/x64/brgemm/brgemm_utils.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/cpu/x64/brgemm/brgemm_utils.cpp b/src/cpu/x64/brgemm/brgemm_utils.cpp
+index c786a125bd5..5c5e9a0471c 100644
+--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
++++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
+@@ -1,5 +1,5 @@
+ /*******************************************************************************
+-* Copyright 2022-2023 Intel Corporation
++* Copyright 2022-2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -758,6 +758,13 @@ status_t brdgmm_blocking(brgemm_t *brg) {
+     nb_n_block1 = div_up(N, n_block1);
+     n_block1_tail = N % n_block1;
+ 
++    const auto min_possible_m_block2 = brg->brgattr.bs_group > 1
++            ? (max_acc_vmms / (2 * n_block1_num_steps) - brg->brgattr.bs_group
++                    + 1)
++            : 1;
++
++    if (min_possible_m_block2 < 1) brg->brgattr.bs_group = 1;
++
+     if (brg->brgattr.bs_group > 1) {
+         n_block2 = 1;
+     } else {


### PR DESCRIPTION
Apply https://github.com/oneapi-src/oneDNN/commit/bbaec145f8c64818fd5c3ed2cb9e2ae69daef887
To release 2.2.2

See Issue: https://github.com/pytorch/pytorch/issues/120547#issuecomment-1984931801

Test PR: https://github.com/pytorch/pytorch/pull/122101