### PR TITLE
add magma build for CUDA 12.6

### DIFF
--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: linux.2xlarge
     strategy:
       matrix:
-        cuda_version: ["124", "121", "118"]
+        cuda_version: ["126", "124", "121", "118"]
     steps:
       - name: Checkout PyTorch builder
         uses: actions/checkout@v3

--- a/.github/workflows/build-magma-linux.yml
+++ b/.github/workflows/build-magma-linux.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           make magma-cuda${{ matrix.cuda_version }}
       - name: Save as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: magma/output/linux-64/magma-cuda*.bz2
       - name: Install conda

--- a/magma/Makefile
+++ b/magma/Makefile
@@ -14,6 +14,7 @@ DOCKER_RUN = set -eou pipefail; docker run --rm -i \
 	magma/build_magma.sh
 
 .PHONY: all
+all: magma-cuda126
 all: magma-cuda124
 all: magma-cuda121
 all: magma-cuda118
@@ -22,6 +23,12 @@ all: magma-cuda118
 clean:
 	$(RM) -r magma-*
 	$(RM) -r output
+
+.PHONY: magma-cuda126
+magma-cuda124: DESIRED_CUDA := 12.6
+magma-cuda124: PACKAGE_NAME := magma-cuda126
+magma-cuda124:
+	$(DOCKER_RUN)
 
 .PHONY: magma-cuda124
 magma-cuda124: DESIRED_CUDA := 12.4

--- a/magma/Makefile
+++ b/magma/Makefile
@@ -25,9 +25,9 @@ clean:
 	$(RM) -r output
 
 .PHONY: magma-cuda126
-magma-cuda124: DESIRED_CUDA := 12.6
-magma-cuda124: PACKAGE_NAME := magma-cuda126
-magma-cuda124:
+magma-cuda126: DESIRED_CUDA := 12.6
+magma-cuda126: PACKAGE_NAME := magma-cuda126
+magma-cuda126:
 	$(DOCKER_RUN)
 
 .PHONY: magma-cuda124


### PR DESCRIPTION
This PR adds magma build for CUDA 12.6 according to https://github.com/pytorch/builder/blob/main/CUDA_UPGRADE_GUIDE.MD
Reference PR - https://github.com/pytorch/builder/pull/1722

Related to https://github.com/pytorch/pytorch/issues/138440

cc @atalman 