### PR TITLE
Windows pin numpy to 2.1.2 for py 3.13

### DIFF
--- a/windows/condaenv.bat
+++ b/windows/condaenv.bat
@@ -14,7 +14,7 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     if "%%v" == "3.10" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools=72.1.0 python=%%v
     if "%%v" == "3.11" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools=72.1.0 python=%%v
     if "%%v" == "3.12" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools=72.1.0 python=%%v
-    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.0.1 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
+    if "%%v" == "3.13" call conda create -n py!PYTHON_VERSION_STR! -y -q -c=conda-forge numpy=2.1.2 pyyaml boto3 cmake ninja typing_extensions setuptools python=%%v
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-include
     call conda run -n py!PYTHON_VERSION_STR! pip install mkl-static
 )


### PR DESCRIPTION
Should resolve this failure with Windows CD: https://github.com/pytorch/pytorch/actions/runs/11371653501/job/31634225629