### PR TITLE
Revert "Use numpy 2.0.0rc1 for windows builds"

### DIFF
--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -10,11 +10,11 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
     if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions python=%%v
-    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy>=1.11 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.21.3 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 pyyaml boto3 cmake ninja typing_extensions python=%%v
+    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 pyyaml boto3 cmake ninja typing_extensions python=%%v
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-include
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-static
 )


### PR DESCRIPTION
Reverts pytorch/builder#1941 
More testing is required