### PR TITLE
Revert "aarch64: apply the cherrypicked onednn PR-1768"

### DIFF
--- a/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/aarch64_linux/aarch64_wheel_ci_build.py
@@ -111,9 +111,6 @@ if __name__ == '__main__':
     with open("/builder/mkldnn_fix/fix-xbyak-failure.patch") as f:
         check_call(["patch", "-p1"], stdin=f, cwd="/pytorch/third_party/ideep/mkl-dnn")
 
-    print("Applying mkl-dnn patch to improve torch.compile() perf")
-    os.system("cd /pytorch/third_party/ideep/mkl-dnn && patch -p1 < /builder/mkldnn_fix/onednn-pr1768-aarch64-add-acl-sbgemm-inner-product-primitive.patch")  # noqa: E501
-
     os.system(f"cd /pytorch; {build_vars} python3 setup.py bdist_wheel")
     pytorch_wheel_name = complete_wheel("pytorch")
     print(f"Build Compelete. Created {pytorch_wheel_name}..")

--- a/aarch64_linux/build_aarch64_wheel.py
+++ b/aarch64_linux/build_aarch64_wheel.py
@@ -558,7 +558,6 @@ def start_build(host: RemoteHost, *,
         build_vars += " USE_MKLDNN=ON USE_MKLDNN_ACL=ON"
         host.run_cmd("cd $HOME && git clone https://github.com/pytorch/builder.git")
         host.run_cmd("cd $HOME/pytorch/third_party/ideep/mkl-dnn && patch -p1 < $HOME/builder/mkldnn_fix/fix-xbyak-failure.patch")  # noqa: E501
-        host.run_cmd("cd $HOME/pytorch/third_party/ideep/mkl-dnn && patch -p1 < $HOME/builder/mkldnn_fix/onednn-pr1768-aarch64-add-acl-sbgemm-inner-product-primitive.patch")  # noqa: E501
         host.run_cmd(f"cd $HOME/pytorch && export ACL_ROOT_DIR=$HOME/ComputeLibrary && {build_vars} python3 setup.py bdist_wheel{build_opts}")  # noqa: E501
         print('Repair the wheel')
         pytorch_wheel_name = host.list_dir("pytorch/dist")[0]


### PR DESCRIPTION
Reverts pytorch/builder#1717
Not required anymore, these changes are landed: https://github.com/pytorch/pytorch/pull/122164 