### PR TITLE
Fix libtorch Docker builds

### DIFF
--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -33,9 +33,8 @@ RUN apt-get update -y && \
 
 FROM base as cpu
 # Install python
-COPY --from=python /opt/python    /opt/python
-COPY --from=python /opt/_internal /opt/_internal
-ENV PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+ADD common/install_cpython.sh install_cpython.sh
+RUN bash ./install_cpython.sh && rm install_cpython.sh
 # Install MKL
 ADD ./common/install_mkl.sh install_mkl.sh
 RUN bash ./install_mkl.sh && rm install_mkl.sh

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -21,7 +21,7 @@ ADD ./common/install_openssl.sh install_openssl.sh
 RUN bash ./install_openssl.sh && rm install_openssl.sh
 
 # Install python
-FROM base as python
+FROM base as cpu
 ADD common/install_cpython.sh install_cpython.sh
 RUN apt-get update -y && \
     apt-get install build-essential gdb lcov libbz2-dev libffi-dev \
@@ -30,9 +30,6 @@ RUN apt-get update -y && \
     bash ./install_cpython.sh && \
     rm install_cpython.sh && \
     apt-get clean
-
-FROM python as cpu
-# Install MKL
 ADD ./common/install_mkl.sh install_mkl.sh
 RUN bash ./install_mkl.sh && rm install_mkl.sh
 

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -y && \
     rm install_cpython.sh && \
     apt-get clean
 
-FROM base as cpu
+FROM python as cpu
 # Install MKL
 ADD ./common/install_mkl.sh install_mkl.sh
 RUN bash ./install_mkl.sh && rm install_mkl.sh
@@ -64,7 +64,7 @@ FROM cpu as rocm
 ARG PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH ${PYTORCH_ROCM_ARCH}
 ENV MKLROOT /opt/intel
-# Adding ROCM_PATH env var so that LoadHip.cmake (even with logic updated for ROCm6.0) 
+# Adding ROCM_PATH env var so that LoadHip.cmake (even with logic updated for ROCm6.0)
 # find HIP works for ROCm5.7. Not needed for ROCm6.0 and above.
 # Remove below when ROCm5.7 is not in support matrix anymore.
 ENV ROCM_PATH /opt/rocm

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -21,7 +21,7 @@ ADD ./common/install_openssl.sh install_openssl.sh
 RUN bash ./install_openssl.sh && rm install_openssl.sh
 
 # Install python
-FROM base as cpu
+FROM base as python
 ADD common/install_cpython.sh install_cpython.sh
 RUN apt-get update -y && \
     apt-get install build-essential gdb lcov libbz2-dev libffi-dev \
@@ -30,6 +30,13 @@ RUN apt-get update -y && \
     bash ./install_cpython.sh && \
     rm install_cpython.sh && \
     apt-get clean
+
+FROM base as cpu
+# Install python
+COPY --from=python /opt/python    /opt/python
+COPY --from=python /opt/_internal /opt/_internal
+ENV PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+# Install MKL
 ADD ./common/install_mkl.sh install_mkl.sh
 RUN bash ./install_mkl.sh && rm install_mkl.sh
 

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -31,16 +31,17 @@ RUN apt-get update -y && \
     rm install_cpython.sh && \
     apt-get clean
 
+FROM base as conda
+ADD ./common/install_conda.sh install_conda.sh
+RUN bash ./install_conda.sh && rm install_conda.sh
+
 FROM base as cpu
+# Install Anaconda
+COPY --from=conda /opt/conda /opt/conda
 # Install python
-ADD common/install_cpython.sh install_cpython.sh
-RUN apt-get update -y && \
-    apt-get install build-essential gdb lcov libbz2-dev libffi-dev \
-        libgdbm-dev liblzma-dev libncurses5-dev libreadline6-dev \
-        libsqlite3-dev libssl-dev lzma lzma-dev tk-dev uuid-dev zlib1g-dev -y && \
-    bash ./install_cpython.sh && \
-    rm install_cpython.sh && \
-    apt-get clean
+COPY --from=python /opt/python    /opt/python
+COPY --from=python /opt/_internal /opt/_internal
+ENV PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
 # Install MKL
 ADD ./common/install_mkl.sh install_mkl.sh
 RUN bash ./install_mkl.sh && rm install_mkl.sh
@@ -49,10 +50,6 @@ FROM cpu as cuda
 ADD ./common/install_cuda.sh install_cuda.sh
 ADD ./common/install_magma.sh install_magma.sh
 ENV CUDA_HOME /usr/local/cuda
-
-FROM base as conda
-ADD ./common/install_conda.sh install_conda.sh
-RUN bash ./install_conda.sh && rm install_conda.sh
 
 FROM cuda as cuda11.8
 RUN bash ./install_cuda.sh 11.8

--- a/libtorch/Dockerfile
+++ b/libtorch/Dockerfile
@@ -34,7 +34,13 @@ RUN apt-get update -y && \
 FROM base as cpu
 # Install python
 ADD common/install_cpython.sh install_cpython.sh
-RUN bash ./install_cpython.sh && rm install_cpython.sh
+RUN apt-get update -y && \
+    apt-get install build-essential gdb lcov libbz2-dev libffi-dev \
+        libgdbm-dev liblzma-dev libncurses5-dev libreadline6-dev \
+        libsqlite3-dev libssl-dev lzma lzma-dev tk-dev uuid-dev zlib1g-dev -y && \
+    bash ./install_cpython.sh && \
+    rm install_cpython.sh && \
+    apt-get clean
 # Install MKL
 ADD ./common/install_mkl.sh install_mkl.sh
 RUN bash ./install_mkl.sh && rm install_mkl.sh


### PR DESCRIPTION
Follow up after: https://github.com/pytorch/builder/pull/1899
We require python and pip to be installed in order to install mkl, hence this change for libtorch Docker builds