### PR TITLE
Update PyTorch-CUDA for CUDA 12.4.1 Bump

### DIFF
--- a/conda/pytorch-cuda/meta.yaml
+++ b/conda/pytorch-cuda/meta.yaml
@@ -11,7 +11,7 @@
 # deployment:
 # https://conda.anaconda.org/pytorch/noarch/
 # https://conda.anaconda.org/pytorch/noarch/repodata.json
-{% set build = 6 %}
+{% set build = 7 %}
 {% set cuda_constraints=">=11.7,<11.8" %}
 {% set libcufft_constraints=">=10.7.2.50,<10.9.0.58" %}
 {% set libcublas_constraints=">=11.10.1.25,<11.11.3.6" %}
@@ -38,13 +38,13 @@
 {% set libnvjitlink_constraints=">=12.1.105,<12.2.0" %}
 {% elif version == '12.4' %}
 {% set cuda_constraints=">=12.4,<12.5" %}
-{% set libcufft_constraints=">=11.2.0.44,<11.2.1.3" %}
-{% set libcublas_constraints=">=12.4.2.65,<12.4.5.8" %}
-{% set libcusolver_constraints=">=11.6.0.99,<11.6.1.9" %}
-{% set libcusparse_constraints=">=12.3.0.142,<12.3.1.170" %}
-{% set libnpp_constraints=">=12.2.5.2,<12.2.5.30" %}
-{% set libnvjpeg_constraints=">=12.3.1.89,<12.3.1.117" %}
-{% set libnvjitlink_constraints=">=12.4.99,<12.4.127" %}
+{% set libcufft_constraints=">=11.2.1.3,<11.2.3.18" %}
+{% set libcublas_constraints=">=12.4.5.8,<12.5.2.13" %}
+{% set libcusolver_constraints=">=11.6.1.9,<11.6.2.40" %}
+{% set libcusparse_constraints=">=12.3.1.170,<12.4.1.18" %}
+{% set libnpp_constraints=">=12.2.5.30,<12.3.0.116" %}
+{% set libnvjpeg_constraints=">=12.3.1.117,<12.3.2.38" %}
+{% set libnvjitlink_constraints=">=12.4.127,<12.5.40" %}
 {% endif %}
 
 package:


### PR DESCRIPTION
Update constraints to use cuda 12.4.1 as [ and cuda 12.5.0 as )
CUDA 12.4.1 page: https://docs.nvidia.com/cuda/archive/12.4.1/cuda-toolkit-release-notes/index.html
CUDA 12.5.0 page: https://docs.nvidia.com/cuda/archive/12.5.0/cuda-toolkit-release-notes/index.html

Similar to: https://github.com/pytorch/builder/pull/1792

cc @atalman @malfet @ptrblck @eqy @tinglvv 