### PR TITLE
Fix xpu manylinux wheel build dependencies issue

### DIFF
--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -353,8 +353,11 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
             fi
 
             # ROCm workaround for roctracer dlopens
-            if [[ "$DESIRED_CUDA" == *"rocm"* || "$DESIRED_CUDA" == *"xpu"* ]]; then
+            if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
                 patchedpath=$(fname_without_so_number $destpath)
+            # Keep the so number for XPU dependencies
+            elif [[ "$DESIRED_CUDA" == *"xpu"* ]]; then
+                patchedpath=$destpath
             else
                 patchedpath=$(fname_with_sha256 $destpath)
             fi

--- a/manywheel/build_common.sh
+++ b/manywheel/build_common.sh
@@ -353,7 +353,7 @@ for pkg in /$WHEELHOUSE_DIR/torch_no_python*.whl /$WHEELHOUSE_DIR/torch*linux*.w
             fi
 
             # ROCm workaround for roctracer dlopens
-            if [[ "$DESIRED_CUDA" == *"rocm"* ]]; then
+            if [[ "$DESIRED_CUDA" == *"rocm"* || "$DESIRED_CUDA" == *"xpu"* ]]; then
                 patchedpath=$(fname_without_so_number $destpath)
             else
                 patchedpath=$(fname_with_sha256 $destpath)


### PR DESCRIPTION
This fix to resolve the `python -c "import torch; print(torch.xpu.is_available())"` always `False` issue even on XPU machine.

Works for https://github.com/pytorch/pytorch/issues/114850