### PR TITLE
Revert "[Release 2.4] Temp change to build triton from pin"

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -285,7 +285,7 @@ else
     if [[ "$OSTYPE" != "msys" ]]; then
         # TODO: Remove me when Triton has a proper release channel
         TRITON_VERSION=$(cat $pytorch_rootdir/.ci/docker/triton_version.txt)
-        if [[ -n "$OVERRIDE_PACKAGE_VERSION" ]]; then
+        if [[ -n "$OVERRIDE_PACKAGE_VERSION" && "$OVERRIDE_PACKAGE_VERSION" =~ .*dev.* ]]; then
             TRITON_SHORTHASH=$(cut -c1-10 $pytorch_rootdir/.github/ci_commit_pins/triton.txt)
             export CONDA_TRITON_CONSTRAINT="    - torchtriton==${TRITON_VERSION}+${TRITON_SHORTHASH} # [py < 313]"
         else


### PR DESCRIPTION
Reverts pytorch/builder#1863

Need to be reverted. Triton branch cut is here:
https://github.com/triton-lang/triton/tree/release/3.0.x