### PR TITLE
Adjust docker gpu aarch64 docker image

### DIFF
--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -9,7 +9,6 @@ DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
 GPU_ARCH_TYPE=${GPU_ARCH_TYPE:-cpu}
 GPU_ARCH_VERSION=${GPU_ARCH_VERSION:-}
 MANY_LINUX_VERSION=${MANY_LINUX_VERSION:-}
-
 WITH_PUSH=${WITH_PUSH:-}
 
 case ${GPU_ARCH_TYPE} in
@@ -54,11 +53,11 @@ case ${GPU_ARCH_TYPE} in
         ;;
     cuda-aarch64)
         TARGET=cuda_final
-        DOCKER_TAG=cuda-aarch64
+        DOCKER_TAG=cuda${GPU_ARCH_VERSION}
         LEGACY_DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/manylinux-cuda-aarch64
         GPU_IMAGE=arm64v8/centos:7
         DOCKER_GPU_BUILD_ARG="--build-arg BASE_CUDA_VERSION=${GPU_ARCH_VERSION} --build-arg DEVTOOLSET_VERSION=11"
-        MANY_LINUX_VERSION="aarch64"
+        MANY_LINUX_VERSION="cuda_aarch64"
         ;;
     rocm)
         TARGET=rocm_final

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -9,6 +9,7 @@ DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
 GPU_ARCH_TYPE=${GPU_ARCH_TYPE:-cpu}
 GPU_ARCH_VERSION=${GPU_ARCH_VERSION:-}
 MANY_LINUX_VERSION=${MANY_LINUX_VERSION:-}
+DOCKERFILE_SUFFIX=${DOCKERFILE_SUFFIX:-}
 WITH_PUSH=${WITH_PUSH:-}
 
 case ${GPU_ARCH_TYPE} in
@@ -54,10 +55,11 @@ case ${GPU_ARCH_TYPE} in
     cuda-aarch64)
         TARGET=cuda_final
         DOCKER_TAG=cuda${GPU_ARCH_VERSION}
-        LEGACY_DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/manylinux-cuda-aarch64
+        LEGACY_DOCKER_IMAGE=''
         GPU_IMAGE=arm64v8/centos:7
         DOCKER_GPU_BUILD_ARG="--build-arg BASE_CUDA_VERSION=${GPU_ARCH_VERSION} --build-arg DEVTOOLSET_VERSION=11"
-        MANY_LINUX_VERSION="cuda_aarch64"
+        MANY_LINUX_VERSION="aarch64"
+        DOCKERFILE_SUFFIX="cuda_aarch64"
         ;;
     rocm)
         TARGET=rocm_final
@@ -86,11 +88,9 @@ esac
 IMAGES=''
 DOCKER_NAME=manylinux${MANY_LINUX_VERSION}
 DOCKER_IMAGE=${DOCKER_REGISTRY}/pytorch/${DOCKER_NAME}-builder:${DOCKER_TAG}
-if [[ -n ${MANY_LINUX_VERSION} ]]; then
+if [[ -n ${MANY_LINUX_VERSION} && -z ${DOCKERFILE_SUFFIX} ]]; then
     DOCKERFILE_SUFFIX=_${MANY_LINUX_VERSION}
     LEGACY_DOCKER_IMAGE=''
-else
-    DOCKERFILE_SUFFIX=''
 fi
 (
     set -x

--- a/manywheel/build_docker.sh
+++ b/manywheel/build_docker.sh
@@ -59,7 +59,7 @@ case ${GPU_ARCH_TYPE} in
         GPU_IMAGE=arm64v8/centos:7
         DOCKER_GPU_BUILD_ARG="--build-arg BASE_CUDA_VERSION=${GPU_ARCH_VERSION} --build-arg DEVTOOLSET_VERSION=11"
         MANY_LINUX_VERSION="aarch64"
-        DOCKERFILE_SUFFIX="cuda_aarch64"
+        DOCKERFILE_SUFFIX="_cuda_aarch64"
         ;;
     rocm)
         TARGET=rocm_final


### PR DESCRIPTION
Follow up after https://github.com/pytorch/builder/pull/1775

This should fix this error: https://github.com/pytorch/builder/actions/runs/8792217019/job/24127939462#step:4:15
```
 docker build -t docker.io/pytorch/manylinuxaarch64-builder:cuda-aarch64 --build-arg BASE_CUDA_VERSION=12.4 --build-arg DEVTOOLSET_VERSION=11 --build-arg GPU_IMAGE=arm64v8/centos:7 --target cuda_final -f /home/ec2-user/actions-runner/_work/builder/builder/manywheel/Dockerfile_aarch64 /home/ec2-user/actions-runner/_work/builder/builder
#1 [internal] load build definition from Dockerfile_aarch64
```

Since Dockerfile_cuda_aarch64 has to be used. This keeps same docker image:
From:
```
docker.io/pytorch/manylinuxaarch64-builder:cuda-aarch64
```