### PR TITLE
Add ability to switch channels during conda build

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -413,7 +413,13 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
         else
           local_channel="$(pwd)/$output_folder"
         fi
-        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c pytorch-nightly -c nvidia
+
+        CONDA_CHANNEL="pytorch-test"
+        if [[ -n "$OVERRIDE_PACKAGE_VERSION" && "$OVERRIDE_PACKAGE_VERSION" =~ .*dev.* ]]; then
+            CONDA_CHANNEL="pytorch-nightly"
+        fi
+
+        conda install -y -c "file://$local_channel" pytorch==$PYTORCH_BUILD_VERSION -c pytorch -c numba/label/dev -c $CONDA_CHANNEL -c nvidia
 
         echo "$(date) :: Running tests"
         pushd "$pytorch_rootdir"


### PR DESCRIPTION
Should work for both nightly and test:

In nightly OVERRIDE_PACKAGE_VERSION is set to .*dev.*:
https://github.com/pytorch/pytorch/actions/runs/9610012241/job/26505605718#step:16:146