### PR TITLE
CUDA 12.4 Conda Build Fix

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -401,30 +401,30 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     fi
 
     # Install the built package and run tests, unless it's for mac cross compiled arm64
-    if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
-        # Install the package as if from local repo instead of tar.bz2 directly in order
-        # to trigger runtime dependency installation. See https://github.com/conda/conda/issues/1884
-        # Notes:
-        # - pytorch-nightly is included to install torchtriton
-        # - nvidia is included for cuda builds, there's no harm in listing the channel for cpu builds
-        if [[ "$OSTYPE" == "msys" ]]; then
-          # note the extra slash: `pwd -W` returns `c:/path/to/dir`, we need to add an extra slash for the URI
-          local_channel="/$(pwd -W)/$output_folder"
-        else
-          local_channel="$(pwd)/$output_folder"
-        fi
-        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia
+    #if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
+    #    # Install the package as if from local repo instead of tar.bz2 directly in order
+    #    # to trigger runtime dependency installation. See https://github.com/conda/conda/issues/1884
+    #    # Notes:
+    #    # - pytorch-nightly is included to install torchtriton
+    #    # - nvidia is included for cuda builds, there's no harm in listing the channel for cpu builds
+    #    if [[ "$OSTYPE" == "msys" ]]; then
+    #      # note the extra slash: `pwd -W` returns `c:/path/to/dir`, we need to add an extra slash for the URI
+    #      local_channel="/$(pwd -W)/$output_folder"
+    #    else
+    #      local_channel="$(pwd)/$output_folder"
+    #    fi
+    #    conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia
 
-        echo "$(date) :: Running tests"
-        pushd "$pytorch_rootdir"
-        if [[ "$cpu_only" == 1 ]]; then
-            "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" 'cpu'
-        else
-            "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" "cu$cuda_nodot"
-        fi
-        popd
-        echo "$(date) :: Finished tests"
-    fi
+    #    echo "$(date) :: Running tests"
+    #    pushd "$pytorch_rootdir"
+    #    if [[ "$cpu_only" == 1 ]]; then
+    #        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" 'cpu'
+    #    else
+    #        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" "cu$cuda_nodot"
+    #    fi
+    #    popd
+    #    echo "$(date) :: Finished tests"
+    #fi
 
     # Clean up test folder
     source deactivate

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -413,7 +413,7 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
         else
           local_channel="$(pwd)/$output_folder"
         fi
-        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia
+        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia -c nweidia
 
         echo "$(date) :: Running tests"
         pushd "$pytorch_rootdir"

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -401,30 +401,30 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
     fi
 
     # Install the built package and run tests, unless it's for mac cross compiled arm64
-    #if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
-    #    # Install the package as if from local repo instead of tar.bz2 directly in order
-    #    # to trigger runtime dependency installation. See https://github.com/conda/conda/issues/1884
-    #    # Notes:
-    #    # - pytorch-nightly is included to install torchtriton
-    #    # - nvidia is included for cuda builds, there's no harm in listing the channel for cpu builds
-    #    if [[ "$OSTYPE" == "msys" ]]; then
-    #      # note the extra slash: `pwd -W` returns `c:/path/to/dir`, we need to add an extra slash for the URI
-    #      local_channel="/$(pwd -W)/$output_folder"
-    #    else
-    #      local_channel="$(pwd)/$output_folder"
-    #    fi
-    #    conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia
+    if [[ -z "$CROSS_COMPILE_ARM64" ]]; then
+        # Install the package as if from local repo instead of tar.bz2 directly in order
+        # to trigger runtime dependency installation. See https://github.com/conda/conda/issues/1884
+        # Notes:
+        # - pytorch-nightly is included to install torchtriton
+        # - nvidia is included for cuda builds, there's no harm in listing the channel for cpu builds
+        if [[ "$OSTYPE" == "msys" ]]; then
+          # note the extra slash: `pwd -W` returns `c:/path/to/dir`, we need to add an extra slash for the URI
+          local_channel="/$(pwd -W)/$output_folder"
+        else
+          local_channel="$(pwd)/$output_folder"
+        fi
+        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia
 
-    #    echo "$(date) :: Running tests"
-    #    pushd "$pytorch_rootdir"
-    #    if [[ "$cpu_only" == 1 ]]; then
-    #        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" 'cpu'
-    #    else
-    #        "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" "cu$cuda_nodot"
-    #    fi
-    #    popd
-    #    echo "$(date) :: Finished tests"
-    #fi
+        echo "$(date) :: Running tests"
+        pushd "$pytorch_rootdir"
+        if [[ "$cpu_only" == 1 ]]; then
+            "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" 'cpu'
+        else
+            "${SOURCE_DIR}/../run_tests.sh" 'conda' "$py_ver" "cu$cuda_nodot"
+        fi
+        popd
+        echo "$(date) :: Finished tests"
+    fi
 
     # Clean up test folder
     source deactivate

--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -413,7 +413,7 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
         else
           local_channel="$(pwd)/$output_folder"
         fi
-        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia -c nweidia
+        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia
 
         echo "$(date) :: Running tests"
         pushd "$pytorch_rootdir"

--- a/conda/pytorch-nightly/build.sh
+++ b/conda/pytorch-nightly/build.sh
@@ -63,8 +63,8 @@ if [[ -n "$build_with_cuda" ]]; then
     elif [[ $CUDA_VERSION == 12.1* || $CUDA_VERSION == 12.4* ]]; then
         # cuda 12 does not support sm_3x
         TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST;9.0"
-    # for cuda 12.1 (12.4) we use cudnn 8.8 (8.9) and include all dynamic loading libraries
-        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8 /usr/local/cuda-12.1/extras/CUPTI/lib64/libcupti.so.12 /usr/local/cuda/lib64/libcusparseLt.so.0)
+        # for cuda 12.1 (12.4) we use cudnn 8.8 (8.9) and include all dynamic loading libraries
+        DEPS_LIST=(/usr/local/cuda/lib64/libcudnn*.so.8 /usr/local/cuda/extras/CUPTI/lib64/libcupti.so.12 /usr/local/cuda/lib64/libcusparseLt.so.0)
     fi
     if [[ -n "$OVERRIDE_TORCH_CUDA_ARCH_LIST" ]]; then
         TORCH_CUDA_ARCH_LIST="$OVERRIDE_TORCH_CUDA_ARCH_LIST"


### PR DESCRIPTION
Fix the bug where building conda CUDA 12.4 encountered "no such file" as it tried to use CUPTI 12.1. CUPTI12.4 should be used. 

Failure: https://ossci-raw-job-status.s3.amazonaws.com/log/23871568549 Details:

```
basename /usr/local/cuda-12.1/extras/CUPTI/lib64/libcupti.so.12 filename=libcupti.so.12
cp /usr/local/cuda-12.1/extras/CUPTI/lib64/libcupti.so.12 /opt/conda/conda-bld/pytorch_1712964489150/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/lib/python3.10/site-packages/torch/lib/libcupti.so.12 cp: cannot stat /usr/local/cuda-12.1/extras/CUPTI/lib64/libcupti.so.12: No such file or directory
```

cc @malfet @atalman @ptrblck 