### PR TITLE
Windows use mkl static lib.

### DIFF
--- a/windows/build_pytorch.bat
+++ b/windows/build_pytorch.bat
@@ -122,7 +122,7 @@ for %%v in (%DESIRED_PYTHON_PREFIX%) do (
     ) else (
         set "PATH=%CONDA_HOME%\envs\%%v;%CONDA_HOME%\envs\%%v\scripts;%CONDA_HOME%\envs\%%v\Library\bin;%ORIG_PATH%"
     )
-    pip install ninja mkl-include==2021.4.0 mkl-devel==2021.4.0
+    pip install ninja
     @setlocal
     :: Set Flags
     if not "%CUDA_VERSION%"=="cpu" (

--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -9,11 +9,11 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
-    if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy>=1.11 "mkl=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.21.3 "mkl=2020.2" intel-openmp=2023.2.0 pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
-    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 "mkl=2020.2" intel-openmp=2023.2.0 pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
-    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 "mkl=2023.1" intel-openmp=2023.2.0 pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
+    if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 "intel::mkl-static=2020.2" "intel::mkl-include=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy>=1.11 "intel::mkl-static=2020.2" "intel::mkl-include=2020.2" pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.21.3 "intel::mkl-static=2020.2" "intel::mkl-include=2020.2" intel-openmp=2023.2.0 pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
+    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 "intel::mkl-static=2020.2" "intel::mkl-include=2020.2" intel-openmp=2023.2.0 pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
+    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 "intel::mkl-static=2023.1" "intel::mkl-include=2023.1" intel-openmp=2023.2.0 pyyaml boto3 "cmake=3.19.6" ninja typing_extensions python=%%v
 )
 endlocal
 

--- a/windows/internal/copy.bat
+++ b/windows/internal/copy.bat
@@ -11,10 +11,7 @@ copy "%CUDA_PATH%\extras\CUPTI\lib64\cupti64_*.dll*" pytorch\torch\lib
 
 copy "C:\Program Files\NVIDIA Corporation\NvToolsExt\bin\x64\nvToolsExt64_1.dll*" pytorch\torch\lib
 copy "%CONDA_LIB_PATH%\libiomp*5md.dll" pytorch\torch\lib
-IF "%PACKAGE_TYPE%"=="libtorch" (
-    copy "%CONDA_LIB_PATH%\mkl_intel_thread.1.dll" pytorch\torch\lib
-    copy "%CONDA_LIB_PATH%\mkl_core.1.dll" pytorch\torch\lib
-)
+
 :: Should be set in build_pytorch.bat
 copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib
 

--- a/windows/internal/copy_cpu.bat
+++ b/windows/internal/copy_cpu.bat
@@ -1,8 +1,3 @@
 copy "%CONDA_LIB_PATH%\libiomp*5md.dll" pytorch\torch\lib
 :: Should be set in build_pytorch.bat
 copy "%libuv_ROOT%\bin\uv.dll" pytorch\torch\lib
-
-IF "%PACKAGE_TYPE%"=="libtorch" (
-    copy "%CONDA_LIB_PATH%\mkl_intel_thread.1.dll" pytorch\torch\lib
-    copy "%CONDA_LIB_PATH%\mkl_core.1.dll" pytorch\torch\lib
-)


### PR DESCRIPTION
From pytorch issue: https://github.com/pytorch/pytorch/issues/124009 I found libtorch seems use shared mkl lib and missing some mkl dll files.
1. Currently pytorch Linux already use static mkl lib.
2. Windows can also support static mkl lib, I have validated as https://github.com/pytorch/pytorch/pull/116946

So, this PR will switch pytorch to use static mkl lib.
I have tested PR on my local PC:
<img width="1151" alt="image" src="https://github.com/pytorch/builder/assets/8433590/d727c361-3344-4d95-ac2e-8dc307b74690">
