### PR TITLE
Use pypi for mkl-inlcude and mkl-static dependencies

### DIFF
--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -15,12 +15,10 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 pyyaml boto3 cmake ninja typing_extensions python=%%v
     if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 pyyaml boto3 cmake ninja typing_extensions python=%%v
     if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    call conda run -n py!PYTHON_VERSION_STR! pip install mkl-include
+    call conda run -n py!PYTHON_VERSION_STR! pip install mkl-static
 )
 endlocal
-
-:: Install mkl-static and mkl-include
-conda run -n py!PYTHON_VERSION_STR! pip install mkl-include
-conda run -n py!PYTHON_VERSION_STR! pip install mkl-static
 
 :: Install libuv
 conda install -y -q -c conda-forge libuv=1.39

--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -19,8 +19,8 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
 endlocal
 
 :: Install mkl-static and mkl-include
-python -m pip install mkl-include
-python -m pip install mkl-static
+conda run -n py!PYTHON_VERSION_STR! pip install mkl-include
+conda run -n py!PYTHON_VERSION_STR! pip install mkl-static
 
 :: Install libuv
 conda install -y -q -c conda-forge libuv=1.39

--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -9,15 +9,18 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
-    if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 intel::mkl-static intel::mkl-include pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy>=1.11 intel::mkl-static intel::mkl-include pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.21.3 intel::mkl-static intel::mkl-include pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 intel::mkl-static intel::mkl-include pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 intel::mkl-static intel::mkl-include pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 intel::mkl-static intel::mkl-include pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy>=1.11 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.21.3 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 pyyaml boto3 cmake ninja typing_extensions python=%%v
 )
 endlocal
 
+:: Install mkl-static and mkl-include
+python -m pip install mkl-include
+python -m pip install mkl-static
 
 :: Install libuv
 conda install -y -q -c conda-forge libuv=1.39


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/130034
Install mkl-include and static binaries from pypi rather then anaconda, which is not available anymore

Inspecting this fix I do see MKL is being included
```
-- MKL libraries: C:/actions-runner/_work/pytorch/pytorch/builder/windows/conda/envs/py38/Library/lib/mkl_intel_lp64.lib;C:/actions-runner/_work/pytorch/pytorch/builder/windows/conda/envs/py38/Library/lib/mkl_sequential.lib;C:/actions-runner/_work/pytorch/pytorch/builder/windows/conda/envs/py38/Library/lib/mkl_core.lib
-- MKL include directory: C:/actions-runner/_work/pytorch/pytorch/builder/windows/conda/envs/py38/Library/include
-- MKL OpenMP type: 
-- MKL OpenMP library: 
```

Test: https://github.com/pytorch/pytorch/actions/runs/9781702044/job/27007996917?pr=130035