### PR TITLE
2nd attempt to guard aarch64-cuda (or rather cuda-aarch64)

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -19,7 +19,7 @@ else
     conda activate ${ENV_NAME}
     
     # Remove when https://github.com/pytorch/builder/issues/1985 is fixed
-    if [[ ${MATRIX_GPU_ARCH_TYPE} == 'cuda' && ${TARGET_OS} == 'linux-aarch64' ]]; then 
+    if [[ ${MATRIX_GPU_ARCH_TYPE} == 'cuda-aarch64' ]]; then 
         pip3 install numpy --force-reinstall
     fi
 


### PR DESCRIPTION
Previous PR did not seem to execute "pip3 install numpy -force-reinstall" and the CI did not seem to test this (only tested python 3.8). 

cc @atalman  @malfet  @ptrblck  @tinglvv 