### PR TITLE
[Validations] Turn off CUDA exception catch test

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -62,7 +62,7 @@ else
     if [[ ${TARGET_OS} == 'windows' ]]; then
         python  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX}
     else
-        python3  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX}
+        python3  ./test/smoke_test/smoke_test.py ${TEST_SUFFIX} --runtime-error-check disabled
     fi
 
     if [[ ${TARGET_OS} == 'macos-arm64' ]]; then


### PR DESCRIPTION
Related to issue: https://github.com/pytorch/pytorch/issues/125804
Turn off ``runtime-error-check`` for now until the issue is resolved