### PR TITLE
Disable linux.12xlarge.ephemeral due to AWS issue

### DIFF
--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build-docker:
-    runs-on: linux.12xlarge.ephemeral
+    runs-on: linux.12xlarge
     strategy:
       matrix:
         cuda_version: ["11.8", "12.1", "12.4", "cpu"]

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.12xlarge.ephemeral
+    runs-on: linux.12xlarge
     strategy:
       matrix:
         cuda_version: ["12.4", "12.1", "11.8"]

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-cuda-manylinux_2_28:
-    runs-on: linux.12xlarge.ephemeral
+    runs-on: linux.12xlarge
     strategy:
       matrix:
         cuda_version: ["12.4", "12.1", "11.8"]


### PR DESCRIPTION
Follow up on https://github.com/pytorch/builder/pull/1837 (AWS issue: Scale Up Lack of Available GHA Runners to Run issue)

cc @atalman 