### PR TITLE
Restrict validation workflow dispatch to 10 input params

### DIFF
--- a/.github/workflows/validate-aarch64-linux-binaries.yml
+++ b/.github/workflows/validate-aarch64-linux-binaries.yml
@@ -73,11 +73,6 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""

--- a/.github/workflows/validate-binaries.yml
+++ b/.github/workflows/validate-binaries.yml
@@ -96,11 +96,6 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Use version for each domain'
-        default: false
-        required: false
-        type: boolean
       include-test-ops:
         description: 'Include Test Ops tests (only Linux)'
         default: false

--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -84,11 +84,6 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -73,11 +73,6 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -73,11 +73,6 @@ on:
         default: ""
         required: false
         type: string
-      use-version-set:
-        description: 'Applies when version is used, use version for each domain'
-        default: false
-        required: false
-        type: boolean
       release-matrix:
         description: 'Release matrix - optional'
         default: ""


### PR DESCRIPTION
We can have only 10 dispatch parameters.Hence removing rarely used ``use-version-set`` option for now