### PR TITLE
Use python 3.9 for libtorch builds by default (#2000)

### DIFF
--- a/libtorch/build.sh
+++ b/libtorch/build.sh
@@ -7,4 +7,4 @@ set -ex
 
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-USE_CUSPARSELT=0 BUILD_PYTHONLESS=1 DESIRED_PYTHON="3.8" ${SCRIPTPATH}/../manywheel/build.sh
+USE_CUSPARSELT=0 BUILD_PYTHONLESS=1 DESIRED_PYTHON="3.9" ${SCRIPTPATH}/../manywheel/build.sh

--- a/manywheel/build_libtorch.sh
+++ b/manywheel/build_libtorch.sh
@@ -93,11 +93,7 @@ fi
 pushd "$PYTORCH_ROOT"
 python setup.py clean
 retry pip install -qr requirements.txt
-if [[ "$DESIRED_PYTHON"  == "cp38-cp38" ]]; then
-    retry pip install -q numpy==1.15
-else
-    retry pip install -q numpy==1.11
-fi
+retry pip install -q numpy==2.0.1
 
 if [[ "$DESIRED_DEVTOOLSET" == *"cxx11-abi"* ]]; then
     export _GLIBCXX_USE_CXX11_ABI=1


### PR DESCRIPTION
Chery-Pick to use Python 3.9 for libtorch builds