### PR TITLE
Update magma artifact upload

### DIFF
--- a/.github/workflows/build-magma-windows.yml
+++ b/.github/workflows/build-magma-windows.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           path: magma_*_cuda*_*.7z
           overwrite: true
+          name: artifact_${{ matrix.cuda_version }}_${{ matrix.config }}
   push-windows-magma:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment: magma


### PR DESCRIPTION
Currently only 1 artifact is getting uploaded. I see this in the log: 
```
Run actions/upload-artifact@v4
  with:
    path: magma_*_cuda*_*.7z
    overwrite: true
    name: artifact
    if-no-files-found: warn
    compression-level: [6](https://github.com/pytorch/builder/actions/runs/11713319173/job/32625864948#step:6:6)
    include-hidden-files: false
```

This should enable all artifacts to be uploaded
