### PR TITLE
Release pypi staging script. Explicitly specify index.html path for promotion.

### DIFF
--- a/release/pypi/promote_pypi_to_staging.sh
+++ b/release/pypi/promote_pypi_to_staging.sh
@@ -21,25 +21,25 @@ upload_pypi_to_staging() {
 }
 
 # Uncomment these to promote to pypi
-LINUX_VERSION_SUFFIX="%2Bcu121"
+LINUX_VERSION_SUFFIX="%2Bcu124"
 CPU_VERSION_SUFFIX="%2Bcpu"
 MACOS_X86_64="macosx_.*_x86_64"
 MACOS_ARM64="macosx_.*_arm64"
 
-PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}"         upload_pypi_to_staging torch "${PYTORCH_VERSION}"
-PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                                upload_pypi_to_staging torch "${PYTORCH_VERSION}"
-PLATFORM="win_amd64"             VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"           upload_pypi_to_staging torch "${PYTORCH_VERSION}"
-PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                                upload_pypi_to_staging torch "${PYTORCH_VERSION}"
+PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" ARCH="cu124" upload_pypi_to_staging torch "${PYTORCH_VERSION}"
+PLATFORM="manylinux2014_aarch64" VERSION_SUFFIX=""                                     upload_pypi_to_staging torch "${PYTORCH_VERSION}"
+PLATFORM="win_amd64"             VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"                upload_pypi_to_staging torch "${PYTORCH_VERSION}"
+PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                                     upload_pypi_to_staging torch "${PYTORCH_VERSION}"
 
-PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
-PLATFORM="linux_aarch64"         VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
-PLATFORM="win_amd64"             VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"   upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
-PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                        upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
+PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" ARCH="cu124" upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
+PLATFORM="linux_aarch64"         VERSION_SUFFIX=""                                     upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
+PLATFORM="win_amd64"             VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"                upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
+PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                                     upload_pypi_to_staging torchvision "${TORCHVISION_VERSION}"
 
-PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
-PLATFORM="linux_aarch64"         VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
-PLATFORM="win_amd64"             VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"   upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
-PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                        upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
+PLATFORM="linux_x86_64"          VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" ARCH="cu124" upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
+PLATFORM="linux_aarch64"         VERSION_SUFFIX=""                                     upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
+PLATFORM="win_amd64"             VERSION_SUFFIX="${CPU_VERSION_SUFFIX}"                upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
+PLATFORM="${MACOS_ARM64}"        VERSION_SUFFIX=""                                     upload_pypi_to_staging torchaudio "${TORCHAUDIO_VERSION}"
 
 #PLATFORM="manylinux2014_x86_64" VERSION_SUFFIX="${LINUX_VERSION_SUFFIX}" upload_pypi_to_staging torchao "${TORCHAO_VERSION}"
 #PLATFORM="" VERSION_SUFFIX="${CPU_VERSION_SUFFIX}" upload_pypi_to_staging torchtune "${TORCHTUNE_VERSION}"

--- a/release/pypi/upload_pypi_to_staging.sh
+++ b/release/pypi/upload_pypi_to_staging.sh
@@ -17,9 +17,12 @@ VERSION_SUFFIX=${VERSION_SUFFIX:-}
 # i.e. PLATFORM=linux_x86_64
 # For domains like torchaudio / torchtext this is to be left blank
 PLATFORM=${PLATFORM:-}
+# Refers to the specific architecture we'd like to promote
+# i.e. cpu, cu121, cu124
+ARCH==${ARCH:-cpu}
 
 pkgs_to_promote=$(\
-    curl -fsSL "https://download.pytorch.org/whl/test/${PACKAGE_NAME}/index.html" \
+    curl -fsSL "https://download.pytorch.org/whl/test/${ARCH}/${PACKAGE_NAME}/index.html" \
         | grep "${PACKAGE_NAME}-${PACKAGE_VERSION}${VERSION_SUFFIX}-" \
         | grep "${PLATFORM}" \
         | cut -d '"' -f2


### PR DESCRIPTION
This fixes the issue we observed with aarch64 promotion that picked both cuda and cpu builds:

Issue can be observed in this log:
```
=-=-=-= Promoting torchaudio's v2.5.0 to pypi staging' =-=-=-=
+ PACKAGE_VERSION=2.5.0
+ PACKAGE_NAME=torchaudio
+ DRY_RUN=enabled
+ bash /home/ec2-user/github/update_dep/builder/release/pypi/upload_pypi_to_staging.sh
/tmp/tmp.k1NDlWaqsT ~/github/update_dep/builder/release/pypi
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp310-cp310-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1627k  100 1627k    0     0  24.2M      0 --:--:-- --:--:-- --:--:-- 24.4M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp311-cp311-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1632k  100 1632k    0     0  34.7M      0 --:--:-- --:--:-- --:--:-- 35.4M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp312-cp312-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1629k  100 1629k    0     0  25.7M      0 --:--:-- --:--:-- --:--:-- 26.0M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp39-cp39-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1629k  100 1629k    0     0  22.3M      0 --:--:-- --:--:-- --:--:-- 22.4M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cu124/torchaudio-2.5.0-cp310-cp310-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3200k  100 3200k    0     0  62.4M      0 --:--:-- --:--:-- --:--:-- 63.7M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp310-cp310-manylinux2014_aarch64.whl
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cu124/torchaudio-2.5.0-cp311-cp311-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3209k  100 3209k    0     0  42.2M      0 --:--:-- --:--:-- --:--:-- 42.3M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp311-cp311-manylinux2014_aarch64.whl
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cu124/torchaudio-2.5.0-cp312-cp312-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3205k  100 3205k    0     0  61.6M      0 --:--:-- --:--:-- --:--:-- 62.6M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp312-cp312-manylinux2014_aarch64.whl
+ curl -fSL -o /tmp/tmp.z0Ke4jxmjg/torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl https://download.pytorch.org/whl/test/cu124/torchaudio-2.5.0-cp39-cp39-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3202k  100 3202k    0     0  46.6M      0 --:--:-- --:--:-- --:--:-- 46.6M
+ aws s3 cp --dryrun torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
(dryrun) upload: ./torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-cp39-cp39-manylinux2014_aarch64.whl
```

This is output of the log with the fix:
```
=-=-=-= Promoting torchaudio's v2.5.0 to pypi staging' =-=-=-=
+ PACKAGE_VERSION=2.5.0
+ PACKAGE_NAME=torchaudio
+ DRY_RUN=disabled
+ bash /home/ec2-user/github/update_dep/builder/release/pypi/upload_pypi_to_staging.sh
/tmp/tmp.yp1cnmPl4l ~/github/update_dep/builder/release/pypi
+ curl -fSL -o /tmp/tmp.zGGocZ09p7/torchaudio-2.5.0-1-cp310-cp310-linux_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp310-cp310-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1627k  100 1627k    0     0  42.1M      0 --:--:-- --:--:-- --:--:-- 42.9M
+ aws s3 cp torchaudio-2.5.0-1-cp310-cp310-linux_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
upload: ./torchaudio-2.5.0-1-cp310-cp310-linux_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-1-cp310-cp310-linux_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-1-cp310-cp310-linux_aarch64.whl
+ curl -fSL -o /tmp/tmp.zGGocZ09p7/torchaudio-2.5.0-1-cp311-cp311-linux_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp311-cp311-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1632k  100 1632k    0     0  41.6M      0 --:--:-- --:--:-- --:--:-- 41.9M
+ aws s3 cp torchaudio-2.5.0-1-cp311-cp311-linux_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
upload: ./torchaudio-2.5.0-1-cp311-cp311-linux_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-1-cp311-cp311-linux_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-1-cp311-cp311-linux_aarch64.whl
+ curl -fSL -o /tmp/tmp.zGGocZ09p7/torchaudio-2.5.0-1-cp312-cp312-linux_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp312-cp312-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1629k  100 1629k    0     0  40.8M      0 --:--:-- --:--:-- --:--:-- 40.8M
+ aws s3 cp torchaudio-2.5.0-1-cp312-cp312-linux_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
upload: ./torchaudio-2.5.0-1-cp312-cp312-linux_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-1-cp312-cp312-linux_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-1-cp312-cp312-linux_aarch64.whl
+ curl -fSL -o /tmp/tmp.zGGocZ09p7/torchaudio-2.5.0-1-cp39-cp39-linux_aarch64.whl https://download.pytorch.org/whl/test/cpu/torchaudio-2.5.0-cp39-cp39-linux_aarch64.whl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1629k  100 1629k    0     0  39.6M      0 --:--:-- --:--:-- --:--:-- 39.7M
+ aws s3 cp torchaudio-2.5.0-1-cp39-cp39-linux_aarch64.whl s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/
upload: ./torchaudio-2.5.0-1-cp39-cp39-linux_aarch64.whl to s3://pytorch-backup/torchaudio-2.5.0-pypi-staging/torchaudio-2.5.0-1-cp39-cp39-linux_aarch64.whl
+ rm -rf ./torchaudio-2.5.0-1-cp39-cp39-linux_aarch64.whl
```