### PR TITLE
[Manywheel] Add Python-3.13 compilation from branch

### DIFF
--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -6,7 +6,7 @@ PYTHON_DOWNLOAD_GITHUB_BRANCH=https://github.com/python/cpython/archive/refs/hea
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
 # Python versions to be installed in /opt/$VERSION_NO
-CPYTHON_VERSIONS=${CPYTHON_VERSIONS:-"3.8.1 3.9.0 3.10.1 3.11.0 3.12.0 3.13.0"}
+CPYTHON_VERSIONS=${CPYTHON_VERSIONS:-"3.7.5 3.8.1 3.9.0 3.10.1 3.11.0 3.12.0 3.13.0"}
 
 function check_var {
     if [ -z "$1" ]; then

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -17,9 +17,11 @@ function check_var {
 
 function do_cpython_build {
     local py_ver=$1
+    local py_folder=$2
     check_var $py_ver
+    check_var $py_folder
     tar -xzf Python-$py_ver.tgz
-    pushd Python-$py_ver
+    pushd $py_folder
 
     local prefix="/opt/_internal/cpython-${py_ver}"
     mkdir -p ${prefix}/lib
@@ -45,7 +47,7 @@ function do_cpython_build {
     fi
 
     popd
-    rm -rf Python-$py_ver
+    rm -rf $py_folder
     # Some python's install as bin/python3. Make them available as
     # bin/python.
     if [ -e ${prefix}/bin/python3 ]; then
@@ -69,10 +71,12 @@ function build_cpython {
         PY_VER_SHORT="3.13"
         check_var $PYTHON_DOWNLOAD_GITHUB_BRANCH
         wget $PYTHON_DOWNLOAD_GITHUB_BRANCH/$PY_VER_SHORT.tar.gz -O Python-$py_ver.tgz
+        do_cpython_build $py_ver cpython-$PY_VER_SHORT
     else
         wget -q $PYTHON_DOWNLOAD_URL/$py_ver_folder/Python-$py_ver.tgz
+        do_cpython_build $py_ver Python-$py_ver
     fi
-    do_cpython_build $py_ver none
+
     rm -f Python-$py_ver.tgz
 }
 

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -65,9 +65,9 @@ function build_cpython {
     check_var $py_ver
     check_var $PYTHON_DOWNLOAD_URL
     local py_ver_folder=$py_ver
-    # Only b2 version of 3.12 is available right now
     if [ "$py_ver" = "3.13.0" ]; then
         PY_VER_SHORT="3.13"
+        check_var $PYTHON_DOWNLOAD_GITHUB_BRANCH
         wget $PYTHON_DOWNLOAD_GITHUB_BRANCH/$PY_VER_SHORT.tar.gz -O Python-$py_ver.tgz
     else
         wget -q $PYTHON_DOWNLOAD_URL/$py_ver_folder/Python-$py_ver.tgz

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -2,7 +2,7 @@
 set -uex -o pipefail
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
-PYTHON_DOWNLOAD_GITHUB_BRANCH=https://github.com/python/cpython/archive/refs/heads/
+PYTHON_DOWNLOAD_GITHUB_BRANCH=https://github.com/python/cpython/archive/refs/heads
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
 # Python versions to be installed in /opt/$VERSION_NO

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -2,10 +2,11 @@
 set -uex -o pipefail
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
+PYTHON_DOWNLOAD_GITHUB_BRANCH=https://github.com/python/cpython/archive/refs/heads/
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
 # Python versions to be installed in /opt/$VERSION_NO
-CPYTHON_VERSIONS=${CPYTHON_VERSIONS:-"3.7.5 3.8.1 3.9.0 3.10.1 3.11.0 3.12.0"}
+CPYTHON_VERSIONS=${CPYTHON_VERSIONS:-"3.8.1 3.9.0 3.10.1 3.11.0 3.12.0 3.13.0"}
 
 function check_var {
     if [ -z "$1" ]; then
@@ -64,7 +65,13 @@ function build_cpython {
     check_var $py_ver
     check_var $PYTHON_DOWNLOAD_URL
     local py_ver_folder=$py_ver
-    wget -q $PYTHON_DOWNLOAD_URL/$py_ver_folder/Python-$py_ver.tgz
+    # Only b2 version of 3.12 is available right now
+    if [ "$py_ver" = "3.13.0" ]; then
+        PY_VER_SHORT="3.13"
+        wget $PYTHON_DOWNLOAD_GITHUB_BRANCH/$PY_VER_SHORT.tar.gz -O Python-$PY_VER_SHORT.tgz
+    else
+        wget -q $PYTHON_DOWNLOAD_URL/$py_ver_folder/Python-$py_ver.tgz
+    fi
     do_cpython_build $py_ver none
     rm -f Python-$py_ver.tgz
 }

--- a/common/install_cpython.sh
+++ b/common/install_cpython.sh
@@ -68,7 +68,7 @@ function build_cpython {
     # Only b2 version of 3.12 is available right now
     if [ "$py_ver" = "3.13.0" ]; then
         PY_VER_SHORT="3.13"
-        wget $PYTHON_DOWNLOAD_GITHUB_BRANCH/$PY_VER_SHORT.tar.gz -O Python-$PY_VER_SHORT.tgz
+        wget $PYTHON_DOWNLOAD_GITHUB_BRANCH/$PY_VER_SHORT.tar.gz -O Python-$py_ver.tgz
     else
         wget -q $PYTHON_DOWNLOAD_URL/$py_ver_folder/Python-$py_ver.tgz
     fi


### PR DESCRIPTION
Same as : https://github.com/pytorch/builder/pull/1427
This however adds an option to build python from latest release branch since we need patch that missed the b1 cut.
cc @albanD @malfet 