### PR TITLE
[Release 2.4] cherry pick of Use numpy 2.0.0rc1 for windows builds #1945

### DIFF
--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -10,10 +10,10 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
     if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy>=1.11 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.21.3 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.23.4 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=1.26.0 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-include
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-static
 )


### PR DESCRIPTION
Use numpy 2.0.0rc1 for windows builds. Use atalman channel so that numpy is taken from: [anaconda.org/atalman/numpy](https://anaconda.org/atalman/numpy) (conda-forge numpy 2.0.0rc1 seems not to work)
Test: https://github.com/pytorch/pytorch/pull/121979
Windows Workfows passing: [pytorch/pytorch/actions/runs/10172945340/job/28136289071?pr=121979](https://github.com/pytorch/pytorch/actions/runs/10172945340/job/28136289071?pr=121979)

Issue: https://github.com/pytorch/pytorch/issues/131668