### PR TITLE
[Windows nightly] Use conda=22.9.0 and conda-build=3.26.1

### DIFF
--- a/conda/build_pytorch.sh
+++ b/conda/build_pytorch.sh
@@ -220,7 +220,7 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     pushd $tmp_conda
     export PATH="$(pwd):$(pwd)/Library/usr/bin:$(pwd)/Library/bin:$(pwd)/Scripts:$(pwd)/bin:$PATH"
     popd
-    retry conda install -yq conda-build=24.5.1
+    retry conda install -yq conda-build=3.26.1
 fi
 
 cd "$SOURCE_DIR"
@@ -357,7 +357,7 @@ for py_ver in "${DESIRED_PYTHON[@]}"; do
       # Don't run tests on windows (they were ignored mostly anyways)
       NO_TEST="--no-test"
       # Fow windows need to keep older conda version
-      conda install -y conda-package-handling conda==23.7.0
+      conda install -y conda-package-handling conda==22.9.0
     else
       conda install -y conda-package-handling conda==23.5.2
     fi


### PR DESCRIPTION
Taken from last successful run

```
2024-07-24T07:43:36.2073983Z The following packages will be downloaded:
2024-07-24T07:43:36.2074295Z 
2024-07-24T07:43:36.2074446Z     package                    |            build
2024-07-24T07:43:36.2074917Z     ---------------------------|-----------------
2024-07-24T07:43:36.2075441Z     conda-22.9.0               |  py310haa95532_0         898 KB
2024-07-24T07:43:36.2076041Z     conda-build-3.26.1         |  py310haa95532_0         601 KB
2024-07-24T07:43:36.2076708Z     conda-libmamba-solver-22.8.1|  py310haa95532_0          63 KB
2024-07-24T07:43:36.2077395Z     glob2-0.7                  |     pyhd3eb1b0_0          12 KB
....
```