### PR TITLE
docs(NCCL): :memo: update echo command to reflect NCCL 2.20.5

### DIFF
--- a/common/install_cuda.sh
+++ b/common/install_cuda.sh
@@ -25,7 +25,7 @@ function install_cusparselt_052 {
 }
 
 function install_118 {
-    echo "Installing CUDA 11.8 and cuDNN 8.7 and NCCL 2.15 and cuSparseLt-0.4.0"
+    echo "Installing CUDA 11.8 and cuDNN 8.7 and NCCL 2.20.5 and cuSparseLt-0.4.0"
     rm -rf /usr/local/cuda-11.8 /usr/local/cuda
     # install CUDA 11.8.0 in the same container
     wget -q https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run


### PR DESCRIPTION
install_118 function references an older version of NCCL which is not the version being installed.