### PR TITLE
Use linux.12xlarge for manylinux docker build workflows

### DIFF
--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.12xlarge.ephemeral
+    runs-on: linux.12xlarge
     strategy:
       matrix:
         cuda_version: ["12.4", "12.1", "11.8"]


### PR DESCRIPTION
These are less prone to: Scale Up Lack of Available GHA Runners to Run issue