### PR TITLE
add +PTX to CUDA 12.4 nightly binaries

### DIFF
--- a/manywheel/build_cuda.sh
+++ b/manywheel/build_cuda.sh
@@ -63,7 +63,7 @@ case ${CUDA_VERSION} in
         if [[ "$GPU_ARCH_TYPE" = "cuda-aarch64" ]]; then
             TORCH_CUDA_ARCH_LIST="9.0"
         else
-            TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST};9.0"
+            TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST};9.0+PTX"
         fi
         EXTRA_CAFFE2_CMAKE_FLAGS+=("-DATEN_NO_TEST=ON")
         ;;


### PR DESCRIPTION
This PR adds `+PTX` back to our x86 CUDA 12.4 binaries, which was previously dropped.
We should consider adding this change only to nightly binaries and keep versioned releases as they are to keep the binary size lower.
However, I'm unsure how and where the nightly builds are calling this script.

CC @malfet 