### PR TITLE
[Release only] Pin PYTORCH_BUILD_NUMBER for final RC

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -71,7 +71,7 @@ requirements:
   {% endif %}
 
 build:
-  number: {{ environ.get('PYTORCH_BUILD_NUMBER', '1') }}
+  number: 1
   detect_binary_files_with_prefix: False
   string: "{{ environ.get('PYTORCH_BUILD_STRING') }}"
   script_env:


### PR DESCRIPTION
Previous builds all used : PYTORCH_BUILD_NUMBER = 0
You can see this from index.json of conda package:
```
  "arch": "x86_64",
  "build": "py3.9_cuda12.1_cudnn8.9.2_0",
  "build_number": 0,
```