### PR TITLE
Disable kineto for torch xpu nightly wheel build

### DIFF
--- a/manywheel/build_cpu.sh
+++ b/manywheel/build_cpu.sh
@@ -21,6 +21,8 @@ DIR_SUFFIX=cpu
 if [[ "$GPU_ARCH_TYPE" == "xpu" ]]; then
     DIR_SUFFIX=xpu
     source /opt/intel/oneapi/pytorch-gpu-dev-0.5/oneapi-vars.sh
+    # XPU kineto feature dependencies are not fully ready, disable kineto build as temp WA
+    export USE_KINETO=0
 fi
 
 WHEELHOUSE_DIR="wheelhouse$DIR_SUFFIX"


### PR DESCRIPTION
Temporally disable kineto for torch xpu nightly build. Refer latest xpu nightly build failure https://github.com/pytorch/pytorch/actions/runs/10315473776/job/28555724501