### PR TITLE
Change OpenSSL URL

### DIFF
--- a/manywheel/build_scripts/build_utils.sh
+++ b/manywheel/build_scripts/build_utils.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Helper utilities for build
 
-OPENSSL_DOWNLOAD_URL=https://ftp.openssl.org/source/old/1.1.1/
+OPENSSL_DOWNLOAD_URL=https://mirror.math.princeton.edu/pub/openssl/source/old/1.1.1/
 CURL_DOWNLOAD_URL=https://curl.askapache.com/download
 
 AUTOCONF_DOWNLOAD_URL=https://ftp.gnu.org/gnu/autoconf

--- a/manywheel/build_scripts/build_utils.sh
+++ b/manywheel/build_scripts/build_utils.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Helper utilities for build
 
-OPENSSL_DOWNLOAD_URL=https://mirror.math.princeton.edu/pub/openssl/source/old/1.1.1/
+OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source/old/1.1.1/
 CURL_DOWNLOAD_URL=https://curl.askapache.com/download
 
 AUTOCONF_DOWNLOAD_URL=https://ftp.gnu.org/gnu/autoconf


### PR DESCRIPTION
It seems https://ftp.openssl.org/source/old/1.1.1/ is no longer available, 
switching to https://mirror.math.princeton.edu/pub/openssl/source/old/1.1.1/ 

But need to follow up on why we are using so much older ssl. 