### PR TITLE
Do not validate packages of type conda

### DIFF
--- a/.github/workflows/validate-linux-binaries.yml
+++ b/.github/workflows/validate-linux-binaries.yml
@@ -120,7 +120,7 @@ jobs:
   generate-linux-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
-      package-type: all
+      package-type: wheel,libtorch #  We stopped producing conda nightlies
       os: linux
       channel: ${{ inputs.channel }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}

--- a/.github/workflows/validate-macos-arm64-binaries.yml
+++ b/.github/workflows/validate-macos-arm64-binaries.yml
@@ -98,7 +98,7 @@ jobs:
   generate-macos-arm64-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
-      package-type: all
+      package-type: wheel,libtorch #  We stopped producing conda nightlies
       os: macos-arm64
       channel: ${{ inputs.channel }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}

--- a/.github/workflows/validate-windows-binaries.yml
+++ b/.github/workflows/validate-windows-binaries.yml
@@ -98,7 +98,7 @@ jobs:
   generate-windows-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
-      package-type: all
+      package-type: wheel,libtorch #  We stopped producing conda nightlies
       os: windows
       channel: ${{ inputs.channel }}
       use-only-dl-pytorch-org: ${{ inputs.use-only-dl-pytorch-org }}


### PR DESCRIPTION
Conda nightlies have been deprecated and will be stopped soon https://dev-discuss.pytorch.org/t/pytorch-deprecation-of-conda-nightly-builds/2590

So we remove conda packages from the validation list.

Fixes: #2036 