### PR TITLE
Unpin conda on aarch64

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -3,7 +3,7 @@ if [[ ${MATRIX_PACKAGE_TYPE} == "libtorch" ]]; then
     unzip libtorch.zip
 else
 
-    if [[ ${TARGET_OS} == 'macos-arm64' ]]; then
+    if [[ ${TARGET_OS} == 'macos-arm64' ]] || [[ ${TARGET_OS} == 'linux-aarch64' ]]; then
         conda update -y -n base -c defaults conda
     else
         # Conda pinned see issue: https://github.com/ContinuumIO/anaconda-issues/issues/13350


### PR DESCRIPTION
This might be similar to https://github.com/pytorch/builder/pull/1721.  The new version of libmamba 1.5.7 is not working with conda 23.11.0 anymore on aarch64, i.e. https://github.com/pytorch/builder/actions/runs/8431876130/job/23090020964#step:11:1611

May be we should revert it back to not pining conda like it was before https://github.com/pytorch/builder/commit/af4827c637d2f1fca7fbc52e96364ea9840508a3