### PR TITLE
[Release 2.4] Temp change to build triton from pin

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -285,7 +285,7 @@ else
     if [[ "$OSTYPE" != "msys" ]]; then
         # TODO: Remove me when Triton has a proper release channel
         TRITON_VERSION=$(cat $pytorch_rootdir/.ci/docker/triton_version.txt)
-        if [[ -n "$OVERRIDE_PACKAGE_VERSION" && "$OVERRIDE_PACKAGE_VERSION" =~ .*dev.* ]]; then
+        if [[ -n "$OVERRIDE_PACKAGE_VERSION" ]]; then
             TRITON_SHORTHASH=$(cut -c1-10 $pytorch_rootdir/.github/ci_commit_pins/triton.txt)
             export CONDA_TRITON_CONSTRAINT="    - torchtriton==${TRITON_VERSION}+${TRITON_SHORTHASH} # [py < 313]"
         else


### PR DESCRIPTION
Same as this: https://github.com/pytorch/builder/commit/ba3e20bd7812a068d1157352541cea7751222706
While triton release branch does not exist yet, build it from hash