### PR TITLE
feat: Update Magma from `2.6.1` -> `2.8.0` to support CUDA 12 and Hopper architecture

### DIFF
--- a/magma/package_files/meta.yaml
+++ b/magma/package_files/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: "{{ environ.get('PACKAGE_NAME') }}"
-  version: 2.6.1
+  version: 2.8.0
 
 source:
-   url: http://icl.utk.edu/projectsfiles/magma/downloads/magma-2.6.1.tar.gz
+   url: http://icl.utk.edu/projectsfiles/magma/downloads/magma-2.8.0.tar.gz
    patches:
      - cmakelists.patch
      - thread_queue.patch


### PR DESCRIPTION
- Update Magma from `2.6.1` -> `2.8.0` to support CUDA 12 and Hopper architecture. See #1759 for more details

Resolves #1759 

cc @atalman / @malfet / @ptrblck 