### PR TITLE
Use numpy 2.0.1 for libtorch builds with python 3.9

### DIFF
--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -93,11 +93,7 @@ fi
 pushd "$PYTORCH_ROOT"
 python setup.py clean
 retry pip install -qr requirements.txt
-if [[ "$DESIRED_PYTHON"  == "cp38-cp38" ]]; then
-    retry pip install -q numpy==1.15
-else
-    retry pip install -q numpy==1.11
-fi
+retry pip install -q numpy==2.0.1
 
 if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
     export _GLIBCXX_USE_CXX11_ABI=1


### PR DESCRIPTION
This should resolve libtorch failure: https://github.com/pytorch/pytorch/actions/runs/11120744081/job/30928723129