### PR TITLE
Update pytorch-cuda for cuda12.4 conda build

### DIFF
--- a/conda/pytorch-cuda/conda_build_config.yaml
+++ b/conda/pytorch-cuda/conda_build_config.yaml
@@ -2,6 +2,7 @@ version:
     - 11.7
     - 11.8
     - 12.1
+    - 12.4
 target_platform:
     - win-64
     - linux-64

--- a/conda/pytorch-cuda/meta.yaml
+++ b/conda/pytorch-cuda/meta.yaml
@@ -11,7 +11,7 @@
 # deployment:
 # https://conda.anaconda.org/pytorch/noarch/
 # https://conda.anaconda.org/pytorch/noarch/repodata.json
-{% set build = 5 %}
+{% set build = 6 %}
 {% set cuda_constraints=">=11.7,<11.8" %}
 {% set libcufft_constraints=">=10.7.2.50,<10.9.0.58" %}
 {% set libcublas_constraints=">=11.10.1.25,<11.11.3.6" %}
@@ -36,6 +36,15 @@
 {% set libnpp_constraints=">=12.0.2.50,<12.1.0.40" %}
 {% set libnvjpeg_constraints=">=12.1.0.39,<12.2.0.2" %}
 {% set libnvjitlink_constraints=">=12.1.105,<12.2.0" %}
+{% elif version == '12.4' %}
+{% set cuda_constraints=">=12.4,<12.5" %}
+{% set libcufft_constraints=">=11.2.0.44,<11.2.1.3" %}
+{% set libcublas_constraints=">=12.4.2.65,<12.4.5.8" %}
+{% set libcusolver_constraints=">=11.6.0.99,<11.6.1.9" %}
+{% set libcusparse_constraints=">=12.3.0.142,<12.3.1.170" %}
+{% set libnpp_constraints=">=12.2.5.2,<12.2.5.30" %}
+{% set libnvjpeg_constraints=">=12.3.1.89,<12.3.1.117" %}
+{% set libnvjitlink_constraints=">=12.4.99,<12.4.127" %}
 {% endif %}
 
 package:


### PR DESCRIPTION
Constraint left from  https://docs.nvidia.com/cuda/archive/12.4.0/cuda-toolkit-release-notes/index.html 
Constraint right from
https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html on 04/19/2024

Without pytorch-cuda,[ the conda build jobs](https://github.com/pytorch/pytorch/actions/runs/8714246950/job/23904155594) in https://github.com/pytorch/pytorch/pull/121684 will have errors like  pytorch-cuda12.4 not found when tested manually, and may also produce misleading errors like the following: 

`2024-04-17T04:01:30.9725707Z Found conflicts! Looking for incompatible packages.
2024-04-17T04:01:30.9726420Z This can take several minutes.  Press CTRL-C to abort.
2024-04-17T04:01:30.9983809Z 
2024-04-17T04:01:30.9984478Z Building graph of deps:   0% 0/6 [00:00<?, ?it/s]
2024-04-17T04:01:30.9985329Z Examining @/linux-64::__unix==0=0:   0% 0/6 [00:00<?, ?it/s]
2024-04-17T04:01:30.9986140Z Examining @/linux-64::__glibc==2.17=0:  17% 1/6 [00:00<00:00, 9218.25it/s]
2024-04-17T04:01:31.0060669Z Examining pytorch==2.4.0.dev20240417:  33% 2/6 [00:00<00:00, 11335.96it/s]
2024-04-17T04:01:31.0201605Z Examining python=3.12:  50% 3/6 [00:00<00:00, 391.50it/s]                 
2024-04-17T04:01:31.0202725Z Examining @/linux-64::__linux==4.14.336=0:  67% 4/6 [00:00<00:00, 183.58it/s]
2024-04-17T04:01:31.0203650Z Examining @/linux-64::__archspec==1=x86_64:  83% 5/6 [00:00<00:00, 228.72it/s]
2024-04-17T04:01:31.0204349Z                                                                               
2024-04-17T04:01:31.0204709Z 
2024-04-17T04:01:31.0204901Z Determining conflicts:   0% 0/6 [00:00<?, ?it/s]
2024-04-17T04:01:31.0234483Z Examining conflict for python __glibc:   0% 0/6 [00:00<?, ?it/s]
2024-04-17T04:01:31.0317849Z Examining conflict for pytorch python:  17% 1/6 [00:00<00:00, 354.19it/s]
2024-04-17T04:01:31.0721905Z                                                                          
2024-04-17T04:01:31.0722561Z failed
2024-04-17T04:01:31.0723502Z 
2024-04-17T04:01:31.0724254Z UnsatisfiableError: The following specifications were found to be incompatible with each other:
2024-04-17T04:01:31.0724950Z 
2024-04-17T04:01:31.0725784Z Output in format: Requested package -> Available versionsThe following specifications were found to be incompatible with your system:
2024-04-17T04:01:31.0726590Z 
2024-04-17T04:01:31.0726910Z   - feature:/linux-64::__glibc==2.17=0
2024-04-17T04:01:31.0727592Z   - python=3.12 -> libgcc-ng[version='>=11.2.0'] -> __glibc[version='>=2.17']
2024-04-17T04:01:31.0728118Z 
2024-04-17T04:01:31.0728278Z Your installed version is: 2.17`


cc @ptrblck @tinglvv  @malfet @atalman 


