### PR TITLE
add cuda version to arm nightly wheel

### DIFF
--- a/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/aarch64_linux/aarch64_wheel_ci_build.py
@@ -220,7 +220,9 @@ if __name__ == "__main__":
         )
         if enable_cuda:
             desired_cuda = os.getenv("DESIRED_CUDA")
-            build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={version}.dev{build_date}+{desired_cuda} PYTORCH_BUILD_NUMBER=1 "
+            build_vars += (
+                f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={version}.dev{build_date}+{desired_cuda} PYTORCH_BUILD_NUMBER=1 "
+            )
         else:
             build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={version}.dev{build_date} PYTORCH_BUILD_NUMBER=1 "
     elif branch.startswith(("v1.", "v2.")):

--- a/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/aarch64_linux/aarch64_wheel_ci_build.py
@@ -218,7 +218,11 @@ if __name__ == "__main__":
         version = (
             check_output(["cat", "version.txt"], cwd="/pytorch").decode().strip()[:-2]
         )
-        build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={version}.dev{build_date} PYTORCH_BUILD_NUMBER=1 "
+        if enable_cuda:
+            desired_cuda = os.getenv("DESIRED_CUDA")
+            build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={version}.dev{build_date}+{desired_cuda} PYTORCH_BUILD_NUMBER=1 "
+        else:
+            build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={version}.dev{build_date} PYTORCH_BUILD_NUMBER=1 "
     elif branch.startswith(("v1.", "v2.")):
         build_vars += f"BUILD_TEST=0 PYTORCH_BUILD_VERSION={branch[1:branch.find('-')]} PYTORCH_BUILD_NUMBER=1 "
 


### PR DESCRIPTION
Follow up on https://github.com/pytorch/pytorch/pull/126174.
Need to add DESIRED_CUDA (ex: `cu124)` to wheel name in nightly/release branch.
Currently looks like - [torch-2.4.0.dev20240529-cp38-cp38-linux_aarch64.whl](https://download.pytorch.org/whl/nightly/cu124/torch-2.4.0.dev20240529-cp38-cp38-linux_aarch64.whl)

cc @atalman @ptrblck @nWEIdia 

