### PR TITLE
Typo fix for docker image name

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -50,7 +50,7 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
   elif [[ "$DESIRED_CUDA" == cpu ]]; then
     export DOCKER_IMAGE="pytorch/manylinux-builder:cpu"
   else
-    export DOCKER_IMAGE="pytorch/manylinux-builer:${DESIRED_CUDA:2}"
+    export DOCKER_IMAGE="pytorch/manylinux-builder:${DESIRED_CUDA:2}"
   fi
 fi
 


### PR DESCRIPTION
Changing builer to builder as it seems to be a typo