### PR TITLE
Move numpy pin to 2.0.x

### DIFF
--- a/conda/pytorch-nightly/meta.yaml
+++ b/conda/pytorch-nightly/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - ninja
     - libuv # [win]
     - numpy=1.22.3 # [py == 38]
-    - numpy=2.0.0rc1 # [py >= 39]
+    - numpy=2.0.1 # [py >= 39]
     - openssl=1.1.1l # [py >= 38 and py <= 310 and linux]
     - openssl=1.1.1s # [py == 311 and linux]
     - openssl=3.0.12 # [py >= 312 and linux]

--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -135,37 +135,31 @@ case $desired_python in
         echo "Using 3.13 deps"
         SETUPTOOLS_PINNED_VERSION=">=68.0.0"
         PYYAML_PINNED_VERSION=">=6.0.1"
-        NUMPY_PINNED_VERSION="=2.0.0rc1"
+        NUMPY_PINNED_VERSION="=2.0.2"
         ;;
     3.12)
         echo "Using 3.12 deps"
         SETUPTOOLS_PINNED_VERSION=">=68.0.0"
         PYYAML_PINNED_VERSION=">=6.0.1"
-        NUMPY_PINNED_VERSION="=2.0.0rc1"
+        NUMPY_PINNED_VERSION="=2.0.2"
         ;;
     3.11)
         echo "Using 3.11 deps"
         SETUPTOOLS_PINNED_VERSION=">=46.0.0"
         PYYAML_PINNED_VERSION=">=5.3"
-        NUMPY_PINNED_VERSION="=2.0.0rc1"
+        NUMPY_PINNED_VERSION="=2.0.2"
         ;;
     3.10)
         echo "Using 3.10 deps"
         SETUPTOOLS_PINNED_VERSION=">=46.0.0"
         PYYAML_PINNED_VERSION=">=5.3"
-        NUMPY_PINNED_VERSION="=2.0.0rc1"
+        NUMPY_PINNED_VERSION="=2.0.2"
         ;;
     3.9)
         echo "Using 3.9 deps"
         SETUPTOOLS_PINNED_VERSION=">=46.0.0"
         PYYAML_PINNED_VERSION=">=5.3"
-        NUMPY_PINNED_VERSION="=2.0.0rc1"
-        ;;
-    3.8)
-        echo "Using 3.8 deps"
-        SETUPTOOLS_PINNED_VERSION=">=46.0.0"
-        PYYAML_PINNED_VERSION=">=5.3"
-        NUMPY_PINNED_VERSION="=1.19"
+        NUMPY_PINNED_VERSION="=2.0.2"
         ;;
     *)
         echo "Using default deps"

--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -9,12 +9,11 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
-    if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
-    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge -c=atalman numpy=2.0.0rc1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-include
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-static
 )


### PR DESCRIPTION
Please note for conda we move to 2.0.1 version since its the latest available: https://anaconda.org/anaconda/numpy/files?version=2.0.1
For wheels we move to 2.0.2