### PR TITLE
Remove quiet mode when installing numpy

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -122,14 +122,14 @@ python setup.py clean
 retry pip install -qr requirements.txt
 case ${DESIRED_PYTHON} in
   cp38*)
-    retry pip install -q numpy==1.15
+    retry pip install numpy==1.15
     ;;
   cp31*)
-    retry pip install -q --pre numpy==2.0.2
+    retry pip install --pre numpy==2.0.2
     ;;
   # Should catch 3.9+
   *)
-    retry pip install -q --pre numpy==2.0.2
+    retry pip install --pre numpy==2.0.2
     ;;
 esac
 


### PR DESCRIPTION
Seeing following error during py3.13 build : https://github.com/pytorch/pytorch/actions/runs/10845011974

Removing quiet option to help debugging:
```
++ pip install -q --pre numpy==2.0.2
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [933 lines of output]
      + /opt/_internal/cpython-3.13.0/bin/python /tmp/pip-install-1rg0z2_j/numpy_7978849d6c8c466e9ddf2f6fb78b3549/vendored-meson/meson/meson.py setup /tmp/pip-install-1rg0z2_j/numpy_7978849d6c8c466e9ddf2f6fb78b3549 /tmp/pip-install-1rg0z2_j/numpy_7978849d6c8c466e9ddf2f6fb78b3549/.mesonpy-6gyb5le3 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/tmp/pip-install-1rg0z2_j/numpy_7978849d6c8c466e9ddf2f6fb78b3549/.mesonpy-6gyb5le3/meson-python-native-file.ini
      The Meson build system
      Version: 1.4.99
      Source dir: /tmp/pip-install-1rg0z2_j/numpy_7978849d6c8c466e9ddf2f6fb78b3549
      Build dir: /tmp/pip-install-1rg0z2_j/numpy_7978849d6c8c466e9ddf2f6fb78b3549/.mesonpy-6gyb5le3
      Build type: native build
      Project name: NumPy
      Project version: 2.0.2
      C compiler for the host machine: cc (gcc 9.3.1 "cc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)")
      C linker for the host machine: cc ld.bfd 2.32-16
      C++ compiler for the host machine: c++ (gcc 9.3.1 "c++ (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)")
      C++ linker for the host machine: c++ ld.bfd 2.32-16
      Cython compiler for the host machine: cython (cython 3.0.11)
      Host machine cpu family: x86_64
      Host machine cpu: x86_64
      Program python found: YES (/opt/_internal/cpython-3.13.0/bin/python)
      Found pkg-config: YES (/usr/bin/pkg-config) 0.27.1
      Run-time dependency python found: YES 3.13
      Has header "Python.h" with dependency python-3.13: YES
      Compiler for C supports arguments -fno-strict-aliasing: YES
      Test features "SSE SSE2 SSE3" : Supported
      Test features "SSSE3" : Supported
      Test features "SSE41" : Supported
      Test features "POPCNT" : Supported
      Test features "SSE42" : Supported
      Test features "AVX" : Supported
      Test features "F16C" : Supported
      Test features "FMA3" : Supported
      Test features "AVX2" : Supported
      Test features "AVX512F" : Supported
      Test features "AVX512CD" : Supported
      Test features "AVX512_KNL" : Supported
      Test features "AVX512_KNM" : Supported
      Test features "AVX512_SKX" : Supported
      Test features "AVX512_CLX" : Supported
      Test features "AVX512_CNL" : Supported
      Test features "AVX512_ICL" : Supported
      Test features "AVX512_SPR" : Unsupported due to Arguments "-msse, -msse2, -msse3, -mssse3, -msse4.1, -mpopcnt, -msse4.2, -mavx, -mf16c, -mfma, -mavx2, -mno-mmx, -mavx512f, -mavx512cd, -mavx512vl, -mavx512bw, -mavx512dq, -mavx512vnni, -mavx512ifma, -mavx512vbmi, -mavx512vbmi2, -mavx512bitalg, -mavx512vpopcntdq, -mavx512fp16" are not supported
      Configuring npy_cpu_dispatch_config.h using configuration
      Message:
      CPU Optimization Options
        baseline:
          Requested : min
          Enabled   : SSE SSE2 SSE3
        dispatch:
          Requested : max -xop -fma4
          Enabled   : SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL
```