### PR TITLE
Fix locale can not change warning

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -85,7 +85,8 @@ RUN yum install -y \
         wget \
         which \
         xz \
-        gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
+        gcc-toolset-${DEVTOOLSET_VERSION}-toolchain \
+        glibc-langpack-en
 
 RUN yum install -y \
     https://repo.ius.io/ius-release-el7.rpm \


### PR DESCRIPTION
Currently the docker images built from Docker_2_28 have locale can't set warning, and this issue will cause the xpu 3.8 manylinux wheel build job failed on numpy 1.15 installation phase, please refer https://github.com/pytorch/pytorch/actions/runs/9707728985/job/26809022850

Before fix:
```
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```