### PR TITLE
Temporarily put back py3.8 environment creation

### DIFF
--- a/wheel/build_wheel.sh
+++ b/wheel/build_wheel.sh
@@ -161,6 +161,12 @@ case $desired_python in
         PYYAML_PINNED_VERSION=">=5.3"
         NUMPY_PINNED_VERSION="=2.0.2"
         ;;
+    3.8)
+        echo "Using 3.8 deps"
+        SETUPTOOLS_PINNED_VERSION=">=46.0.0"
+        PYYAML_PINNED_VERSION=">=5.3"
+        NUMPY_PINNED_VERSION="=1.19"
+        ;;
     *)
         echo "Using default deps"
         NUMPY_PINNED_VERSION="=1.11.3"

--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -9,6 +9,7 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
+    if "%%v" == "3.8" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=1.11 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
     if "%%v" == "3.9" call conda create -n py!PYTHON_VERSION_STR! -y -q numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
     if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
     if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v


### PR DESCRIPTION
Will resolve libtorch failure, which is still using Python 3.8: https://github.com/pytorch/pytorch/actions/runs/10722567367/job/29734281913#step:12:20

Removed by: https://github.com/pytorch/builder/pull/1979