### PR TITLE
Windows nightly pin conda-build

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -220,7 +220,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     pushd $tmp_conda
     export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"
     popd
-    retry conda install -yq conda-build
+    retry conda install -yq conda-build=24.5.1
 fi
 
 cd "$SOURCE_DIR"


### PR DESCRIPTION
Fixes windows nightly failures by pinning conda.
Here are the failures: https://github.com/pytorch/pytorch/actions/runs/10090038332/job/27898631065