### PR TITLE
[aarch64] set rpath for libs copied for cuda sbsa wheel

### DIFF
--- a/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/aarch64_linux/aarch64_wheel_ci_build.py
@@ -96,7 +96,8 @@ def update_wheel(wheel_path) -> None:
         lib_name = os.path.basename(lib_path)
         shutil.copy2(lib_path, f"{folder}/tmp/torch/lib/{lib_name}")
         os.system(
-            f"cd {folder}/tmp/torch/lib/; patchelf --set-rpath '$ORIGIN' --force-rpath {folder}/tmp/torch/lib/{lib_name}"
+            f"cd {folder}/tmp/torch/lib/; "
+            f"patchelf --set-rpath '$ORIGIN' --force-rpath {folder}/tmp/torch/lib/{lib_name}"
         )
     os.mkdir(f"{folder}/cuda_wheel")
     os.system(f"cd {folder}/tmp/; zip -r {folder}/cuda_wheel/{wheelname} *")

--- a/aarch64_linux/aarch64_wheel_ci_build.py
+++ b/aarch64_linux/aarch64_wheel_ci_build.py
@@ -95,12 +95,9 @@ def update_wheel(wheel_path) -> None:
     for lib_path in libs_to_copy:
         lib_name = os.path.basename(lib_path)
         shutil.copy2(lib_path, f"{folder}/tmp/torch/lib/{lib_name}")
-    os.system(
-        f"cd {folder}/tmp/torch/lib/; patchelf --set-rpath '$ORIGIN' {folder}/tmp/torch/lib/libtorch_cuda.so"
-    )
-    os.system(
-        f"cd {folder}/tmp/torch/lib/; patchelf --set-rpath '$ORIGIN' {folder}/tmp/torch/lib/libcudnn_graph.so.9"
-    )
+        os.system(
+            f"cd {folder}/tmp/torch/lib/; patchelf --set-rpath '$ORIGIN' --force-rpath {folder}/tmp/torch/lib/{lib_name}"
+        )
     os.mkdir(f"{folder}/cuda_wheel")
     os.system(f"cd {folder}/tmp/; zip -r {folder}/cuda_wheel/{wheelname} *")
     shutil.move(


### PR DESCRIPTION
Set RPATH for all libs copied in the pip CUDA SBSA wheel to prevent lib not found error

Initially raised by @xwang233 initially in nightly testing -  
```
python test/test_decomp.py -v TestDecompCUDA.test_comprehensive_asinh_cuda_complex128 fails with NVRTC error: nvrtc: error: failed to open libnvrtc-builtins.so.12.4. Make sure that libnvrtc-builtins.so.12.4 is installed correctly
```

cc @xwang233 @ptrblck @atalman @nWEIdia 