### PR TITLE
Docker builds switch back to ephemeral runners

### DIFF
--- a/.github/workflows/build-conda-images.yml
+++ b/.github/workflows/build-conda-images.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build-docker:
-    runs-on: linux.12xlarge
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["11.8", "12.1", "12.4", "cpu"]

--- a/.github/workflows/build-libtorch-images.yml
+++ b/.github/workflows/build-libtorch-images.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.12xlarge
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["12.4", "12.1", "11.8"]
@@ -49,7 +49,7 @@ jobs:
         run: |
           libtorch/build_docker.sh
   build-docker-rocm:
-    runs-on: linux.12xlarge
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         rocm_version: ["6.0", "6.1"]

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   build-docker-cuda:
-    runs-on: linux.12xlarge
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["12.4", "12.1", "11.8"]
@@ -62,7 +62,7 @@ jobs:
           manywheel/build_docker.sh
   # NOTE: manylinux_2_28 are still experimental, see https://github.com/pytorch/pytorch/issues/123649
   build-docker-cuda-manylinux_2_28:
-    runs-on: linux.12xlarge
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         cuda_version: ["12.4", "12.1", "11.8"]
@@ -102,7 +102,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-rocm:
-    runs-on: linux.12xlarge
+    runs-on: linux.12xlarge.ephemeral
     strategy:
       matrix:
         rocm_version: ["6.0", "6.1"]
@@ -194,7 +194,7 @@ jobs:
         run: |
           manywheel/build_docker.sh
   build-docker-xpu:
-    runs-on: linux.12xlarge
+    runs-on: linux.12xlarge.ephemeral
     env:
       GPU_ARCH_TYPE: xpu
     steps:


### PR DESCRIPTION
Reverting:
https://github.com/pytorch/builder/pull/1839
https://github.com/pytorch/builder/pull/1837