### PR TITLE
Add numpy 2.0.0rc1 support to conda and wheels

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - typing_extensions
     - ninja
     - libuv # [win]
-    - numpy=1.19 # [py <= 39]
+    - numpy=1.19 # [py == 38]
     - numpy=2.0.0rc1 # [py >= 39]
     - openssl=1.1.1l # [py >= 38 and py <= 310 and linux]
     - openssl=1.1.1s # [py == 311 and linux]


### PR DESCRIPTION
Fix py3.8 condition